### PR TITLE
some socket error handling improvements

### DIFF
--- a/common.h
+++ b/common.h
@@ -19,6 +19,7 @@
 #define redis_multi_access_type_name "Redis Multi type access"
 
 #define _NL "\r\n"
+#define _NL_len (sizeof(_NL)-1)
 
 /* properties */
 #define REDIS_NOT_FOUND 0

--- a/library.c
+++ b/library.c
@@ -267,12 +267,12 @@ redis_cmd_format_header(char **ret, char *keyword, int arg_count) {
 
 	smart_str_appendc(&buf, '*');
 	smart_str_append_long(&buf, arg_count + 1);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) -1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 	smart_str_appendc(&buf, '$');
 	smart_str_append_long(&buf, l);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) -1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 	smart_str_appendl(&buf, keyword, l);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 
 	// Set our return pointer
 	*ret = buf.c;
@@ -296,12 +296,12 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...) {
 	/* add header */
 	smart_str_appendc(&buf, '*');
 	smart_str_append_long(&buf, strlen(format) + 1);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 	smart_str_appendc(&buf, '$');
 	smart_str_append_long(&buf, l);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 	smart_str_appendl(&buf, keyword, l);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 
 	while (*p) {
 		smart_str_appendc(&buf, '$');
@@ -311,7 +311,7 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...) {
 					char *val = va_arg(ap, char*);
 					int val_len = va_arg(ap, int);
 					smart_str_append_long(&buf, val_len);
-					smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+					smart_str_appendl(&buf, _NL, _NL_len);
 					smart_str_appendl(&buf, val, val_len);
 				}
 				break;
@@ -321,7 +321,7 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...) {
 				double d = va_arg(ap, double);
 				REDIS_DOUBLE_TO_STRING(dbl_str, dbl_len, d)
 				smart_str_append_long(&buf, dbl_len);
-				smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+				smart_str_appendl(&buf, _NL, _NL_len);
 				smart_str_appendl(&buf, dbl_str, dbl_len);
 				efree(dbl_str);
 			}
@@ -333,7 +333,7 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...) {
 				char tmp[32];
 				int tmp_len = snprintf(tmp, sizeof(tmp), "%d", i);
 				smart_str_append_long(&buf, tmp_len);
-				smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+				smart_str_appendl(&buf, _NL, _NL_len);
 				smart_str_appendl(&buf, tmp, tmp_len);
 			}
 				break;
@@ -343,13 +343,13 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...) {
 				char tmp[32];
 				int tmp_len = snprintf(tmp, sizeof(tmp), "%ld", l);
 				smart_str_append_long(&buf, tmp_len);
-				smart_str_appendl(&buf, _NL, sizeof(_NL) -1);
+				smart_str_appendl(&buf, _NL, _NL_len);
 				smart_str_appendl(&buf, tmp, tmp_len);
 			}
 				break;
 		}
 		p++;
-		smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+		smart_str_appendl(&buf, _NL, _NL_len);
 	}
 	smart_str_0(&buf);
 
@@ -389,7 +389,7 @@ redis_cmd_format(char **ret, char *format, ...) {
 					double d = va_arg(ap, double);
 					REDIS_DOUBLE_TO_STRING(dbl_str, dbl_len, d)
 					smart_str_append_long(&buf, dbl_len);
-					smart_str_appendl(&buf, _NL, sizeof(_NL) - 1);
+					smart_str_appendl(&buf, _NL, _NL_len);
 					smart_str_appendl(&buf, dbl_str, dbl_len);
 					efree(dbl_str);
 				}
@@ -431,9 +431,9 @@ int redis_cmd_append_str(char **cmd, int cmd_len, char *append, int append_len) 
 	// Append our new command sequence
 	smart_str_appendc(&buf, '$');
 	smart_str_append_long(&buf, append_len);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) -1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 	smart_str_appendl(&buf, append, append_len);
-	smart_str_appendl(&buf, _NL, sizeof(_NL) -1);
+	smart_str_appendl(&buf, _NL, _NL_len);
 
 	// Free our old command
 	efree(*cmd);
@@ -452,12 +452,12 @@ int redis_cmd_append_str(char **cmd, int cmd_len, char *append, int append_len) 
 int redis_cmd_init_sstr(smart_str *str, int num_args, char *keyword, int keyword_len) {
     smart_str_appendc(str, '*');
     smart_str_append_long(str, num_args + 1);
-    smart_str_appendl(str, _NL, sizeof(_NL) -1);
+    smart_str_appendl(str, _NL, _NL_len);
     smart_str_appendc(str, '$');
     smart_str_append_long(str, keyword_len);
-    smart_str_appendl(str, _NL, sizeof(_NL) - 1);
+    smart_str_appendl(str, _NL, _NL_len);
     smart_str_appendl(str, keyword, keyword_len);
-    smart_str_appendl(str, _NL, sizeof(_NL) - 1);
+    smart_str_appendl(str, _NL, _NL_len);
     return str->len;
 }
 
@@ -467,9 +467,9 @@ int redis_cmd_init_sstr(smart_str *str, int num_args, char *keyword, int keyword
 int redis_cmd_append_sstr(smart_str *str, char *append, int append_len) {
     smart_str_appendc(str, '$');
     smart_str_append_long(str, append_len);
-    smart_str_appendl(str, _NL, sizeof(_NL) - 1);
+    smart_str_appendl(str, _NL, _NL_len);
     smart_str_appendl(str, append, append_len);
-    smart_str_appendl(str, _NL, sizeof(_NL) - 1);
+    smart_str_appendl(str, _NL, _NL_len);
 
     // Return our new length
     return str->len;

--- a/redis.c
+++ b/redis.c
@@ -379,9 +379,10 @@ PHPAPI int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, int no_thr
     zval **socket;
     int resource_type;
 
-    if (Z_TYPE_P(id) != IS_OBJECT || zend_hash_find(Z_OBJPROP_P(id), "socket",
-                                  sizeof("socket"), (void **) &socket) == FAILURE) {
-    	// Throw an exception unless we've been requested not to
+    if (Z_TYPE_P(id) != IS_OBJECT ||
+        zend_hash_find(Z_OBJPROP_P(id), "socket", sizeof("socket"), (void **)&socket) == FAILURE ||
+        Z_TYPE_PP(socket) != IS_RESOURCE)
+    {
         if(!no_throw) {
         	zend_throw_exception(redis_exception_ce, "Redis server went away", 0 TSRMLS_CC);
         }

--- a/redis.c
+++ b/redis.c
@@ -384,20 +384,20 @@ PHPAPI int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, int no_thr
         Z_TYPE_PP(socket) != IS_RESOURCE)
     {
         if(!no_throw) {
-        	zend_throw_exception(redis_exception_ce, "Redis server went away", 0 TSRMLS_CC);
+            zend_throw_exception(redis_exception_ce, "no connection", 0 TSRMLS_CC);
         }
         return -1;
     }
 
     *redis_sock = (RedisSock *) zend_list_find(Z_LVAL_PP(socket), &resource_type);
-
     if (!*redis_sock || resource_type != le_redis_sock) {
-		// Throw an exception unless we've been requested not to
-    	if(!no_throw) {
-    		zend_throw_exception(redis_exception_ce, "Redis server went away", 0 TSRMLS_CC);
-    	}
-		return -1;
+        // Throw an exception unless we've been requested not to
+        if(!no_throw) {
+            zend_throw_exception(redis_exception_ce, "bad "redis_sock_name" resource", 0 TSRMLS_CC);
+        }
+        return -1;
     }
+
     if ((*redis_sock)->lazy_connect)
     {
         (*redis_sock)->lazy_connect = 0;

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -119,14 +119,11 @@ class Redis_Test extends TestSuite
     }
 
     public function test1000() {
-
-	 $s = str_repeat('A', 1000);
-	 $this->redis->set('x', $s);
-	 $this->assertEquals($s, $this->redis->get('x'));
-
-	 $s = str_repeat('A', 1000000);
-	 $this->redis->set('x', $s);
-	 $this->assertEquals($s, $this->redis->get('x'));
+        for($len = 1; $len <= 1000000; $len *= 10) {
+            $s = str_repeat('A', $len);
+            $this->assertTrue($this->redis->set('x', $s));
+            $this->assertEquals($s, $this->redis->get('x'));
+        }
     }
 
 	public function testEcho() {


### PR DESCRIPTION
We're using PhpRedis in production with persistent connections.  We're running into issues where these connections will get into a bad state that takes a long time to get cleaned up.  I'm planing on revising how redis_sock->stream is managed during errors, and and this is a handful of simple issues I've found along the way.
