### PR TITLE
Fixing the "protocol error, got '*' as reply type byte"

### DIFF
--- a/library.c
+++ b/library.c
@@ -150,6 +150,7 @@ PHPAPI char *redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC)
             return resp;
 
         case '+':
+		case '*':
         case ':':
 	    // Single Line Reply
             /* :123\r\n */


### PR DESCRIPTION
This error was occurring when a SORT was being executed on an empty list or set.
