### PR TITLE
config set function.

### DIFF
--- a/php_redis.h
+++ b/php_redis.h
@@ -153,6 +153,8 @@ PHP_METHOD(Redis, unsubscribe);
 PHP_METHOD(Redis, getOption);
 PHP_METHOD(Redis, setOption);
 
+PHP_METHOD(Redis, config);
+
 #ifdef PHP_WIN32
 #define PHP_REDIS_API __declspec(dllexport)
 #else


### PR DESCRIPTION
hey nicolasff,

i implemented the config function for phpredis. it works for config set[1] and is prepared to work also for config get[2]. for config get the response has to be passed through correctly. i could not yet find out how to do that.

i would be happy to support your work :)

regards
david

[1] http://redis.io/commands/config-set
[2] http://redis.io/commands/config-get
