### PR TITLE
Check if php_stream_write was executed without an error

### DIFF
--- a/library.c
+++ b/library.c
@@ -1815,7 +1815,7 @@ PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz T
 
     size_t bytes_written = php_stream_write(redis_sock->stream, cmd, sz);
     
-    if (bytes_written != sz) {
+    if (bytes_written < sz) {
         return -1;
     }
     


### PR DESCRIPTION
In the file library.c on line 1808 a php_stream_write is executed, but this call misses to check whether the write was successful. The documentation of this function recommends to check the number of bytes written. If there was a connection issue or a packet loss, the number of bytes written will be less than count. After fixing this line the driver will return an exception correctly if the connection gets lost.

Best,
Markus
