### PR TITLE
INFO COMMANDSTATS

### DIFF
--- a/library.h
+++ b/library.h
@@ -14,6 +14,7 @@ PHPAPI void redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
 PHPAPI void redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHPAPI void redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHPAPI void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+PHPAPI void redis_info_commandstats_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHPAPI void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHPAPI RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, int persistent, char *persistent_id);
 PHPAPI int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC);
@@ -42,3 +43,16 @@ redis_key_prefix(RedisSock *redis_sock, char **key, int *key_len TSRMLS_DC);
 PHPAPI int
 redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **return_value TSRMLS_DC);
 
+/*
+ * Some generic string splitting routines
+ */
+
+// Split a string by token
+char **str_split(const char *str, const char *sep, int *count);
+
+// Strdup methods
+char *str_duplen(const char *str, size_t len);
+char *str_dup(const char *str);
+
+// Free an array of strings
+void str_free_array(char **arr, unsigned int size);

--- a/tests/test.php
+++ b/tests/test.php
@@ -36,7 +36,6 @@ class TestSuite {
 		$methods = $rc->GetMethods(ReflectionMethod::IS_PUBLIC);
 
 		foreach($methods as $m) {
-
 			$name = $m->name;
 			if(substr($name, 0, 4) !== 'test')
 				continue;


### PR DESCRIPTION
Hey,

I've implemented the new `INFO COMMANDSTATS` command, which passed through the normal `redis->info()` method, which now takes an optional boolean value to determine if we want commandstats information.

I don't know how you figure it should come back, but I have put it in the following form:

```
[1] => Array
        (
            [get] => Array
                (
                    [calls] => 10591
                    [usec] => 37045
                    [usec_per_call] => 3.50
                )

            [set] => Array
                (
                    [calls] => 11840
                    [usec] => 8739746
                    [usec_per_call] => 738.15
                )

            [setnx] => Array
                (
                    [calls] => 1290
                    [usec] => 4916
                    [usec_per_call] => 3.81
                )
```
