### PR TITLE
Fix PHP_REDIS_VERSION to 2.5.7.

### DIFF
--- a/php_redis.h
+++ b/php_redis.h
@@ -25,7 +25,7 @@
 #define PHP_REDIS_H
 
 /* phpredis version */
-#define PHP_REDIS_VERSION "2.2.5"
+#define PHP_REDIS_VERSION "2.2.7"
 
 PHP_METHOD(Redis, __construct);
 PHP_METHOD(Redis, __destruct);


### PR DESCRIPTION
ping @michael-grunder I guess that for php7 release the major version number would be bumped no? Something like 3.0.0 ?

For example, [APCu ](http://pecl.php.net/package/APCu) has a release `4.*` for php <= 5.6 and `5.*` for php >= `7.*`.

Also, are you ok to add a composer.json file for pickle? Something like this one:
```json
{
    "name": "redis",
    "version": "2.2.7",
    "type": "extension",
    "license": [
        "PHP"
    ],
    "authors": [
        {
            "name": "Nicolas Favre-Felix",
            "email": "n.favrefelix@gmail.com"
        },
        {
            "name": "Michael Grunder",
            "email": "michael.grunder@gmail.com"
        }
    ],
    "description": "PHP extension for interfacing with Redis"
}
```