### PR TITLE
Feature/stream context

### DIFF
--- a/common.h
+++ b/common.h
@@ -206,7 +206,8 @@ typedef struct {
     int            persistent;
     int            watching;
     char           *persistent_id;
-
+	php_stream_context *context;
+	
     int            serializer;
     long           dbNumber;
 

--- a/common.h
+++ b/common.h
@@ -1,6 +1,8 @@
 #include "php.h"
 #include "php_ini.h"
 #include <ext/standard/php_smart_str.h>
+#include <ext/standard/streamsfuncs.h>
+#include <ext/standard/file.h>
 
 #ifndef REDIS_COMMON_H
 #define REDIS_COMMON_H

--- a/library.c
+++ b/library.c
@@ -1095,7 +1095,7 @@ PHP_REDIS_API void redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
  */
 PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port,
                                     double timeout, int persistent, char *persistent_id,
-                                    long retry_interval,
+                                    long retry_interval, php_stream_context *context
                                     zend_bool lazy_connect)
 {
     RedisSock *redis_sock;
@@ -1109,7 +1109,8 @@ PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned sh
     redis_sock->retry_interval = retry_interval * 1000;
     redis_sock->persistent = persistent;
     redis_sock->lazy_connect = lazy_connect;
-
+	redis_sock->context=context;
+	
     if(persistent_id) {
 		size_t persistent_id_len = strlen(persistent_id);
         redis_sock->persistent_id = ecalloc(persistent_id_len + 1, 1);
@@ -1183,7 +1184,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
     redis_sock->stream = php_stream_xport_create(host, host_len, ENFORCE_SAFE_MODE,
 							 STREAM_XPORT_CLIENT
 							 | STREAM_XPORT_CONNECT,
-							 persistent_id, tv_ptr, NULL, &errstr, &err
+							 persistent_id, tv_ptr, redis_sock->context, &errstr, &err
 							);
 
     if (persistent_id) {

--- a/library.c
+++ b/library.c
@@ -1095,7 +1095,7 @@ PHP_REDIS_API void redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
  */
 PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port,
                                     double timeout, int persistent, char *persistent_id,
-                                    long retry_interval, php_stream_context *context
+                                    long retry_interval, php_stream_context *context,
                                     zend_bool lazy_connect)
 {
     RedisSock *redis_sock;

--- a/library.h
+++ b/library.h
@@ -23,7 +23,7 @@ PHP_REDIS_API void redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock
 PHP_REDIS_API void redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
-PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, int persistent, char *persistent_id, long retry_interval, zend_bool lazy_connect);
+PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, int persistent, char *persistent_id, long retry_interval, php_stream_context *context, zend_bool lazy_connect);
 PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock, int force_connect TSRMLS_DC);
 PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC);

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -72,7 +72,7 @@ ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b
 		call_user_function(&redis_ce->function_table, &ra->redis[i], &z_cons, &z_ret, 0, NULL TSRMLS_CC);
 
 		/* create socket */
-		redis_sock = redis_sock_create(host, host_len, port, ra->connect_timeout, ra->pconnect, NULL, retry_interval, b_lazy_connect);
+		redis_sock = redis_sock_create(host, host_len, port, ra->connect_timeout, ra->pconnect, NULL, retry_interval,NULL, b_lazy_connect);
 
 	    if (!b_lazy_connect)
     	{

--- a/redis_session.c
+++ b/redis_session.c
@@ -277,9 +277,9 @@ PS_OPEN_FUNC(redis)
 			}
 
             if(url->host) {
-                    redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, persistent, persistent_id, retry_interval, 0);
+                    redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, persistent, persistent_id, retry_interval,NULL, 0);
             } else { /* unix */
-                    redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, persistent, persistent_id, retry_interval, 0);
+                    redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, persistent, persistent_id, retry_interval,NULL, 0);
             }
 			redis_pool_add(pool, redis_sock, weight, database, prefix, auth TSRMLS_CC);
 


### PR DESCRIPTION
Here I added support for stream contexts in  the base class..  The reason for this is to allow you to specify the outgoing IP you are binding to.. This is necessary if you want to use a private network that is isolated on it's own IP address. or if you have firewall rules allowing only specific ip addresses from your server to connect to the instance of redis.

This is important to anyone who uses servers on a network like Softlayer.. where you have a 10.0.0.0  ip address that you use to access other servers on a private network completely separate from the public network.

I did not implement support yet in sessions or arrays... IT makes sense  to implement it there too.. but I wanted to make sure you were receptive to the change before making the change as I don't need it, currently.

I did make the changes necessary in redis_array_impl.c and redis_session.c to deal with the parameter change to redis_sock_create
