### PR TITLE
Use the newer RESP protocol for the QUIT command

### DIFF
--- a/library.c
+++ b/library.c
@@ -1490,7 +1490,7 @@ PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC)
     redis_sock->dbNumber = 0;
     if (redis_sock->stream != NULL) {
 			if (!redis_sock->persistent) {
-				redis_sock_write(redis_sock, "QUIT" _NL, sizeof("QUIT" _NL) - 1 TSRMLS_CC);
+				redis_sock_write(redis_sock, "*1" _NL "$4" _NL "QUIT" _NL, sizeof("*1" _NL "$4" _NL "QUIT" _NL) - 1 TSRMLS_CC);
 			}
 
 			redis_sock->status = REDIS_SOCK_STATUS_DISCONNECTED;


### PR DESCRIPTION
Improves compatibility with servers which do not support the 'old' redis protocol. For example the SSDB key-value server only supports RESP (https://github.com/ideawu/ssdb/issues/608)

"The RESP protocol was introduced in Redis 1.2, but it became the standard way for talking with the Redis server in Redis 2.0. This is the protocol you should implement in your Redis client."(http://redis.io/topics/protocol).
