### PR TITLE
Fixed missing "~~~" before "_userialize"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3182,6 +3182,7 @@ $redis->_serialize(new stdClass()); // Returns "Object"
 
 $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
 $redis->_serialize("foo"); // Returns 's:3:"foo";'
+~~~
 
 ### _unserialize
 -----


### PR DESCRIPTION
My OCD compelled me to fix this, it was just a missing "~~~" right after the "_serialize" examples, nothing fancy, it just really hurt to see all the markdown messed up :)
