### PR TITLE
Fix segmentation fault on PHP 7.0.0RC5

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -430,7 +430,7 @@ PHP_REDIS_API int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC,
     zval *socket;
 
     if (Z_TYPE_P(id) != IS_OBJECT || (socket = zend_hash_str_find(Z_OBJPROP_P(id), "socket",
-                    sizeof("socket") - 1)) == NULL) {
+                    sizeof("socket") - 1)) == NULL || Z_RES_P(socket) == NULL) {
         // Throw an exception unless we've been requested not to
         if(!no_throw) {
             zend_throw_exception(redis_exception_ce, "Redis server went away",


### PR DESCRIPTION
```
(gdb) run ...

...

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff1366eec in redis_sock_get (id=<optimized out>, redis_sock=redis_sock@entry=0x7fffffffaea0,
    no_throw=no_throw@entry=1) at /usr/local/src/phpredis/redis.c:442
warning: Source file is more recent than executable.
442	    *redis_sock = (RedisSock *)Z_RES_P(socket)->ptr;

...

(gdb) bt
#0  0x00007ffff1366eec in redis_sock_get (id=<optimized out>, redis_sock=redis_sock@entry=0x7fffffffaea0,
    no_throw=no_throw@entry=1) at /usr/local/src/phpredis/redis.c:442
#1  0x00007ffff1367b60 in zim_Redis___destruct (execute_data=0x7ffff1a14d90, return_value=0x7fffffffaff0)
    at /usr/local/src/phpredis/redis.c:663
#2  0x00000000007876d0 in zend_call_function (fci=fci@entry=0x7fffffffb050, fci_cache=fci_cache@entry=0x7fffffffb020)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_execute_API.c:873
#3  0x00000000007b4244 in zend_call_method (object=object@entry=0x7fffffffb110, obj_ce=<optimized out>,
    fn_proxy=fn_proxy@entry=0x7fffffffb108, function_name=function_name@entry=0xd208de "__destruct",
    function_name_len=function_name_len@entry=10, retval_ptr=retval_ptr@entry=0x0, param_count=param_count@entry=0,
    arg1=arg1@entry=0x0, arg2=arg2@entry=0x0) at /usr/local/src/php-7.0.0RC5/Zend/zend_interfaces.c:104
#4  0x00000000007cd0e7 in zend_objects_destroy_object (object=<optimized out>)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_objects.c:148
#5  0x00000000007d203b in zend_objects_store_del (object=0x7fffe1aa3d48)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_objects_API.c:164
#6  0x00000000007ccdac in i_zval_ptr_dtor (zval_ptr=0x7fffe6f3aae8)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_variables.h:58
#7  zend_object_std_dtor (object=0x7fffe6f3aaa0) at /usr/local/src/php-7.0.0RC5/Zend/zend_objects.c:69
#8  0x00000000007d2081 in zend_objects_store_del (object=0x7fffe6f3aaa0)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_objects_API.c:182
#9  0x0000000000807740 in zend_assign_to_variable (value_type=4 '\004', value=<optimized out>,
    variable_ptr=0x7ffff1a58360) at /usr/local/src/php-7.0.0RC5/Zend/zend_execute.h:103
#10 ZEND_ASSIGN_DIM_SPEC_VAR_CV_HANDLER () at /usr/local/src/php-7.0.0RC5/Zend/zend_vm_execute.h:20608
#11 0x00000000007d5d7b in execute_ex (ex=<optimized out>) at /usr/local/src/php-7.0.0RC5/Zend/zend_vm_execute.h:414
#12 0x00000000008269b9 in zend_execute (op_array=<optimized out>, return_value=<optimized out>)
    at /usr/local/src/php-7.0.0RC5/Zend/zend_vm_execute.h:458
#13 0x0000000000796b07 in zend_execute_scripts (type=type@entry=8, retval=retval@entry=0x0,
    file_count=file_count@entry=3) at /usr/local/src/php-7.0.0RC5/Zend/zend.c:1428
#14 0x000000000072bc10 in php_execute_script (primary_file=primary_file@entry=0x7fffffffd830)
    at /usr/local/src/php-7.0.0RC5/main/main.c:2471
#15 0x00000000008287da in do_cli (argc=5, argv=0x10e1400) at /usr/local/src/php-7.0.0RC5/sapi/cli/php_cli.c:974
#16 0x000000000043daa7 in main (argc=5, argv=0x10e1400) at /usr/local/src/php-7.0.0RC5/sapi/cli/php_cli.c:1345

(gdb) print *socket
$1 = {value = {lval = 0, dval = 0, counted = 0x0, str = 0x0, arr = 0x0, obj = 0x0, res = 0x0, ref = 0x0, ast = 0x0,
    zv = 0x0, ptr = 0x0, ce = 0x0, func = 0x0, ww = {w1 = 0, w2 = 0}}, u1 = {v = {type = 4 '\004',
      type_flags = 0 '\000', const_flags = 0 '\000', reserved = 0 '\000'}, type_info = 4}, u2 = {
    var_flags = 4294967295, next = 4294967295, cache_slot = 4294967295, lineno = 4294967295, num_args = 4294967295,
    fe_pos = 4294967295, fe_iter_idx = 4294967295}}
```
