### PR TITLE
add Redis::OPT_READ_TIMEOUT option for issue #70

### DIFF
--- a/common.h
+++ b/common.h
@@ -34,6 +34,7 @@ typedef enum _REDIS_REPLY_TYPE {
 /* options */
 #define REDIS_OPT_SERIALIZER		1
 #define REDIS_OPT_PREFIX		    2
+#define REDIS_OPT_READ_TIMEOUT		3
 
 /* serializers */
 #define REDIS_SERIALIZER_NONE		0
@@ -156,6 +157,7 @@ typedef struct {
     char           *host;
     short          port;
     double         timeout;
+    double         read_timeout;
     int            failed;
     int            status;
     int            persistent;

--- a/redis.c
+++ b/redis.c
@@ -434,6 +434,7 @@ PHP_MINIT_FUNCTION(redis)
     /* options */
     add_constant_long(redis_ce, "OPT_SERIALIZER", REDIS_OPT_SERIALIZER);
     add_constant_long(redis_ce, "OPT_PREFIX", REDIS_OPT_PREFIX);
+    add_constant_long(redis_ce, "OPT_READ_TIMEOUT", REDIS_OPT_READ_TIMEOUT);
 
     /* serializer */
     add_constant_long(redis_ce, "SERIALIZER_NONE", REDIS_SERIALIZER_NONE);
@@ -5650,6 +5651,9 @@ PHP_METHOD(Redis, getOption)  {
 					}
                     RETURN_NULL();
 
+            case REDIS_OPT_READ_TIMEOUT:
+                    RETURN_DOUBLE(redis_sock->read_timeout);
+
             default:
                     RETURN_FALSE;
 
@@ -5665,6 +5669,7 @@ PHP_METHOD(Redis, setOption) {
     long option, val_long;
 	char *val_str;
 	int val_len;
+    struct timeval read_tv;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ols",
 									 &object, redis_ce, &option, &val_str, &val_len) == FAILURE) {
@@ -5703,6 +5708,16 @@ PHP_METHOD(Redis, setOption) {
 						memcpy(redis_sock->prefix, val_str, val_len);
 					}
 					RETURN_TRUE;
+
+            case REDIS_OPT_READ_TIMEOUT:
+                    redis_sock->read_timeout = atof(val_str);
+                    if(redis_sock->stream) {
+                        read_tv.tv_sec  = (time_t)redis_sock->read_timeout;
+                        read_tv.tv_usec = (int)((redis_sock->read_timeout - read_tv.tv_sec) * 1000000);
+                        php_stream_set_option(redis_sock->stream, PHP_STREAM_OPTION_READ_TIMEOUT,
+                                              0, &read_tv);
+                    }
+                    RETURN_TRUE;
 
             default:
                     RETURN_FALSE;

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -3321,6 +3321,15 @@ class Redis_Test extends TestSuite
 				          strval(intval($time_arr[0])) === strval($time_arr[0]) &&
 						  strval(intval($time_arr[1])) === strval($time_arr[1]));
 	}
+
+	public function testReadTimeoutOption() {
+
+		$this->assertTrue(defined('Redis::OPT_READ_TIMEOUT'));
+
+		$this->redis->setOption(Redis::OPT_READ_TIMEOUT, "12.3");
+		$this->assertEquals(12.3, $this->redis->getOption(Redis::OPT_READ_TIMEOUT));
+	}
+
 }
 
 exit(TestSuite::run("Redis_Test"));


### PR DESCRIPTION
This is a patch to fix issue [#70 debug read error on connection](https://github.com/nicolasff/phpredis/issues/70).

`Redis#connect()` uses its third argument `timeout` not only for the connection timeout but also for the read timeout on an opened stream. (by calling `php_stream_set_option` on the stream)

This behavior causes "read error" on any reading methods (get, hget, blpop, etc.) if you give very short timeout value to `connect()`.

This patch adds `Redis::OPT_READ_TIMEOUT` for `Redis#setOption()` so that you can specify another timeout value for `php_stream_set_option`.

You can test this fix by @micharl-grunder's [reproduce code](https://github.com/nicolasff/phpredis/issues/70#issuecomment-5096151).
### Before

``` php
try {
        $r = new Redis();
        if(!$r->connect('localhost',6379,5)) {
                echo "Couldn't connect\n";
                die();
        }
        $st = microtime(true);
        $val = $r->blpop('mykey',0);
        $et = microtime(true);
} catch(Exception $ex) {
        echo "ex: " . $ex->getMessage() . "\n";
        $et = microtime(true);
}

echo "Took: " . ($et-$st) . " to get the key\n";
```

output:

```
ex: read error on connection
Took: 5.0015189647675 to get the key
```
### After

``` php
try {
        $r = new Redis();
        if(!$r->connect('localhost',6379,5)) {
                echo "Couldn't connect\n";
                die();
        }
        $r->setOption(Redis::OPT_READ_TIMEOUT, 10);   // by patch
        $st = microtime(true);
        $val = $r->blpop('mykey',0);
        $et = microtime(true);
} catch(Exception $ex) {
        echo "ex: " . $ex->getMessage() . "\n";
        $et = microtime(true);
}

echo "Took: " . ($et-$st) . " to get the key\n";
```

output:

```
ex: read error on connection
Took: 10.001543998718 to get the key
```
