### PR TITLE
Fix zend_hash_quick_find usage to avoid assertion failures

### DIFF
--- a/redis_array.c
+++ b/redis_array.c
@@ -956,7 +956,7 @@ PHP_METHOD(RedisArray, mget)
 
 		    if(pos[i] != n) continue;
 
-			zend_hash_quick_find(Z_ARRVAL_P(z_ret), NULL, 0, j, (void**)&z_cur);
+			zend_hash_index_find(Z_ARRVAL_P(z_ret), j, (void**)&z_cur);
 			j++;
 
 			MAKE_STD_ZVAL(z_tmp);
@@ -971,7 +971,7 @@ PHP_METHOD(RedisArray, mget)
 
 	/* copy temp array in the right order to return_value */
 	for(i = 0; i < argc; ++i) {
-		zend_hash_quick_find(Z_ARRVAL_P(z_tmp_array), NULL, 0, i, (void**)&z_cur);
+		zend_hash_index_find(Z_ARRVAL_P(z_tmp_array), i, (void**)&z_cur);
 
 		MAKE_STD_ZVAL(z_tmp);
 		*z_tmp = **z_cur;

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -32,7 +32,7 @@ extern zend_class_entry *redis_ce;
 RedisArray*
 ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b_lazy_connect TSRMLS_DC)
 {
-	int i, host_len, id;
+	int i = 0, host_len, id;
 	int count = zend_hash_num_elements(hosts);
 	char *host, *p;
 	short port;
@@ -43,10 +43,10 @@ ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b
 	ZVAL_STRING(&z_cons, "__construct", 0);
 
 	/* init connections */
-	for(i = 0; i < count; ++i) {
-		if(FAILURE == zend_hash_quick_find(hosts, NULL, 0, i, (void**)&zpData) ||
-           Z_TYPE_PP(zpData) != IS_STRING) 
-        {
+	for (zend_hash_internal_pointer_reset(hosts); zend_hash_has_more_elements(hosts) == SUCCESS; zend_hash_move_forward(hosts))
+	{
+		if ((zend_hash_get_current_data(hosts, (void **) &zpData) == FAILURE) || (Z_TYPE_PP(zpData) != IS_STRING))
+		{
 			efree(ra);
 			return NULL;
 		}
@@ -87,6 +87,8 @@ ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b
 		id = zend_list_insert(redis_sock, le_redis_sock);
 #endif
 		add_property_resource(ra->redis[i], "socket", id);
+
+		i++;
 	}
 
 	return ra;

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -510,7 +510,7 @@ ra_find_key(RedisArray *ra, zval *z_args, const char *cmd, int *key_len) {
 	int key_pos = 0; /* TODO: change this depending on the command */
 
 	if(	zend_hash_num_elements(Z_ARRVAL_P(z_args)) == 0
-		|| zend_hash_quick_find(Z_ARRVAL_P(z_args), NULL, 0, key_pos, (void**)&zp_tmp) == FAILURE
+		|| zend_hash_index_find(Z_ARRVAL_P(z_args), key_pos, (void**) &zp_tmp) == FAILURE
 		|| Z_TYPE_PP(zp_tmp) != IS_STRING) {
 
 		return NULL;
@@ -553,7 +553,7 @@ ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis TSRMLS_DC) {
 	/* prepare keys */
 	for(i = 0; i < argc - 1; ++i) {
 		zval **zpp;
-		zend_hash_quick_find(Z_ARRVAL_P(z_keys), NULL, 0, i, (void**)&zpp);
+		zend_hash_index_find(Z_ARRVAL_P(z_keys), i, (void**)&zpp);
 		z_args[i+1] = *zpp;
 	}
 
@@ -653,7 +653,7 @@ ra_index_exec(zval *z_redis, zval *return_value, int keep_all TSRMLS_DC) {
 				if(keep_all) {
 						*return_value = z_ret;
 						zval_copy_ctor(return_value);
-				} else if(zend_hash_quick_find(Z_ARRVAL(z_ret), NULL, 0, 0, (void**)&zp_tmp) != FAILURE) {
+				} else if(zend_hash_index_find(Z_ARRVAL(z_ret), 0, (void**)&zp_tmp) != FAILURE) {
 						*return_value = **zp_tmp;
 						zval_copy_ctor(return_value);
 				}


### PR DESCRIPTION
As of around 2013, `zend_hash_quick_find` has an assertion that will crash PHP if it is called with the `nKeyLength` argument set to 0:

http://lxr.php.net/xref/PHP_5_6/Zend/zend_hash.c?a=true&h=862#867

This causes any use of RedisArray to crash on a debug build (tested on PHP 5.6.5 on OSX). It will not crash on a non-debug build because the assertions are not "live".

```php
$r = new RedisArray(['localhost:6379']);
```

Crashes with:

```
Assertion failed: (nKeyLength != 0), function zend_hash_quick_find, file /Users/michaelmaclean/.phpbrew/build/php-5.6.5/Zend/zend_hash.c, line 867.
[1]    72715 abort      php test.php
```

This fixes that issue.