### PR TITLE
missing EXTENSION directive

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -5,7 +5,9 @@
 #include "cluster_library.h"
 #include "crc16.h"
 #include <zend_exceptions.h>
-
+#ifdef PHP_WIN32
+# include <win32/time.h>
+#endif
 extern zend_class_entry *redis_cluster_exception_ce;
 
 /* Some debug methods that will go away when we're through with them */

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -12,6 +12,7 @@ extern zend_class_entry *redis_cluster_exception_ce;
 
 static void cluster_dump_nodes(redisCluster *c) {
     redisClusterNode **pp, *p;
+    const char *slave;
 
     for(zend_hash_internal_pointer_reset(c->nodes);
         zend_hash_has_more_elements(c->nodes)==SUCCESS;
@@ -20,7 +21,7 @@ static void cluster_dump_nodes(redisCluster *c) {
         zend_hash_get_current_data(c->nodes, (void**)&pp);
         p = *pp;
 
-        const char *slave = (p->slave) ? "slave" : "master";
+        slave = (p->slave) ? "slave" : "master";
         php_printf("%d %s %d %d", p->sock->port, slave,p->sock->prefix_len,
             p->slot);
 
@@ -201,12 +202,13 @@ cluster_read_sock_resp(RedisSock *redis_sock, REDIS_REPLY_TYPE type,
                        size_t len TSRMLS_DC)
 {
     clusterReply *r;
+    /* Error flag in case we go recursive */
+    int err = 0;
 
     r = ecalloc(1, sizeof(clusterReply));
     r->type = type;
 
-    // Error flag in case we go recursive
-    int err = 0;
+
 
     switch(r->type) {
         case TYPE_INT:
@@ -1742,6 +1744,7 @@ PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
     subscribeContext *sctx = (subscribeContext*)ctx;
     zval *z_tab, **z_chan, **z_flag;
     int pull = 0, argc = sctx->argc;
+	char *flag;
 
     efree(sctx);
     array_init(return_value);
@@ -1774,7 +1777,7 @@ PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
         }
 
         // Redis will give us either :1 or :0 here
-        char *flag = Z_STRVAL_PP(z_flag);
+        flag = Z_STRVAL_PP(z_flag);
 
         // Add result
         add_assoc_bool(return_value, Z_STRVAL_PP(z_chan), flag[1]=='1');
@@ -2070,10 +2073,12 @@ PHP_REDIS_API zval *cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
                                      redisCluster *c, void *ctx)
 {
+	clusterFoldItem *fi;
+
     MAKE_STD_ZVAL(c->multi_resp);
     array_init(c->multi_resp);
 
-    clusterFoldItem *fi = c->multi_head;
+    fi = c->multi_head;
     while(fi) {
         /* Make sure our transaction didn't fail here */
         if (c->multi_len[fi->slot] > -1) {
@@ -2108,11 +2113,12 @@ PHP_REDIS_API void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
                                     redisCluster *c, void *ctx)
 {
     clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
+	short fail;
 
     /* Protect against an invalid response type, -1 response length, and failure
      * to consume the responses. */
     c->cmd_sock->serializer = c->flags->serializer;
-    short fail = c->reply_type != TYPE_MULTIBULK || c->reply_len == -1 ||
+    fail = c->reply_type != TYPE_MULTIBULK || c->reply_len == -1 ||
         mbulk_resp_loop(c->cmd_sock, mctx->z_multi, c->reply_len, NULL TSRMLS_CC)==FAILURE;
 
     // If we had a failure, pad results with FALSE to indicate failure.  Non

--- a/config.w32
+++ b/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("redis-session", "whether to enable sessions", "yes");
 ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "no");
 
 if (PHP_REDIS != "no") {
-	var sources = "redis.c library.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c";
+	var sources = "redis.c library.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c redis_commands.c";
 	if (PHP_REDIS_SESSION != "no") {
 		sources += " redis_session.c"
 		ADD_EXTENSION_DEP("redis", "session");

--- a/config.w32
+++ b/config.w32
@@ -7,12 +7,12 @@ ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "n
 if (PHP_REDIS != "no") {
 	var sources = "redis.c library.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c";
 	if (PHP_REDIS_SESSION != "no") {
-		ADD_SOURCES(configure_module_dirname, "redis_session.c", "redis");
+		sources += " redis_session.c"
 		ADD_EXTENSION_DEP("redis", "session");
 		ADD_FLAG("CFLAGS_REDIS", ' /D PHP_SESSION=1 ');
 		AC_DEFINE("HAVE_REDIS_SESSION", 1);
 	}
-
+	EXTENSION("redis", sources);
 	if (PHP_REDIS_IGBINARY != "no") {
 		if (CHECK_HEADER_ADD_INCLUDE("igbinary.h", "CFLAGS_REDIS", configure_module_dirname + "\\..\\igbinary")) {
 

--- a/library.c
+++ b/library.c
@@ -30,10 +30,12 @@
 #define SCORE_DECODE_DOUBLE 2
 
 #ifdef PHP_WIN32
-    # if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION <= 4
+# if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION <= 4
         /* This proto is available from 5.5 on only */
         PHP_REDIS_API int usleep(unsigned int useconds);
-    # endif
+# else	
+#  include <win32/time.h>
+# endif
 #endif
 
 extern zend_class_entry *redis_ce;

--- a/redis.c
+++ b/redis.c
@@ -668,12 +668,14 @@ PHP_METHOD(Redis, __construct)
     Public Destructor
  */
 PHP_METHOD(Redis,__destruct) {
+    // Grab our socket
+    RedisSock *redis_sock;
+
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
         RETURN_FALSE;
     }
 
-    // Grab our socket
-    RedisSock *redis_sock;
+
     if (redis_sock_get(getThis(), &redis_sock TSRMLS_CC, 1) < 0) {
         RETURN_FALSE;
     }

--- a/redis.c
+++ b/redis.c
@@ -40,6 +40,9 @@
 #include <ext/standard/php_smart_str.h>
 #include <ext/standard/php_var.h>
 #include <ext/standard/php_math.h>
+#ifdef PHP_WIN32
+# include <win32/time.h>
+#endif
 
 #include "library.h"
 

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -565,8 +565,9 @@ ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC) {
 
 	/* Initialize key array */
 	zval *z_keys, **z_entry_pp;
+	HashPosition pos;
+
 	MAKE_STD_ZVAL(z_keys);
-    HashPosition pos;
 #if PHP_VERSION_ID > 50300
 	array_init_size(z_keys, zend_hash_num_elements(Z_ARRVAL_P(z_pairs)));
 #else

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1600,10 +1600,11 @@ static void generic_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw,
                                zrange_cb fun)
 {
     redisCluster *c = GET_CONTEXT();
-    c->readonly = CLUSTER_IS_ATOMIC(c);
     cluster_cb cb;
     char *cmd; int cmd_len; short slot;
     int withscores=0;
+
+    c->readonly = CLUSTER_IS_ATOMIC(c);
 
     if(fun(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, kw, &cmd, &cmd_len,
            &withscores, &slot, NULL)==FAILURE)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -234,7 +234,7 @@ static void ht_free_node(void *data) {
 }
 
 /* Initialize/Register our RedisCluster exceptions */
-PHPAPI zend_class_entry *rediscluster_get_exception_base(int root TSRMLS_DC) {
+PHP_REDIS_API zend_class_entry *rediscluster_get_exception_base(int root TSRMLS_DC) {
 #if HAVE_SPL
     if(!root) {
         if(!spl_rte_ce) {

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -37,32 +37,36 @@
 
 /* Simple macro to free our enqueued callbacks after we EXEC */
 #define CLUSTER_FREE_QUEUE(c) \
-    clusterFoldItem *_item = c->multi_head, *_tmp; \
-    while(_item) { \
-        _tmp = _item->next; \
-        efree(_item); \
-        _item = _tmp; \
-    } \
-    c->multi_head = c->multi_curr = NULL; \
+	{ \
+		clusterFoldItem *_item = c->multi_head, *_tmp; \
+		while(_item) { \
+			_tmp = _item->next; \
+			efree(_item); \
+			_item = _tmp; \
+		} \
+		c->multi_head = c->multi_curr = NULL; \
+	}
 
 /* Reset anything flagged as MULTI */
 #define CLUSTER_RESET_MULTI(c) \
-    redisClusterNode **_node; \
-    for(zend_hash_internal_pointer_reset(c->nodes); \
-        zend_hash_get_current_data(c->nodes, (void**)&_node); \
-        zend_hash_move_forward(c->nodes)) \
-    { \
-        (*_node)->sock->watching = 0; \
-        (*_node)->sock->mode     = ATOMIC; \
-    } \
-    c->flags->watching = 0; \
-    c->flags->mode     = ATOMIC; \
+	{ \
+		redisClusterNode **_node; \
+		for(zend_hash_internal_pointer_reset(c->nodes); \
+			zend_hash_get_current_data(c->nodes, (void**)&_node); \
+			zend_hash_move_forward(c->nodes)) \
+		{ \
+			(*_node)->sock->watching = 0; \
+			(*_node)->sock->mode     = ATOMIC; \
+		} \
+		c->flags->watching = 0; \
+		c->flags->mode     = ATOMIC; \
+	}
 
 /* Simple 1-1 command -> response macro */
 #define CLUSTER_PROCESS_CMD(cmdname, resp_func, readcmd) \
     redisCluster *c = GET_CONTEXT(); \
-    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
     char *cmd; int cmd_len; short slot; void *ctx=NULL; \
+    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
     if(redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,c->flags, &cmd, \
                              &cmd_len, &slot, &ctx)==FAILURE) { \
         RETURN_FALSE; \
@@ -81,8 +85,8 @@
 /* More generic processing, where only the keyword differs */
 #define CLUSTER_PROCESS_KW_CMD(kw, cmdfunc, resp_func, readcmd) \
     redisCluster *c = GET_CONTEXT(); \
-    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
     char *cmd; int cmd_len; short slot; void *ctx=NULL; \
+    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
     if(cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, kw, &cmd, &cmd_len,\
                &slot,&ctx)==FAILURE) { \
         RETURN_FALSE; \

--- a/redis_session.c
+++ b/redis_session.c
@@ -157,10 +157,12 @@ PHP_REDIS_API redis_pool_member *
 redis_pool_get_sock(redis_pool *pool, const char *key TSRMLS_DC) {
 
     unsigned int pos, i;
+	redis_pool_member *rpm;
+
     memcpy(&pos, key, sizeof(pos));
     pos %= pool->totalWeight;
 
-    redis_pool_member *rpm = pool->head;
+	rpm = pool->head;
 
     for(i = 0; i < pool->totalWeight;) {
         if(pos >= i && pos < i + rpm->weight) {
@@ -192,7 +194,7 @@ PS_OPEN_FUNC(redis)
     php_url *url;
     zval *params, **param;
     int i, j, path_len;
-
+    RedisSock *redis_sock;
     redis_pool *pool = redis_pool_new(TSRMLS_C);
 
     for (i=0,j=0,path_len=strlen(save_path); i<path_len; i=j+1) {
@@ -280,7 +282,6 @@ PS_OPEN_FUNC(redis)
                 return FAILURE;
             }
 
-            RedisSock *redis_sock;
             if(url->host) {
                 redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, persistent, persistent_id, retry_interval, 0);
             } else { /* unix */


### PR DESCRIPTION
First fix to restore Windows support.

By the way, what do you think about merging php 5&7 in one branch and two separate folders:
- php5
- php7
- config.m4
- config.w32
- readme...
  etc...

Doing so will allow cleaner versioning and support for semver. That will also make it very easy for build automation and release under pickle/composer (or existing pecl).

I can prepare a PR to do it if you like to, that would be awesome.
