### PR TITLE
Source compatibility for compiling with VS 2008 on win32

### DIFF
--- a/common.h
+++ b/common.h
@@ -52,21 +52,23 @@
 
 
 #define MULTI_RESPONSE(callback) IF_MULTI_OR_PIPELINE() { \
-	fold_item *f1 = malloc(sizeof(fold_item)); \
+	fold_item *f1, *current; \
+	f1 = malloc(sizeof(fold_item)); \
 	f1->fun = (void *)callback; \
 	f1->next = NULL; \
-	fold_item *current = redis_sock->current;\
+	current = redis_sock->current;\
 	if(current) current->next = f1; \
 	redis_sock->current = f1; \
   }
 
 #define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) request_item *tmp; \
+	struct request_item *current_request;\
 	tmp = malloc(sizeof(request_item));\
 	tmp->request_str = calloc(cmd_len, 1);\
 	memcpy(tmp->request_str, cmd, cmd_len);\
 	tmp->request_size = cmd_len;\
 	tmp->next = NULL;\
-	struct request_item *current_request = redis_sock->pipeline_current; \
+	current_request = redis_sock->pipeline_current; \
 	if(current_request) {\
 		current_request->next = tmp;\
 	} \
@@ -81,11 +83,12 @@
 }
 
 #define REDIS_SAVE_CALLBACK(callback, closure_context) IF_MULTI_OR_PIPELINE() { \
-	fold_item *f1 = malloc(sizeof(fold_item)); \
+	fold_item *f1, *current; \
+	f1 = malloc(sizeof(fold_item)); \
 	f1->fun = (void *)callback; \
 	f1->ctx = closure_context; \
 	f1->next = NULL; \
-	fold_item *current = redis_sock->current;\
+	current = redis_sock->current;\
 	if(current) current->next = f1; \
 	redis_sock->current = f1; \
 	if(NULL == redis_sock->head) { \

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,15 @@
+// vim: ft=javascript:
+
+ARG_ENABLE("redis", "whether to enable redis support", "yes");
+ARG_ENABLE("redis-session", "whether to enable sessions", "yes");
+
+if (PHP_REDIS != "no") {
+	var sources = "redis.c library.c igbinary\\igbinary.c igbinary\\hash_si.c igbinary\\hash_function.c";
+	if (PHP_REDIS_SESSION != "no") {
+		AC_DEFINE('PHP_SESSION', 1);
+		sources += " redis_session.c";
+	}
+	
+	AC_DEFINE("PHP_EXPORTS", 1);
+	EXTENSION("redis", sources);
+}

--- a/igbinary/hash_function.c
+++ b/igbinary/hash_function.c
@@ -3,7 +3,10 @@
 lookup3.c, by Bob Jenkins, May 2006, Public Domain.
 */
 
+#ifndef _MSC_VER
 #include <sys/param.h>  /* attempt to define endianness */
+#endif
+
 #ifdef linux
 # include <endian.h>    /* attempt to define endianness */
 #endif

--- a/igbinary/hash_si.c
+++ b/igbinary/hash_si.c
@@ -13,12 +13,18 @@
 #include "hash.h"
 #include "hash_function.h"
 
+#ifdef _MSC_VER
+  #define INLINE __forceinline /* use __forceinline (VC++ specific) */
+#else
+  #define INLINE inline        /* use standard inline */
+#endif
+
 /* {{{ nextpow2 */
 /** Next power of 2.
  * @param n Integer.
  * @return next to n power of 2 .
  */
-inline static uint32_t nextpow2(uint32_t n) {
+INLINE static uint32_t nextpow2(uint32_t n) {
 	uint32_t m = 1;
 	while (m < n) {
 		m = m << 1;
@@ -66,7 +72,7 @@ void hash_si_deinit(struct hash_si *h) {
  * @param key_len Key length.
  * @return index.
  */
-inline static size_t _hash_si_find(struct hash_si *h, const char *key, size_t key_len) {
+INLINE static size_t _hash_si_find(struct hash_si *h, const char *key, size_t key_len) {
 	uint32_t hv;
 	size_t size;
 	
@@ -155,7 +161,7 @@ int hash_si_remove(struct hash_si *h, const char *key, size_t key_len, uint32_t 
 /** Rehash/resize hash_si.
  * @param h Pointer to hash_si struct.
  */
-inline static void hash_si_rehash(struct hash_si *h) {
+INLINE static void hash_si_rehash(struct hash_si *h) {
 	uint32_t hv;
 	int i;
 	struct hash_si newh;

--- a/igbinary/igbinary.c
+++ b/igbinary/igbinary.c
@@ -294,12 +294,12 @@ int igbinary_unserialize(const uint8_t *buf, size_t buf_len, zval **z TSRMLS_DC)
 /* }}} */
 /* {{{ proto string igbinary_unserialize(mixed value) */
 PHP_FUNCTION(igbinary_unserialize) {
+	char *string;
+	int string_len;
+	
 	(void) return_value_ptr;
 	(void) this_ptr;
 	(void) return_value_used;
-
-	char *string;
-	int string_len;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &string, &string_len) == FAILURE) {
 		RETURN_NULL();
@@ -316,12 +316,12 @@ PHP_FUNCTION(igbinary_unserialize) {
 /* }}} */
 /* {{{ proto mixed igbinary_serialize(string value) */
 PHP_FUNCTION(igbinary_serialize) {
+	zval *z;
+	struct igbinary_serialize_data igsd;
+	
 	(void) return_value_ptr;
 	(void) this_ptr;
 	(void) return_value_used;
-
-	zval *z;
-	struct igbinary_serialize_data igsd;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &z) == FAILURE) {
 		RETURN_NULL();
@@ -608,13 +608,14 @@ inline static int igbinary_serialize_long(struct igbinary_serialize_data *igsd, 
 /* }}} */
 /* {{{ igbinary_serialize_double */
 /** Serializes double. */
-inline static int igbinary_serialize_double(struct igbinary_serialize_data *igsd, double d TSRMLS_DC) {
-	igbinary_serialize8(igsd, igbinary_type_double TSRMLS_CC);
-
+inline static int igbinary_serialize_double(struct igbinary_serialize_data *igsd, double d TSRMLS_DC) 
+{
 	union {
 		double d;
 		uint64_t u;
 	} u;
+	
+	igbinary_serialize8(igsd, igbinary_type_double TSRMLS_CC);
 
 	u.d = d;
 
@@ -1295,17 +1296,17 @@ inline static int igbinary_unserialize_long(struct igbinary_unserialize_data *ig
 /* {{{ igbinary_unserialize_double */
 /** Unserializes double. */
 inline static int igbinary_unserialize_double(struct igbinary_unserialize_data *igsd, enum igbinary_type t, double *ret TSRMLS_DC) {
+	union {
+		double d;
+		uint64_t u;
+	} u;
+	
 	(void) t;
 
 	if (igsd->buffer_offset + 8 > igsd->buffer_size) {
 		zend_error(E_WARNING, "igbinary_unserialize_double: end-of-data");
 		return 1;
 	}
-
-	union {
-		double d;
-		uint64_t u;
-	} u;
 
 	u.u = igbinary_unserialize64(igsd TSRMLS_CC);
 

--- a/igbinary/igbinary.h
+++ b/igbinary/igbinary.h
@@ -13,6 +13,10 @@
 
 #define IGBINARY_VERSION "1.0.2"
 
+#ifdef _MSC_VER
+#define __func__ __FUNCTION__
+#endif
+
 /** Serialize zval.
  * Return buffer is allocated by this function with emalloc.
  * @param[out] ret Return buffer

--- a/php_redis.h
+++ b/php_redis.h
@@ -190,9 +190,10 @@ PHPAPI void set_pipeline_head(zval *object, request_item *head);
 PHPAPI request_item* get_pipeline_current(zval *object);
 PHPAPI void set_pipeline_current(zval *object, request_item *current);
 
+#ifndef _MSC_VER
 ZEND_BEGIN_MODULE_GLOBALS(redis)
 ZEND_END_MODULE_GLOBALS(redis)
-
+#endif
 
 struct redis_queued_item {
 


### PR DESCRIPTION
Hi,

So this is my 2nd pull request, the first one is to owclient. Would you like to merge this changes so that it's easier to compile phpredis on windows?

Here's the summary of the changes
1) moved all variables declaration before expression (in *.c and *.h/macros)
2) converted long long into long since VS 2008 does not have atoll
3) added a config.w32

Thanks.
