### PR TITLE
Fix segmentation fault in RedisArray:__construct / ra_make_array

### DIFF
--- a/redis_array.c
+++ b/redis_array.c
@@ -204,7 +204,7 @@ uint32_t rcrc32(const char *s, size_t sz) {
     Public constructor */
 PHP_METHOD(RedisArray, __construct)
 {
-	zval *z0, z_fun, z_dist, *zpData, *z_opts = NULL;
+	zval *z0, z_fun = {0}, z_dist = {0}, *zpData, *z_opts = NULL;
 	zval *id;
 	RedisArray *ra = NULL;
 	zend_bool b_index = 0, b_autorehash = 0, b_pconnect = 0;

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -155,7 +155,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
 
 	zval z_params_hosts, *z_hosts;
 	zval z_params_prev, *z_prev;
-	zval z_params_funs, *z_data_p, z_fun, z_dist;
+	zval z_params_funs, *z_data_p, z_fun = {0}, z_dist = {0};
 	zval z_params_index;
 	zval z_params_autorehash;
 	zval z_params_retry_interval;


### PR DESCRIPTION
z_dist and z_fun can be uninitialized, and z_dist is dereferenced in ra_make_array

Before:
```
==16221== Memcheck, a memory error detector
==16221== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==16221== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==16221== Command: ~/.phpenv/versions/7.0.1/bin/php tests/TestRedis.php --class RedisArray
==16221== 
==16221== Conditional jump or move depends on uninitialised value(s)
==16221==    at 0xD00E1C9: ra_make_array (redis_array_impl.c:317)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== Conditional jump or move depends on uninitialised value(s)
==16221==    at 0xD00E24F: ra_make_array (redis_array_impl.c:320)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== Conditional jump or move depends on uninitialised value(s)
==16221==    at 0xD00E25B: ra_make_array (redis_array_impl.c:320)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== Use of uninitialised value of size 8
==16221==    at 0xD00E27B: ra_make_array (redis_array_impl.c:320)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== Use of uninitialised value of size 8
==16221==    at 0xD00E284: ra_make_array (redis_array_impl.c:320)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== 
==16221== Process terminating with default action of signal 11 (SIGSEGV)
==16221==  Bad permissions for mapped region at address 0x115FD88
==16221==    at 0xD00E284: ra_make_array (redis_array_impl.c:320)
==16221==    by 0xD0083E2: zim_RedisArray___construct (redis_array.c:299)
==16221==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16221==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16221==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16221==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16221==    by 0xA22FFD: php_execute_script (main.c:2471)
==16221==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16221==    by 0xBB344B: main (php_cli.c:1345)
==16221== 
==16221== HEAP SUMMARY:
==16221==     in use at exit: 2,557,184 bytes in 26,702 blocks
==16221==   total heap usage: 28,695 allocs, 1,993 frees, 3,205,975 bytes allocated
==16221== 
==16221== LEAK SUMMARY:
==16221==    definitely lost: 0 bytes in 0 blocks
==16221==    indirectly lost: 0 bytes in 0 blocks
==16221==      possibly lost: 1,925,036 bytes in 22,258 blocks
==16221==    still reachable: 632,148 bytes in 4,444 blocks
==16221==         suppressed: 0 bytes in 0 blocks
==16221== Rerun with --leak-check=full to see details of leaked memory
==16221== 
==16221== For counts of detected and suppressed errors, rerun with: -v
==16221== Use --track-origins=yes to see where uninitialised values come from
==16221== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```

After:
```
==16986== Memcheck, a memory error detector
==16986== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==16986== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==16986== Command: ~/.phpenv/versions/7.0.1/bin/php tests/TestRedis.php --class RedisArray
==16986== 
==16986== Invalid read of size 8
==16986==    at 0xD00AE6E: zim_RedisArray_mset (redis_array.c:959)
==16986==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16986==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16986==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16986==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16986==    by 0xA22FFD: php_execute_script (main.c:2471)
==16986==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16986==    by 0xBB344B: main (php_cli.c:1345)
==16986==  Address 0x700000002 is not stack'd, malloc'd or (recently) free'd
==16986== 
==16986== 
==16986== Process terminating with default action of signal 11 (SIGSEGV)
==16986==  Access not within mapped region at address 0x700000002
==16986==    at 0xD00AE6E: zim_RedisArray_mset (redis_array.c:959)
==16986==    by 0xB493F1: ZEND_DO_FCALL_SPEC_HANDLER (zend_vm_execute.h:842)
==16986==    by 0xB47D7C: execute_ex (zend_vm_execute.h:414)
==16986==    by 0xB47F7E: zend_execute (zend_vm_execute.h:458)
==16986==    by 0xAE3A4F: zend_execute_scripts (zend.c:1428)
==16986==    by 0xA22FFD: php_execute_script (main.c:2471)
==16986==    by 0xBB1FB6: do_cli (php_cli.c:974)
==16986==    by 0xBB344B: main (php_cli.c:1345)
==16986==  If you believe this happened as a result of a stack
==16986==  overflow in your program's main thread (unlikely but
==16986==  possible), you can try to increase the size of the
==16986==  main thread stack using the --main-stacksize= flag.
==16986==  The main thread stack size used in this run was 8388608.
==16986== 
==16986== HEAP SUMMARY:
==16986==     in use at exit: 2,557,232 bytes in 26,703 blocks
==16986==   total heap usage: 28,696 allocs, 1,993 frees, 3,206,023 bytes allocated
==16986== 
==16986== LEAK SUMMARY:
==16986==    definitely lost: 0 bytes in 0 blocks
==16986==    indirectly lost: 0 bytes in 0 blocks
==16986==      possibly lost: 1,924,908 bytes in 22,256 blocks
==16986==    still reachable: 632,324 bytes in 4,447 blocks
==16986==         suppressed: 0 bytes in 0 blocks
==16986== Rerun with --leak-check=full to see details of leaked memory
==16986== 
==16986== For counts of detected and suppressed errors, rerun with: -v
==16986== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

```

Still segfaulting, unfortunately, but I believe that's a separate issue (#707)