### PR TITLE
fixed bug different type command returns

### DIFF
--- a/library.c
+++ b/library.c
@@ -692,6 +692,11 @@ PHPAPI int redis_sock_read_multibulk_reply_zipped_with_flag(INTERNAL_FUNCTION_PA
     }
 
     if(inbuf[0] != '*') {
+        IF_MULTI_OR_PIPELINE() {
+            add_next_index_bool(z_tab, 0);
+        } else {
+            RETURN_FALSE;
+        }
         return -1;
     }
     numElems = atoi(inbuf+1);
@@ -1056,6 +1061,11 @@ PHPAPI int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSo
     }
 
     if(inbuf[0] != '*') {
+        IF_MULTI_OR_PIPELINE() {
+            add_next_index_bool(z_tab, 0);
+        } else {
+            RETURN_FALSE;
+        }
         return -1;
     }
     numElems = atoi(inbuf+1);
@@ -1098,6 +1108,11 @@ PHPAPI int redis_sock_read_multibulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, Red
     }
 
     if(inbuf[0] != '*') {
+        IF_MULTI_OR_PIPELINE() {
+            add_next_index_bool(z_tab, 0);
+        } else {
+            RETURN_FALSE;
+        }
         return -1;
     }
     numElems = atoi(inbuf+1);
@@ -1172,6 +1187,11 @@ PHPAPI int redis_sock_read_multibulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, R
     }
 
     if(inbuf[0] != '*') {
+        IF_MULTI_OR_PIPELINE() {
+            add_next_index_bool(z_tab, 0);
+        } else {
+            RETURN_FALSE;
+        }
         return -1;
     }
     numElems = atoi(inbuf+1);

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -2078,10 +2078,12 @@ class Redis_Test extends TestSuite
 
     public function testMultiExec() {
 	$this->sequence(Redis::MULTI);
+	$this->differentType(Redis::MULTI);
 
 	// with prefix as well
 	$this->redis->setOption(Redis::OPT_PREFIX, "test:");
 	$this->sequence(Redis::MULTI);
+	$this->differentType(Redis::MULTI);
 	$this->redis->setOption(Redis::OPT_PREFIX, "");
 
 	$this->redis->set('x', '42');
@@ -2118,10 +2120,12 @@ class Redis_Test extends TestSuite
 
     public function testPipeline() {
 	$this->sequence(Redis::PIPELINE);
+	$this->differentType(Redis::PIPELINE);
 
 	// with prefix as well
 	$this->redis->setOption(Redis::OPT_PREFIX, "test:");
 	$this->sequence(Redis::PIPELINE);
+	$this->differentType(Redis::PIPELINE);
 	$this->redis->setOption(Redis::OPT_PREFIX, "");
     }
 
@@ -2684,6 +2688,890 @@ class Redis_Test extends TestSuite
             ->exec();
 
         $this->assertTrue($result === array(1.0, FALSE, FALSE, 2.0));
+    }
+
+    protected function differentType($mode) {
+
+        // string
+        $key = 'string';
+        $ret = $this->redis->multi($mode)
+            ->delete($key)
+            ->set($key, 'value')
+
+            // lists I/F
+            ->rPush($key, 'lvalue')
+            ->lPush($key, 'lvalue')
+            ->lLen($key)
+            ->lPop($key)
+            ->lGetRange($key, 0, -1)
+            ->lTrim($key, 0, 1)
+            ->lGet($key, 0)
+            ->lSet($key, 0, "newValue")
+            ->lRemove($key, 'lvalue', 1)
+            ->lPop($key)
+            ->rPop($key)
+            ->rPoplPush($key, __FUNCTION__ . 'lkey1')
+
+            // sets I/F
+            ->sAdd($key, 'sValue1')
+            ->sRemove($key, 'sValue1')
+            ->sPop($key)
+            ->sMove($key, __FUNCTION__ . 'skey1', 'sValue1')
+            ->sSize($key)
+            ->sContains($key, 'sValue1')
+            ->sInter($key, __FUNCTION__ . 'skey2')
+            ->sUnion($key, __FUNCTION__ . 'skey4')
+            ->sDiff($key, __FUNCTION__ . 'skey7')
+            ->sMembers($key)
+            ->sRandMember($key)
+
+            // sorted sets I/F
+            ->zAdd($key, 1, 'zValue1')
+            ->zDelete($key, 'zValue1')
+            ->zIncrBy($key, 1, 'zValue1')
+            ->zRank($key, 'zValue1')
+            ->zRevRank($key, 'zValue1')
+            ->zRange($key, 0, -1)
+            ->zReverseRange($key, 0, -1)
+            ->zRangeByScore($key, 1, 2)
+            ->zCount($key, 0, -1)
+            ->zCard($key)
+            ->zScore($key, 'zValue1')
+            ->zDeleteRangeByRank($key, 1, 2)
+            ->zDeleteRangeByScore($key, 1, 2)
+
+            // hash I/F
+            ->hSet($key, 'key1', 'value1')
+            ->hGet($key, 'key1')
+            ->hMGet($key, array('key1'))
+            ->hMSet($key, array('key1' => 'value1'))
+            ->hIncrBy($key, 'key2', 1)
+            ->hExists($key, 'key2')
+            ->hDel($key, 'key2')
+            ->hLen($key)
+            ->hKeys($key)
+            ->hVals($key)
+            ->hGetAll($key)
+
+            ->exec();
+
+        $i = 0;
+        $this->assertTrue(is_array($ret));
+        $this->assertTrue(is_long($ret[$i++])); // delete
+        $this->assertTrue($ret[$i++] === TRUE); // set
+
+        $this->assertTrue($ret[$i++] === FALSE); // rpush
+        $this->assertTrue($ret[$i++] === FALSE); // lpush
+        $this->assertTrue($ret[$i++] === FALSE); // llen
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // lgetrange
+        $this->assertTrue($ret[$i++] === FALSE); // ltrim
+        $this->assertTrue($ret[$i++] === FALSE); // lget
+        $this->assertTrue($ret[$i++] === FALSE); // lset
+        $this->assertTrue($ret[$i++] === FALSE); // lremove
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpoplush
+
+        $this->assertTrue($ret[$i++] === FALSE); // sadd
+        $this->assertTrue($ret[$i++] === FALSE); // sremove
+        $this->assertTrue($ret[$i++] === FALSE); // spop
+        $this->assertTrue($ret[$i++] === FALSE); // smove
+        $this->assertTrue($ret[$i++] === FALSE); // ssize
+        $this->assertTrue($ret[$i++] === FALSE); // scontains
+        $this->assertTrue($ret[$i++] === FALSE); // sinter
+        $this->assertTrue($ret[$i++] === FALSE); // sunion
+        $this->assertTrue($ret[$i++] === FALSE); // sdiff
+        $this->assertTrue($ret[$i++] === FALSE); // smembers
+        $this->assertTrue($ret[$i++] === FALSE); // srandmember
+
+        $this->assertTrue($ret[$i++] === FALSE); // zadd
+        $this->assertTrue($ret[$i++] === FALSE); // zdelete
+        $this->assertTrue($ret[$i++] === FALSE); // zincrby
+        $this->assertTrue($ret[$i++] === FALSE); // zrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrevrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrange
+        $this->assertTrue($ret[$i++] === FALSE); // zreverserange
+        $this->assertTrue($ret[$i++] === FALSE); // zrangebyscore
+        $this->assertTrue($ret[$i++] === FALSE); // zcount
+        $this->assertTrue($ret[$i++] === FALSE); // zcard
+        $this->assertTrue($ret[$i++] === FALSE); // zscore
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyrank
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyscore
+
+        $this->assertTrue($ret[$i++] === FALSE); // hset
+        $this->assertTrue($ret[$i++] === FALSE); // hget
+        $this->assertTrue($ret[$i++] === FALSE); // hmget
+        $this->assertTrue($ret[$i++] === FALSE); // hmset
+        $this->assertTrue($ret[$i++] === FALSE); // hincrby
+        $this->assertTrue($ret[$i++] === FALSE); // hexists
+        $this->assertTrue($ret[$i++] === FALSE); // hdel
+        $this->assertTrue($ret[$i++] === FALSE); // hlen
+        $this->assertTrue($ret[$i++] === FALSE); // hkeys
+        $this->assertTrue($ret[$i++] === FALSE); // hvals
+        $this->assertTrue($ret[$i++] === FALSE); // hgetall
+
+        $this->assertEquals($i, count($ret));
+
+        // list
+        $key = 'list';
+        $ret = $this->redis->multi($mode)
+            ->delete($key)
+            ->lpush($key, 'lvalue')
+
+            // string I/F
+            ->get($key)
+            ->getset($key, 'value2')
+            ->append($key, 'append')
+            ->substr($key, 0, 8)
+            ->mget(array($key))
+            ->incr($key)
+            ->incrBy($key, 1)
+            ->decr($key)
+            ->decrBy($key, 1)
+
+            // sets I/F
+            ->sAdd($key, 'sValue1')
+            ->sRemove($key, 'sValue1')
+            ->sPop($key)
+            ->sMove($key, __FUNCTION__ . 'skey1', 'sValue1')
+            ->sSize($key)
+            ->sContains($key, 'sValue1')
+            ->sInter($key, __FUNCTION__ . 'skey2')
+            ->sUnion($key, __FUNCTION__ . 'skey4')
+            ->sDiff($key, __FUNCTION__ . 'skey7')
+            ->sMembers($key)
+            ->sRandMember($key)
+
+            // sorted sets I/F
+            ->zAdd($key, 1, 'zValue1')
+            ->zDelete($key, 'zValue1')
+            ->zIncrBy($key, 1, 'zValue1')
+            ->zRank($key, 'zValue1')
+            ->zRevRank($key, 'zValue1')
+            ->zRange($key, 0, -1)
+            ->zReverseRange($key, 0, -1)
+            ->zRangeByScore($key, 1, 2)
+            ->zCount($key, 0, -1)
+            ->zCard($key)
+            ->zScore($key, 'zValue1')
+            ->zDeleteRangeByRank($key, 1, 2)
+            ->zDeleteRangeByScore($key, 1, 2)
+
+            // hash I/F
+            ->hSet($key, 'key1', 'value1')
+            ->hGet($key, 'key1')
+            ->hMGet($key, array('key1'))
+            ->hMSet($key, array('key1' => 'value1'))
+            ->hIncrBy($key, 'key2', 1)
+            ->hExists($key, 'key2')
+            ->hDel($key, 'key2')
+            ->hLen($key)
+            ->hKeys($key)
+            ->hVals($key)
+            ->hGetAll($key)
+
+            ->exec();
+
+        $i = 0;
+        $this->assertTrue(is_array($ret));
+        $this->assertTrue(is_long($ret[$i++])); // delete
+        $this->assertTrue($ret[$i++] === 1); // lpush
+
+        $this->assertTrue($ret[$i++] === FALSE); // get
+        $this->assertTrue($ret[$i++] === FALSE); // getset
+        $this->assertTrue($ret[$i++] === FALSE); // append
+        $this->assertTrue($ret[$i++] === FALSE); // substr
+        $this->assertTrue(is_array($ret[$i]) && count($ret[$i]) === 1 && $ret[$i][0] === FALSE); // mget
+        $i++;
+        $this->assertTrue($ret[$i++] === FALSE); // incr
+        $this->assertTrue($ret[$i++] === FALSE); // incrBy
+        $this->assertTrue($ret[$i++] === FALSE); // decr
+        $this->assertTrue($ret[$i++] === FALSE); // decrBy
+
+        $this->assertTrue($ret[$i++] === FALSE); // sadd
+        $this->assertTrue($ret[$i++] === FALSE); // sremove
+        $this->assertTrue($ret[$i++] === FALSE); // spop
+        $this->assertTrue($ret[$i++] === FALSE); // smove
+        $this->assertTrue($ret[$i++] === FALSE); // ssize
+        $this->assertTrue($ret[$i++] === FALSE); // scontains
+        $this->assertTrue($ret[$i++] === FALSE); // sinter
+        $this->assertTrue($ret[$i++] === FALSE); // sunion
+        $this->assertTrue($ret[$i++] === FALSE); // sdiff
+        $this->assertTrue($ret[$i++] === FALSE); // smembers
+        $this->assertTrue($ret[$i++] === FALSE); // srandmember
+
+        $this->assertTrue($ret[$i++] === FALSE); // zadd
+        $this->assertTrue($ret[$i++] === FALSE); // zdelete
+        $this->assertTrue($ret[$i++] === FALSE); // zincrby
+        $this->assertTrue($ret[$i++] === FALSE); // zrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrevrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrange
+        $this->assertTrue($ret[$i++] === FALSE); // zreverserange
+        $this->assertTrue($ret[$i++] === FALSE); // zrangebyscore
+        $this->assertTrue($ret[$i++] === FALSE); // zcount
+        $this->assertTrue($ret[$i++] === FALSE); // zcard
+        $this->assertTrue($ret[$i++] === FALSE); // zscore
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyrank
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyscore
+
+        $this->assertTrue($ret[$i++] === FALSE); // hset
+        $this->assertTrue($ret[$i++] === FALSE); // hget
+        $this->assertTrue($ret[$i++] === FALSE); // hmget
+        $this->assertTrue($ret[$i++] === FALSE); // hmset
+        $this->assertTrue($ret[$i++] === FALSE); // hincrby
+        $this->assertTrue($ret[$i++] === FALSE); // hexists
+        $this->assertTrue($ret[$i++] === FALSE); // hdel
+        $this->assertTrue($ret[$i++] === FALSE); // hlen
+        $this->assertTrue($ret[$i++] === FALSE); // hkeys
+        $this->assertTrue($ret[$i++] === FALSE); // hvals
+        $this->assertTrue($ret[$i++] === FALSE); // hgetall
+
+        $this->assertEquals($i, count($ret));
+
+        // set
+        $key = 'set';
+        $ret = $this->redis->multi($mode)
+            ->delete($key)
+            ->sAdd($key, 'sValue')
+
+            // string I/F
+            ->get($key)
+            ->getset($key, 'value2')
+            ->append($key, 'append')
+            ->substr($key, 0, 8)
+            ->mget(array($key))
+            ->incr($key)
+            ->incrBy($key, 1)
+            ->decr($key)
+            ->decrBy($key, 1)
+
+            // lists I/F
+            ->rPush($key, 'lvalue')
+            ->lPush($key, 'lvalue')
+            ->lLen($key)
+            ->lPop($key)
+            ->lGetRange($key, 0, -1)
+            ->lTrim($key, 0, 1)
+            ->lGet($key, 0)
+            ->lSet($key, 0, "newValue")
+            ->lRemove($key, 'lvalue', 1)
+            ->lPop($key)
+            ->rPop($key)
+            ->rPoplPush($key, __FUNCTION__ . 'lkey1')
+
+            // sorted sets I/F
+            ->zAdd($key, 1, 'zValue1')
+            ->zDelete($key, 'zValue1')
+            ->zIncrBy($key, 1, 'zValue1')
+            ->zRank($key, 'zValue1')
+            ->zRevRank($key, 'zValue1')
+            ->zRange($key, 0, -1)
+            ->zReverseRange($key, 0, -1)
+            ->zRangeByScore($key, 1, 2)
+            ->zCount($key, 0, -1)
+            ->zCard($key)
+            ->zScore($key, 'zValue1')
+            ->zDeleteRangeByRank($key, 1, 2)
+            ->zDeleteRangeByScore($key, 1, 2)
+
+            // hash I/F
+            ->hSet($key, 'key1', 'value1')
+            ->hGet($key, 'key1')
+            ->hMGet($key, array('key1'))
+            ->hMSet($key, array('key1' => 'value1'))
+            ->hIncrBy($key, 'key2', 1)
+            ->hExists($key, 'key2')
+            ->hDel($key, 'key2')
+            ->hLen($key)
+            ->hKeys($key)
+            ->hVals($key)
+            ->hGetAll($key)
+
+            ->exec();
+
+        $i = 0;
+        $this->assertTrue(is_array($ret));
+        $this->assertTrue(is_long($ret[$i++])); // delete
+        $this->assertTrue($ret[$i++] === 1); // zadd
+
+        $this->assertTrue($ret[$i++] === FALSE); // get
+        $this->assertTrue($ret[$i++] === FALSE); // getset
+        $this->assertTrue($ret[$i++] === FALSE); // append
+        $this->assertTrue($ret[$i++] === FALSE); // substr
+        $this->assertTrue(is_array($ret[$i]) && count($ret[$i]) === 1 && $ret[$i][0] === FALSE); // mget
+        $i++;
+        $this->assertTrue($ret[$i++] === FALSE); // incr
+        $this->assertTrue($ret[$i++] === FALSE); // incrBy
+        $this->assertTrue($ret[$i++] === FALSE); // decr
+        $this->assertTrue($ret[$i++] === FALSE); // decrBy
+
+        $this->assertTrue($ret[$i++] === FALSE); // rpush
+        $this->assertTrue($ret[$i++] === FALSE); // lpush
+        $this->assertTrue($ret[$i++] === FALSE); // llen
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // lgetrange
+        $this->assertTrue($ret[$i++] === FALSE); // ltrim
+        $this->assertTrue($ret[$i++] === FALSE); // lget
+        $this->assertTrue($ret[$i++] === FALSE); // lset
+        $this->assertTrue($ret[$i++] === FALSE); // lremove
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpoplush
+
+        $this->assertTrue($ret[$i++] === FALSE); // zadd
+        $this->assertTrue($ret[$i++] === FALSE); // zdelete
+        $this->assertTrue($ret[$i++] === FALSE); // zincrby
+        $this->assertTrue($ret[$i++] === FALSE); // zrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrevrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrange
+        $this->assertTrue($ret[$i++] === FALSE); // zreverserange
+        $this->assertTrue($ret[$i++] === FALSE); // zrangebyscore
+        $this->assertTrue($ret[$i++] === FALSE); // zcount
+        $this->assertTrue($ret[$i++] === FALSE); // zcard
+        $this->assertTrue($ret[$i++] === FALSE); // zscore
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyrank
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyscore
+
+        $this->assertTrue($ret[$i++] === FALSE); // hset
+        $this->assertTrue($ret[$i++] === FALSE); // hget
+        $this->assertTrue($ret[$i++] === FALSE); // hmget
+        $this->assertTrue($ret[$i++] === FALSE); // hmset
+        $this->assertTrue($ret[$i++] === FALSE); // hincrby
+        $this->assertTrue($ret[$i++] === FALSE); // hexists
+        $this->assertTrue($ret[$i++] === FALSE); // hdel
+        $this->assertTrue($ret[$i++] === FALSE); // hlen
+        $this->assertTrue($ret[$i++] === FALSE); // hkeys
+        $this->assertTrue($ret[$i++] === FALSE); // hvals
+        $this->assertTrue($ret[$i++] === FALSE); // hgetall
+
+        $this->assertEquals($i, count($ret));
+
+        // sorted set
+        $key = 'sortedset';
+        $ret = $this->redis->multi($mode)
+            ->delete($key)
+            ->zAdd($key, 0, 'zValue')
+
+            // string I/F
+            ->get($key)
+            ->getset($key, 'value2')
+            ->append($key, 'append')
+            ->substr($key, 0, 8)
+            ->mget(array($key))
+            ->incr($key)
+            ->incrBy($key, 1)
+            ->decr($key)
+            ->decrBy($key, 1)
+
+            // lists I/F
+            ->rPush($key, 'lvalue')
+            ->lPush($key, 'lvalue')
+            ->lLen($key)
+            ->lPop($key)
+            ->lGetRange($key, 0, -1)
+            ->lTrim($key, 0, 1)
+            ->lGet($key, 0)
+            ->lSet($key, 0, "newValue")
+            ->lRemove($key, 'lvalue', 1)
+            ->lPop($key)
+            ->rPop($key)
+            ->rPoplPush($key, __FUNCTION__ . 'lkey1')
+
+            // sets I/F
+            ->sAdd($key, 'sValue1')
+            ->sRemove($key, 'sValue1')
+            ->sPop($key)
+            ->sMove($key, __FUNCTION__ . 'skey1', 'sValue1')
+            ->sSize($key)
+            ->sContains($key, 'sValue1')
+            ->sInter($key, __FUNCTION__ . 'skey2')
+            ->sUnion($key, __FUNCTION__ . 'skey4')
+            ->sDiff($key, __FUNCTION__ . 'skey7')
+            ->sMembers($key)
+            ->sRandMember($key)
+
+            // hash I/F
+            ->hSet($key, 'key1', 'value1')
+            ->hGet($key, 'key1')
+            ->hMGet($key, array('key1'))
+            ->hMSet($key, array('key1' => 'value1'))
+            ->hIncrBy($key, 'key2', 1)
+            ->hExists($key, 'key2')
+            ->hDel($key, 'key2')
+            ->hLen($key)
+            ->hKeys($key)
+            ->hVals($key)
+            ->hGetAll($key)
+
+            ->exec();
+
+        $i = 0;
+        $this->assertTrue(is_array($ret));
+        $this->assertTrue(is_long($ret[$i++])); // delete
+        $this->assertTrue($ret[$i++] === 1); // zadd
+
+        $this->assertTrue($ret[$i++] === FALSE); // get
+        $this->assertTrue($ret[$i++] === FALSE); // getset
+        $this->assertTrue($ret[$i++] === FALSE); // append
+        $this->assertTrue($ret[$i++] === FALSE); // substr
+        $this->assertTrue(is_array($ret[$i]) && count($ret[$i]) === 1 && $ret[$i][0] === FALSE); // mget
+        $i++;
+        $this->assertTrue($ret[$i++] === FALSE); // incr
+        $this->assertTrue($ret[$i++] === FALSE); // incrBy
+        $this->assertTrue($ret[$i++] === FALSE); // decr
+        $this->assertTrue($ret[$i++] === FALSE); // decrBy
+
+        $this->assertTrue($ret[$i++] === FALSE); // rpush
+        $this->assertTrue($ret[$i++] === FALSE); // lpush
+        $this->assertTrue($ret[$i++] === FALSE); // llen
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // lgetrange
+        $this->assertTrue($ret[$i++] === FALSE); // ltrim
+        $this->assertTrue($ret[$i++] === FALSE); // lget
+        $this->assertTrue($ret[$i++] === FALSE); // lset
+        $this->assertTrue($ret[$i++] === FALSE); // lremove
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpoplush
+
+        $this->assertTrue($ret[$i++] === FALSE); // sadd
+        $this->assertTrue($ret[$i++] === FALSE); // sremove
+        $this->assertTrue($ret[$i++] === FALSE); // spop
+        $this->assertTrue($ret[$i++] === FALSE); // smove
+        $this->assertTrue($ret[$i++] === FALSE); // ssize
+        $this->assertTrue($ret[$i++] === FALSE); // scontains
+        $this->assertTrue($ret[$i++] === FALSE); // sinter
+        $this->assertTrue($ret[$i++] === FALSE); // sunion
+        $this->assertTrue($ret[$i++] === FALSE); // sdiff
+        $this->assertTrue($ret[$i++] === FALSE); // smembers
+        $this->assertTrue($ret[$i++] === FALSE); // srandmember
+
+        $this->assertTrue($ret[$i++] === FALSE); // hset
+        $this->assertTrue($ret[$i++] === FALSE); // hget
+        $this->assertTrue($ret[$i++] === FALSE); // hmget
+        $this->assertTrue($ret[$i++] === FALSE); // hmset
+        $this->assertTrue($ret[$i++] === FALSE); // hincrby
+        $this->assertTrue($ret[$i++] === FALSE); // hexists
+        $this->assertTrue($ret[$i++] === FALSE); // hdel
+        $this->assertTrue($ret[$i++] === FALSE); // hlen
+        $this->assertTrue($ret[$i++] === FALSE); // hkeys
+        $this->assertTrue($ret[$i++] === FALSE); // hvals
+        $this->assertTrue($ret[$i++] === FALSE); // hgetall
+
+        $this->assertEquals($i, count($ret));
+
+        // hash
+        $key = 'hash';
+        $ret = $this->redis->multi($mode)
+            ->delete($key)
+            ->hset($key, 'key1', 'hValue')
+
+            // string I/F
+            ->get($key)
+            ->getset($key, 'value2')
+            ->append($key, 'append')
+            ->substr($key, 0, 8)
+            ->mget(array($key))
+            ->incr($key)
+            ->incrBy($key, 1)
+            ->decr($key)
+            ->decrBy($key, 1)
+
+            // lists I/F
+            ->rPush($key, 'lvalue')
+            ->lPush($key, 'lvalue')
+            ->lLen($key)
+            ->lPop($key)
+            ->lGetRange($key, 0, -1)
+            ->lTrim($key, 0, 1)
+            ->lGet($key, 0)
+            ->lSet($key, 0, "newValue")
+            ->lRemove($key, 'lvalue', 1)
+            ->lPop($key)
+            ->rPop($key)
+            ->rPoplPush($key, __FUNCTION__ . 'lkey1')
+
+            // sets I/F
+            ->sAdd($key, 'sValue1')
+            ->sRemove($key, 'sValue1')
+            ->sPop($key)
+            ->sMove($key, __FUNCTION__ . 'skey1', 'sValue1')
+            ->sSize($key)
+            ->sContains($key, 'sValue1')
+            ->sInter($key, __FUNCTION__ . 'skey2')
+            ->sUnion($key, __FUNCTION__ . 'skey4')
+            ->sDiff($key, __FUNCTION__ . 'skey7')
+            ->sMembers($key)
+            ->sRandMember($key)
+
+            // sorted sets I/F
+            ->zAdd($key, 1, 'zValue1')
+            ->zDelete($key, 'zValue1')
+            ->zIncrBy($key, 1, 'zValue1')
+            ->zRank($key, 'zValue1')
+            ->zRevRank($key, 'zValue1')
+            ->zRange($key, 0, -1)
+            ->zReverseRange($key, 0, -1)
+            ->zRangeByScore($key, 1, 2)
+            ->zCount($key, 0, -1)
+            ->zCard($key)
+            ->zScore($key, 'zValue1')
+            ->zDeleteRangeByRank($key, 1, 2)
+            ->zDeleteRangeByScore($key, 1, 2)
+
+            ->exec();
+
+        $i = 0;
+        $this->assertTrue(is_array($ret));
+        $this->assertTrue(is_long($ret[$i++])); // delete
+        $this->assertTrue($ret[$i++] === 1); // hset
+
+        $this->assertTrue($ret[$i++] === FALSE); // get
+        $this->assertTrue($ret[$i++] === FALSE); // getset
+        $this->assertTrue($ret[$i++] === FALSE); // append
+        $this->assertTrue($ret[$i++] === FALSE); // substr
+        $this->assertTrue(is_array($ret[$i]) && count($ret[$i]) === 1 && $ret[$i][0] === FALSE); // mget
+        $i++;
+        $this->assertTrue($ret[$i++] === FALSE); // incr
+        $this->assertTrue($ret[$i++] === FALSE); // incrBy
+        $this->assertTrue($ret[$i++] === FALSE); // decr
+        $this->assertTrue($ret[$i++] === FALSE); // decrBy
+
+        $this->assertTrue($ret[$i++] === FALSE); // rpush
+        $this->assertTrue($ret[$i++] === FALSE); // lpush
+        $this->assertTrue($ret[$i++] === FALSE); // llen
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // lgetrange
+        $this->assertTrue($ret[$i++] === FALSE); // ltrim
+        $this->assertTrue($ret[$i++] === FALSE); // lget
+        $this->assertTrue($ret[$i++] === FALSE); // lset
+        $this->assertTrue($ret[$i++] === FALSE); // lremove
+        $this->assertTrue($ret[$i++] === FALSE); // lpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpop
+        $this->assertTrue($ret[$i++] === FALSE); // rpoplush
+
+        $this->assertTrue($ret[$i++] === FALSE); // sadd
+        $this->assertTrue($ret[$i++] === FALSE); // sremove
+        $this->assertTrue($ret[$i++] === FALSE); // spop
+        $this->assertTrue($ret[$i++] === FALSE); // smove
+        $this->assertTrue($ret[$i++] === FALSE); // ssize
+        $this->assertTrue($ret[$i++] === FALSE); // scontains
+        $this->assertTrue($ret[$i++] === FALSE); // sinter
+        $this->assertTrue($ret[$i++] === FALSE); // sunion
+        $this->assertTrue($ret[$i++] === FALSE); // sdiff
+        $this->assertTrue($ret[$i++] === FALSE); // smembers
+        $this->assertTrue($ret[$i++] === FALSE); // srandmember
+
+        $this->assertTrue($ret[$i++] === FALSE); // zadd
+        $this->assertTrue($ret[$i++] === FALSE); // zdelete
+        $this->assertTrue($ret[$i++] === FALSE); // zincrby
+        $this->assertTrue($ret[$i++] === FALSE); // zrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrevrank
+        $this->assertTrue($ret[$i++] === FALSE); // zrange
+        $this->assertTrue($ret[$i++] === FALSE); // zreverserange
+        $this->assertTrue($ret[$i++] === FALSE); // zrangebyscore
+        $this->assertTrue($ret[$i++] === FALSE); // zcount
+        $this->assertTrue($ret[$i++] === FALSE); // zcard
+        $this->assertTrue($ret[$i++] === FALSE); // zscore
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyrank
+        $this->assertTrue($ret[$i++] === FALSE); // zdeleterangebyscore
+
+        $this->assertEquals($i, count($ret));
+    }
+
+    public function testDifferentTypeString() {
+        $key = 'string';
+        $this->redis->del($key);
+        $this->assertEquals(TRUE, $this->redis->set($key, 'value'));
+
+        // lists I/F
+        $this->assertEquals(FALSE, $this->redis->rPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lLen($key));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->lGetRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->lTrim($key, 0, 1));
+        $this->assertEquals(FALSE, $this->redis->lGet($key, 0));
+        $this->assertEquals(FALSE, $this->redis->lSet($key, 0, "newValue"));
+        $this->assertEquals(FALSE, $this->redis->lRemove($key, 'lvalue', 1));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPoplPush($key, __FUNCTION__ . 'lkey1'));
+
+        // sets I/F
+        $this->assertEquals(FALSE, $this->redis->sAdd($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sRemove($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sPop($key));
+        $this->assertEquals(FALSE, $this->redis->sMove($key, __FUNCTION__ . 'skey1', 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sSize($key));
+        $this->assertEquals(FALSE, $this->redis->sContains($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sInter($key, __FUNCTION__ . 'skey2'));
+        $this->assertEquals(FALSE, $this->redis->sUnion($key, __FUNCTION__ . 'skey4'));
+        $this->assertEquals(FALSE, $this->redis->sDiff($key, __FUNCTION__ . 'skey7'));
+        $this->assertEquals(FALSE, $this->redis->sMembers($key));
+        $this->assertEquals(FALSE, $this->redis->sRandMember($key));
+
+        // sorted sets I/F
+        $this->assertEquals(FALSE, $this->redis->zAdd($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDelete($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zIncrBy($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRevRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zReverseRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zRangeByScore($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zCount($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zCard($key));
+        $this->assertEquals(FALSE, $this->redis->zScore($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByRank($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByScore($key, 1, 2));
+
+        // hash I/F
+        $this->assertEquals(FALSE, $this->redis->hSet($key, 'key1', 'value1'));
+        $this->assertEquals(FALSE, $this->redis->hGet($key, 'key1'));
+        $this->assertEquals(FALSE, $this->redis->hMGet($key, array('key1')));
+        $this->assertEquals(FALSE, $this->redis->hMSet($key, array('key1' => 'value1')));
+        $this->assertEquals(FALSE, $this->redis->hIncrBy($key, 'key2', 1));
+        $this->assertEquals(FALSE, $this->redis->hExists($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hDel($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hLen($key));
+        $this->assertEquals(FALSE, $this->redis->hKeys($key));
+        $this->assertEquals(FALSE, $this->redis->hVals($key));
+        $this->assertEquals(FALSE, $this->redis->hGetAll($key));
+    }
+
+    public function testDifferentTypeList() {
+        $key = 'list';
+        $this->redis->del($key);
+        $this->assertEquals(1, $this->redis->lPush($key, 'value'));
+
+        // string I/F
+        $this->assertEquals(FALSE, $this->redis->get($key));
+        $this->assertEquals(FALSE, $this->redis->getset($key, 'value2'));
+        $this->assertEquals(FALSE, $this->redis->append($key, 'append'));
+        $this->assertEquals(FALSE, $this->redis->substr($key, 0, 8));
+        $this->assertEquals(array(FALSE), $this->redis->mget(array($key)));
+        $this->assertEquals(FALSE, $this->redis->incr($key));
+        $this->assertEquals(FALSE, $this->redis->incrBy($key, 1));
+        $this->assertEquals(FALSE, $this->redis->decr($key));
+        $this->assertEquals(FALSE, $this->redis->decrBy($key, 1));
+
+        // sets I/F
+        $this->assertEquals(FALSE, $this->redis->sAdd($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sRemove($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sPop($key));
+        $this->assertEquals(FALSE, $this->redis->sMove($key, __FUNCTION__ . 'skey1', 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sSize($key));
+        $this->assertEquals(FALSE, $this->redis->sContains($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sInter($key, __FUNCTION__ . 'skey2'));
+        $this->assertEquals(FALSE, $this->redis->sUnion($key, __FUNCTION__ . 'skey4'));
+        $this->assertEquals(FALSE, $this->redis->sDiff($key, __FUNCTION__ . 'skey7'));
+        $this->assertEquals(FALSE, $this->redis->sMembers($key));
+        $this->assertEquals(FALSE, $this->redis->sRandMember($key));
+
+        // sorted sets I/F
+        $this->assertEquals(FALSE, $this->redis->zAdd($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDelete($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zIncrBy($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRevRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zReverseRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zRangeByScore($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zCount($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zCard($key));
+        $this->assertEquals(FALSE, $this->redis->zScore($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByRank($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByScore($key, 1, 2));
+
+        // hash I/F
+        $this->assertEquals(FALSE, $this->redis->hSet($key, 'key1', 'value1'));
+        $this->assertEquals(FALSE, $this->redis->hGet($key, 'key1'));
+        $this->assertEquals(FALSE, $this->redis->hMGet($key, array('key1')));
+        $this->assertEquals(FALSE, $this->redis->hMSet($key, array('key1' => 'value1')));
+        $this->assertEquals(FALSE, $this->redis->hIncrBy($key, 'key2', 1));
+        $this->assertEquals(FALSE, $this->redis->hExists($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hDel($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hLen($key));
+        $this->assertEquals(FALSE, $this->redis->hKeys($key));
+        $this->assertEquals(FALSE, $this->redis->hVals($key));
+        $this->assertEquals(FALSE, $this->redis->hGetAll($key));
+    }
+
+    public function testDifferentTypeSet() {
+        $key = 'set';
+        $this->redis->del($key);
+        $this->assertEquals(1, $this->redis->sAdd($key, 'value'));
+
+        // string I/F
+        $this->assertEquals(FALSE, $this->redis->get($key));
+        $this->assertEquals(FALSE, $this->redis->getset($key, 'value2'));
+        $this->assertEquals(FALSE, $this->redis->append($key, 'append'));
+        $this->assertEquals(FALSE, $this->redis->substr($key, 0, 8));
+        $this->assertEquals(array(FALSE), $this->redis->mget(array($key)));
+        $this->assertEquals(FALSE, $this->redis->incr($key));
+        $this->assertEquals(FALSE, $this->redis->incrBy($key, 1));
+        $this->assertEquals(FALSE, $this->redis->decr($key));
+        $this->assertEquals(FALSE, $this->redis->decrBy($key, 1));
+
+        // lists I/F
+        $this->assertEquals(FALSE, $this->redis->rPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lLen($key));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->lGetRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->lTrim($key, 0, 1));
+        $this->assertEquals(FALSE, $this->redis->lGet($key, 0));
+        $this->assertEquals(FALSE, $this->redis->lSet($key, 0, "newValue"));
+        $this->assertEquals(FALSE, $this->redis->lRemove($key, 'lvalue', 1));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPoplPush($key, __FUNCTION__ . 'lkey1'));
+
+        // sorted sets I/F
+        $this->assertEquals(FALSE, $this->redis->zAdd($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDelete($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zIncrBy($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRevRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zReverseRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zRangeByScore($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zCount($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zCard($key));
+        $this->assertEquals(FALSE, $this->redis->zScore($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByRank($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByScore($key, 1, 2));
+
+        // hash I/F
+        $this->assertEquals(FALSE, $this->redis->hSet($key, 'key1', 'value1'));
+        $this->assertEquals(FALSE, $this->redis->hGet($key, 'key1'));
+        $this->assertEquals(FALSE, $this->redis->hMGet($key, array('key1')));
+        $this->assertEquals(FALSE, $this->redis->hMSet($key, array('key1' => 'value1')));
+        $this->assertEquals(FALSE, $this->redis->hIncrBy($key, 'key2', 1));
+        $this->assertEquals(FALSE, $this->redis->hExists($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hDel($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hLen($key));
+        $this->assertEquals(FALSE, $this->redis->hKeys($key));
+        $this->assertEquals(FALSE, $this->redis->hVals($key));
+        $this->assertEquals(FALSE, $this->redis->hGetAll($key));
+    }
+
+    public function testDifferentTypeSortedSet() {
+        $key = 'sortedset';
+        $this->redis->del($key);
+        $this->assertEquals(1, $this->redis->zAdd($key, 0, 'value'));
+
+        // string I/F
+        $this->assertEquals(FALSE, $this->redis->get($key));
+        $this->assertEquals(FALSE, $this->redis->getset($key, 'value2'));
+        $this->assertEquals(FALSE, $this->redis->append($key, 'append'));
+        $this->assertEquals(FALSE, $this->redis->substr($key, 0, 8));
+        $this->assertEquals(array(FALSE), $this->redis->mget(array($key)));
+        $this->assertEquals(FALSE, $this->redis->incr($key));
+        $this->assertEquals(FALSE, $this->redis->incrBy($key, 1));
+        $this->assertEquals(FALSE, $this->redis->decr($key));
+        $this->assertEquals(FALSE, $this->redis->decrBy($key, 1));
+
+        // lists I/F
+        $this->assertEquals(FALSE, $this->redis->rPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lLen($key));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->lGetRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->lTrim($key, 0, 1));
+        $this->assertEquals(FALSE, $this->redis->lGet($key, 0));
+        $this->assertEquals(FALSE, $this->redis->lSet($key, 0, "newValue"));
+        $this->assertEquals(FALSE, $this->redis->lRemove($key, 'lvalue', 1));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPoplPush($key, __FUNCTION__ . 'lkey1'));
+
+        // sets I/F
+        $this->assertEquals(FALSE, $this->redis->sAdd($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sRemove($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sPop($key));
+        $this->assertEquals(FALSE, $this->redis->sMove($key, __FUNCTION__ . 'skey1', 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sSize($key));
+        $this->assertEquals(FALSE, $this->redis->sContains($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sInter($key, __FUNCTION__ . 'skey2'));
+        $this->assertEquals(FALSE, $this->redis->sUnion($key, __FUNCTION__ . 'skey4'));
+        $this->assertEquals(FALSE, $this->redis->sDiff($key, __FUNCTION__ . 'skey7'));
+        $this->assertEquals(FALSE, $this->redis->sMembers($key));
+        $this->assertEquals(FALSE, $this->redis->sRandMember($key));
+
+        // hash I/F
+        $this->assertEquals(FALSE, $this->redis->hSet($key, 'key1', 'value1'));
+        $this->assertEquals(FALSE, $this->redis->hGet($key, 'key1'));
+        $this->assertEquals(FALSE, $this->redis->hMGet($key, array('key1')));
+        $this->assertEquals(FALSE, $this->redis->hMSet($key, array('key1' => 'value1')));
+        $this->assertEquals(FALSE, $this->redis->hIncrBy($key, 'key2', 1));
+        $this->assertEquals(FALSE, $this->redis->hExists($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hDel($key, 'key2'));
+        $this->assertEquals(FALSE, $this->redis->hLen($key));
+        $this->assertEquals(FALSE, $this->redis->hKeys($key));
+        $this->assertEquals(FALSE, $this->redis->hVals($key));
+        $this->assertEquals(FALSE, $this->redis->hGetAll($key));
+    }
+
+    public function testDifferentTypeHash() {
+        $key = 'hash';
+        $this->redis->del($key);
+        $this->assertEquals(1, $this->redis->hSet($key, 'key', 'value'));
+
+        // string I/F
+        $this->assertEquals(FALSE, $this->redis->get($key));
+        $this->assertEquals(FALSE, $this->redis->getset($key, 'value2'));
+        $this->assertEquals(FALSE, $this->redis->append($key, 'append'));
+        $this->assertEquals(FALSE, $this->redis->substr($key, 0, 8));
+        $this->assertEquals(array(FALSE), $this->redis->mget(array($key)));
+        $this->assertEquals(FALSE, $this->redis->incr($key));
+        $this->assertEquals(FALSE, $this->redis->incrBy($key, 1));
+        $this->assertEquals(FALSE, $this->redis->decr($key));
+        $this->assertEquals(FALSE, $this->redis->decrBy($key, 1));
+
+        // lists I/F
+        $this->assertEquals(FALSE, $this->redis->rPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lPush($key, 'lvalue'));
+        $this->assertEquals(FALSE, $this->redis->lLen($key));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->lGetRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->lTrim($key, 0, 1));
+        $this->assertEquals(FALSE, $this->redis->lGet($key, 0));
+        $this->assertEquals(FALSE, $this->redis->lSet($key, 0, "newValue"));
+        $this->assertEquals(FALSE, $this->redis->lRemove($key, 'lvalue', 1));
+        $this->assertEquals(FALSE, $this->redis->lPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPop($key));
+        $this->assertEquals(FALSE, $this->redis->rPoplPush($key, __FUNCTION__ . 'lkey1'));
+
+        // sets I/F
+        $this->assertEquals(FALSE, $this->redis->sAdd($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sRemove($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sPop($key));
+        $this->assertEquals(FALSE, $this->redis->sMove($key, __FUNCTION__ . 'skey1', 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sSize($key));
+        $this->assertEquals(FALSE, $this->redis->sContains($key, 'sValue1'));
+        $this->assertEquals(FALSE, $this->redis->sInter($key, __FUNCTION__ . 'skey2'));
+        $this->assertEquals(FALSE, $this->redis->sUnion($key, __FUNCTION__ . 'skey4'));
+        $this->assertEquals(FALSE, $this->redis->sDiff($key, __FUNCTION__ . 'skey7'));
+        $this->assertEquals(FALSE, $this->redis->sMembers($key));
+        $this->assertEquals(FALSE, $this->redis->sRandMember($key));
+
+        // sorted sets I/F
+        $this->assertEquals(FALSE, $this->redis->zAdd($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDelete($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zIncrBy($key, 1, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRevRank($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zReverseRange($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zRangeByScore($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zCount($key, 0, -1));
+        $this->assertEquals(FALSE, $this->redis->zCard($key));
+        $this->assertEquals(FALSE, $this->redis->zScore($key, 'zValue1'));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByRank($key, 1, 2));
+        $this->assertEquals(FALSE, $this->redis->zDeleteRangeByScore($key, 1, 2));
     }
 
     public function testSerializerPHP() {


### PR DESCRIPTION
bug detail
i.g.

``` php
$ret = $redis->multi()
             ->set("stringkey", "val")
             ->lRange("stringkey", 0, 0)
             ->exec();
var_dump($ret);
```

expect:

```
array(2) {
  [0]=>
  bool(true)
  [1]=>
  bool(false)
}
```

actual:

```
array(1) {
  [0]=>
  bool(true)
}
```
