### PR TITLE
Updated README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -576,6 +576,8 @@ $redis->time();
 * [ttl, pttl](#ttl-pttl) - Get the time to live for a key
 * [restore](#restore) - Create a key using the provided serialized value, previously obtained with [dump](#dump).
 
+-----
+
 ### get
 -----
 _**Description**_: Get the value related to the specified key


### PR DESCRIPTION
I updated the README markdown with the following changes
- Added global TOC
- Added per command group TOC, grouping based on redis.io/commands reference
- Removed HTML <pre> tags in favor of ~~~ markdown syntax
- Cleaned up consistency on description, parameters, examples (was inconsistent)
- Cleaned up a few descriptions, white space formattings

TODO:
- Constants needs to be completed (currently only redis types listed for redis::type)
- some methods arent capitalized like they should be (bitcount, msetnx)

Please comment, so I know you're happy with this or if you want some changes. Apart from splitting up Keys & Strings into two sections I'm pretty happy with it.

Best,
Tit
