### PR TITLE
add method: isOldSocket, check whethe the socket was opened in the previous request 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3062,6 +3062,19 @@ None
 *Mixed* Returns the persistent id phpredis is using (which will only be set if connected with pconnect), NULL if we're not
 using a persistent ID, and FALSE if we're not connected
 
+### IsOldSocket
+
+-----
+_**Description**_: check whether the under socket was connected in the previous pconnect
+
+##### *Parameters*
+None  
+
+##### *Return value*
+
+return true if the last pconnect use a socket already exists.
+return false if the last pconnect create a new socket.
+
 ### GetAuth
 -----
 _**Description**_:  Get the password used to authenticate the phpredis connection

--- a/README.markdown
+++ b/README.markdown
@@ -155,6 +155,7 @@ Redis::REDIS_NOT_FOUND - Not found / other
 1. [getOption](#getoption) - Get client option
 1. [ping](#ping) - Ping the server
 1. [echo](#echo) - Echo the given string
+1. [IsOldSocket](#IsOldSocket) - Whether the under socket was connected in the previous pconnect
 
 ### connect, open
 -----

--- a/common.h
+++ b/common.h
@@ -164,6 +164,7 @@ typedef struct {
     int            failed;
     int            status;
     int            persistent;
+    int            old_sock; //whether the sock was connected with pconnect in the previous request
     int            watching;
     char           *persistent_id;
 

--- a/php_redis.h
+++ b/php_redis.h
@@ -190,6 +190,7 @@ PHP_METHOD(Redis, getTimeout);
 PHP_METHOD(Redis, getReadTimeout);
 PHP_METHOD(Redis, isConnected);
 PHP_METHOD(Redis, getPersistentID);
+PHP_METHOD(Redis, isOldSocket);
 PHP_METHOD(Redis, getAuth);
 
 #ifdef PHP_WIN32

--- a/redis.c
+++ b/redis.c
@@ -244,6 +244,7 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, getTimeout, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, getReadTimeout, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, getPersistentID, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, isOldSocket, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, getAuth, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, isConnected, NULL, ZEND_ACC_PUBLIC)
 
@@ -6460,6 +6461,18 @@ PHP_METHOD(Redis, getPersistentID) {
     } else {
         RETURN_FALSE;
     }
+}
+
+/*
+ * {{{ proto Redis::isOldSocket
+ */
+PHP_METHOD(Redis, isOldSocket) {
+    RedisSock *redis_sock;
+    	if (redis_sock_get(getThis(), &redis_sock TSRMLS_CC, 0) < 0 || !redis_sock->old_sock) {
+    		RETURN_FALSE;
+    	} else {
+    		RETURN_TRUE;
+    	}
 }
 
 /*


### PR DESCRIPTION
add method: isOldSocket, check whethe the socket was opened in the previous request 

auth should not be called when pconnect use an old socket.
