### PR TITLE
Skipped tests

### DIFF
--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -389,7 +389,7 @@ class Redis_Test extends TestSuite
     {
 	// incrbyfloat is new in 2.6.0
 	if (version_compare($this->version, "2.5.0", "lt")) {
-		return;
+		$this->markTestSkipped();
 	}
 
 	$this->redis->delete('key');
@@ -1632,7 +1632,7 @@ class Redis_Test extends TestSuite
 
 	// INFO COMMANDSTATS is new in 2.6.0
 	if (version_compare($this->version, "2.5.0", "lt")) {
-		return;
+		$this->markTestSkipped();
 	}
 
 	$info = $this->redis->info("COMMANDSTATS");
@@ -2988,7 +2988,7 @@ class Redis_Test extends TestSuite
     public function testDumpRestore() {
 
 		if (version_compare($this->version, "2.5.0", "lt")) {
-			return;
+			$this->markTestSkipped();
 		}
 
     	$this->redis->del('foo');
@@ -3053,7 +3053,7 @@ class Redis_Test extends TestSuite
     public function testScript() {
 
 		if (version_compare($this->version, "2.5.0", "lt")) {
-			return;
+			$this->markTestSkipped();
 		}
 
 		// Flush any scripts we have
@@ -3085,7 +3085,7 @@ class Redis_Test extends TestSuite
     public function testEval() {
 
 		if (version_compare($this->version, "2.5.0", "lt")) {
-			return;
+			$this->markTestSkipped();
 		}
 
     	// Basic single line response tests
@@ -3203,7 +3203,7 @@ class Redis_Test extends TestSuite
     public function testEvalSHA() {
 
 		if (version_compare($this->version, "2.5.0", "lt")) {
-			return;
+			$this->markTestSkipped();
 		}
 
     	// Flush any loaded scripts
@@ -3301,7 +3301,7 @@ class Redis_Test extends TestSuite
 	public function testTime() {
 
 		if (version_compare($this->version, "2.5.0", "lt")) {
-			return;
+			$this->markTestSkipped();
 		}
 
 		$time_arr = $this->redis->time();


### PR DESCRIPTION
This commit add a markTestSkipped (name inspired from phpunit) and report skipped tests.

Run against 2.4.16 server :

```
$ php TestRedis.php
Note: these tests might take up to a minute. Don't worry :-)
...................S.....................................S.............S.SSS...S
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:392 (testIncrByFloat) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:1635 (testInfoCommandStats) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:2991 (testDumpRestore) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:3056 (testScript) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:3088 (testEval) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:3206 (testEvalSHA) 
Skipped test: /work/GIT/phpredis/tests/TestRedis.php:3304 (testTime) 
All tests passed.
```
