### PR TITLE
Fix README.markdown to make retry_interval drop to next line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -169,7 +169,7 @@ _**Description**_: Connects to a Redis instance.
 *host*: string. can be a host, or the path to a unix domain socket  
 *port*: int, optional  
 *timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
-*reserved*: should be NULL if retry_interval is specified
+*reserved*: should be NULL if retry_interval is specified  
 *retry_interval*: int, value in milliseconds (optional)
 
 ##### *Return value*
@@ -205,7 +205,7 @@ persistent equivalents.
 *host*: string. can be a host, or the path to a unix domain socket  
 *port*: int, optional  
 *timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
-*persistent_id*: string. identity for the requested persistent connection
+*persistent_id*: string. identity for the requested persistent connection  
 *retry_interval*: int, value in milliseconds (optional)
 
 ##### *Return value*


### PR DESCRIPTION
Currently "retry_interval" parameter documentation is on the same line as "reserved" (missing linebreak)