### PR TITLE
Redis::close() should not throw a "Connection closed" exception

### DIFF
--- a/library.c
+++ b/library.c
@@ -1799,8 +1799,10 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC)
 {
 	if(redis_sock && redis_sock->status == REDIS_SOCK_STATUS_DISCONNECTED) {
+            if (strcmp(cmd, "QUIT") != 0) {
 		zend_throw_exception(redis_exception_ce, "Connection closed", 0 TSRMLS_CC);
-		return -1;
+            }		
+            return -1;
 	}
     if(-1 == redis_check_eof(redis_sock TSRMLS_CC)) {
         return -1;

--- a/library.c
+++ b/library.c
@@ -1799,7 +1799,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC)
 {
 	if(redis_sock && redis_sock->status == REDIS_SOCK_STATUS_DISCONNECTED) {
-            if (strcmp(cmd, "QUIT") != 0) {
+            if (strcmp(cmd, "QUIT" _NL) != 0) {
 		zend_throw_exception(redis_exception_ce, "Connection closed", 0 TSRMLS_CC);
             }		
             return -1;


### PR DESCRIPTION
Redis::close() throws a RedisException "Connection closed" if the command is called on a previously broken connection. A broken connection can have multiple causes like packet loss or a tcp error. I think in such a situation, the driver should clean up all internal connection artifacts on a $redis->close() call but there should be no exception thrown if the connection was already broken.   

    try {
        $redis = new Redis();
        $redis->connect(...);
        $redis->get('something'); // something went wrong and a RedisException is thrown
    } catch (RedisException $e) {
        $redis->close(); //throws a RedisException "Connection closed" again
    }