### PR TITLE
Send DISCARD in destructor

### DIFF
--- a/php_redis.h
+++ b/php_redis.h
@@ -24,6 +24,7 @@
 #define PHP_REDIS_H
 
 PHP_METHOD(Redis, __construct);
+PHP_METHOD(Redis, __destruct);
 PHP_METHOD(Redis, connect);
 PHP_METHOD(Redis, pconnect);
 PHP_METHOD(Redis, close);


### PR DESCRIPTION
This is the code that sends a DISCARD in the destructor, if we think we're in MULTI mode.  

I'm not overly familiar with the Zend api, so I'm sure there are better places to put this stuff.

That being said, it appears to work, and doesn't seem to introduce any leaks.  :)

Cheers
Mike
