### PR TITLE
Fix segfault when using persistent connections

### DIFF
--- a/library.c
+++ b/library.c
@@ -41,7 +41,7 @@ PHPAPI int redis_check_eof(RedisSock *redis_sock TSRMLS_DC)
     for (; eof; count++) {
         if((MULTI == redis_sock->mode) || redis_sock->watching || count == 10) { /* too many failures */
 	    if(redis_sock->stream) { /* close stream if still here */
-                php_stream_close(redis_sock->stream);
+                redis_stream_close(redis_sock);
                 redis_sock->stream = NULL;
 				redis_sock->mode   = ATOMIC;
                 redis_sock->status = REDIS_SOCK_STATUS_FAILED;
@@ -51,7 +51,7 @@ PHPAPI int redis_check_eof(RedisSock *redis_sock TSRMLS_DC)
 	    return -1;
 	}
 	if(redis_sock->stream) { /* close existing stream before reconnecting */
-            php_stream_close(redis_sock->stream);
+            redis_stream_close(redis_sock);
             redis_sock->stream = NULL;
 			redis_sock->mode   = ATOMIC;
             redis_sock->watching = 0;


### PR DESCRIPTION
Steps to reproduce:
- Set `timeout 1` in Redis config
- Restart Redis
- Run the following script:

``` php
<?php

$redis = new Redis();
$redis->pconnect('localhost');

$i = 1;
while(true) {
        sleep($i);
        $redis->set('testkey', $i);
        print "$i - ok\n";
        $i = $i * 2;
}
```

The result will be like this:

```
1 - ok
2 - ok
Segmentation fault
```

The problem appeared [here](https://github.com/nicolasff/phpredis/commit/39df0b7a2c3eed423c22412ad803af121a883900#library.c)
