### PR TITLE
Add support for serializer setting in redis.ini.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,7 +44,11 @@ make && make install
 ~~~
 
 If you would like phpredis to serialize your data using the igbinary library, run configure with `--enable-redis-igbinary`.
-`make install` copies `redis.so` to an appropriate location, but you still need to enable the module in the PHP config file. To do so, either edit your php.ini or add a redis.ini file in `/etc/php5/conf.d` with the following contents: `extension=redis.so`.
+`make install` copies `redis.so` to an appropriate location, but you still need to enable the module in the PHP config file. To do so, either edit your php.ini or add a redis.ini file in `/etc/php5/conf.d` with the following contents:
+
+    extension=redis.so
+    ; optional: Set to igbinary | php | none
+    redis.serializer=igbinary 
 
 You can generate a debian package for PHP5, accessible from Apache 2 by running `./mkdeb-apache2.sh` or with `dpkg-buildpackage` or `svn-buildpackage`.
 

--- a/common.h
+++ b/common.h
@@ -42,6 +42,10 @@ typedef enum _REDIS_REPLY_TYPE {
 #define REDIS_SERIALIZER_PHP 		1
 #define REDIS_SERIALIZER_IGBINARY 	2
 
+#define INI_REDIS_SERIALIZER_NONE		"none"
+#define INI_REDIS_SERIALIZER_PHP 		"php"
+#define INI_REDIS_SERIALIZER_IGBINARY 	"igbinary"
+
 #define IF_MULTI() if(redis_sock->mode == MULTI)
 #define IF_MULTI_OR_ATOMIC() if(redis_sock->mode == MULTI || redis_sock->mode == ATOMIC)\
 

--- a/redis.c
+++ b/redis.c
@@ -59,6 +59,9 @@ zend_class_entry *spl_ce_RuntimeException = NULL;
 extern zend_function_entry redis_array_functions[];
 
 PHP_INI_BEGIN()
+    /* redis serialization */
+    PHP_INI_ENTRY("redis.serializer", INI_REDIS_SERIALIZER_NONE, PHP_INI_ALL, NULL)
+
 	/* redis arrays */
 	PHP_INI_ENTRY("redis.arrays.names", "", PHP_INI_ALL, NULL)
 	PHP_INI_ENTRY("redis.arrays.hosts", "", PHP_INI_ALL, NULL)


### PR DESCRIPTION
Hi there

I think it makes sense to configure the serializer system wide in the redis.ini file. This can still be changed calling $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_XYZ); in the code.

I decided to keep the INI-setting readable and defined new constants containing the possible string values for this setting.

Regards,
Michael
