### PR TITLE
fix port to php7, especially 64bit support

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -251,7 +251,7 @@ cluster_read_sock_resp(RedisSock *redis_sock, REDIS_REPLY_TYPE type,
  */
 
 /* Send a command to the specific socket and validate reply type */
-static int cluster_send_direct(RedisSock *redis_sock, char *cmd, int cmd_len,
+static int cluster_send_direct(RedisSock *redis_sock, char *cmd, size_t cmd_len,
                                REDIS_REPLY_TYPE type TSRMLS_DC)
 {
     char buf[1024];

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1022,7 +1022,8 @@ PHP_REDIS_API void cluster_disconnect(redisCluster *c TSRMLS_DC) {
 
 /* Fisher-Yates shuffle for integer array */
 static void fyshuffle(int *array, size_t len) {
-    int temp, n = len;
+    int temp;
+	size_t n = len;
     size_t r;
 
     /* Randomize */
@@ -2199,7 +2200,7 @@ int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
                         long long count, void *ctx TSRMLS_DC)
 {
     char *line;
-    int line_len;
+    size_t line_len;
 
     // Iterate over the number we have
     while(count--) {
@@ -2220,7 +2221,7 @@ int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
                     long long count, void *ctx TSRMLS_DC)
 {
     char *line;
-    int line_len;
+    size_t line_len;
 
     /* Iterate over the lines we have to process */
     while(count--) {
@@ -2249,7 +2250,7 @@ int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
                            long long count, void *ctx TSRMLS_DC)
 {
     char *line, *key;
-    int line_len, key_len;
+    size_t line_len, key_len;
     long long idx=0;
 
     // Our count wil need to be divisible by 2
@@ -2288,8 +2289,9 @@ int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
                            long long count, void *ctx TSRMLS_DC)
 {
     char *line, *key;
-    int line_len, key_len;
+    size_t key_len;
     long long idx=0;
+	size_t line_len;
 
     // Our context will need to be divisible by 2
     if(count %2 != 0) {
@@ -2328,7 +2330,8 @@ int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
                           long long count, void *ctx TSRMLS_DC)
 {
     char *line;
-    int line_len,i=0;
+    int i=0;
+	size_t line_len;
     zval *z_keys = ctx;
 
     // Loop while we've got replies

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -466,7 +466,7 @@ void cluster_multi_free(clusterMultiCmd *mc) {
 }
 
 /* Add an argument to a clusterMultiCmd */
-void cluster_multi_add(clusterMultiCmd *mc, char *data, int data_len) {
+void cluster_multi_add(clusterMultiCmd *mc, char *data, size_t data_len) {
     mc->argc++;
     redis_cmd_append_sstr(&(mc->args), data, data_len);
 }
@@ -512,7 +512,7 @@ static void ht_free_slave(zval *data) {
 }
 
 /* Get the hash slot for a given key */
-unsigned short cluster_hash_key(const char *key, int len) {
+unsigned short cluster_hash_key(const char *key, size_t len) {
     int s, e;
 
     // Find first occurrence of {, if any
@@ -1287,7 +1287,7 @@ PHP_REDIS_API short cluster_find_slot(redisCluster *c, const char *host,
 
 /* Send a command to a specific slot */
 PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
-                             int cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC)
+                             size_t cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC)
 {
     /* Point our cluster to this slot and it's socket */
     c->cmd_slot = slot;
@@ -1320,7 +1320,7 @@ PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
 /* Send a command to given slot in our cluster.  If we get a MOVED or ASK error
  * we attempt to send the command to the node as directed. */
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
-                                  int cmd_len TSRMLS_DC)
+                                  size_t cmd_len TSRMLS_DC)
 {
     int resp, timedout=0;
     long msstart;
@@ -1849,7 +1849,7 @@ PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 
 /* HSCAN, SSCAN, ZSCAN */
 PHP_REDIS_API int cluster_scan_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
-                              REDIS_SCAN_TYPE type, long *it)
+                              REDIS_SCAN_TYPE type, zend_long *it)
 {
     char *pit;
 

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -275,7 +275,7 @@ typedef struct clusterKeyVal {
  * commands across more than 1 node (e.g. WATCH, MGET, MSET, etc) */
 typedef struct clusterDistList {
     clusterKeyVal *entry;
-    size_t len, size;
+    size_t	 len, size;
 } clusterDistList;
 
 /* Context for things like MGET/MSET/MSETNX.  When executing in MULTI mode,
@@ -334,20 +334,20 @@ void cluster_dist_add_val(redisCluster *c, clusterKeyVal *kv, zval *val
     TSRMLS_DC);
 
 /* Aggregation for multi commands like MGET, MSET, and MSETNX */
-void cluster_multi_init(clusterMultiCmd *mc, char *kw, int kw_len);
+void cluster_multi_init(clusterMultiCmd *mc, char *kw, size_t kw_len);
 void cluster_multi_free(clusterMultiCmd *mc);
-void cluster_multi_add(clusterMultiCmd *mc, char *data, int data_len);
+void cluster_multi_add(clusterMultiCmd *mc, char *data, size_t data_len);
 void cluster_multi_fini(clusterMultiCmd *mc);
 
 /* Hash a key to it's slot, using the Redis Cluster hash algorithm */
 unsigned short cluster_hash_key_zval(zval *key);
-unsigned short cluster_hash_key(const char *key, int len);
+unsigned short cluster_hash_key(const char *key, size_t len);
 
 /* Get the current time in miliseconds */
 long long mstime(void);
 
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
-    int cmd_len TSRMLS_DC);
+    size_t cmd_len TSRMLS_DC);
 
 PHP_REDIS_API void cluster_disconnect(redisCluster *c TSRMLS_DC);
 
@@ -359,7 +359,7 @@ PHP_REDIS_API int cluster_reset_multi(redisCluster *c);
 PHP_REDIS_API short cluster_find_slot(redisCluster *c, const char *host,
     unsigned short port);
 PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
-    int cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC);
+    size_t cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC);
 
 PHP_REDIS_API redisCluster *cluster_create(double timeout, double read_timeout,
     int failover, int persistent);
@@ -436,7 +436,7 @@ PHP_REDIS_API void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS,
 
 /* Response handler for ZSCAN, SSCAN, and HSCAN */
 PHP_REDIS_API int cluster_scan_resp(INTERNAL_FUNCTION_PARAMETERS,
-    redisCluster *c, REDIS_SCAN_TYPE type, long *it);
+    redisCluster *c, REDIS_SCAN_TYPE type, zend_long *it);
 
 /* INFO response handler */
 PHP_REDIS_API void cluster_info_resp(INTERNAL_FUNCTION_PARAMETERS,

--- a/common.h
+++ b/common.h
@@ -257,7 +257,7 @@ typedef struct fold_item {
 
 typedef struct request_item {
     char *request_str;
-    int request_size; /* size_t */
+    size_t request_size;
     struct request_item *next;
 } request_item;
 

--- a/common.h
+++ b/common.h
@@ -201,7 +201,7 @@ typedef enum _PUBSUB_TYPE {
 /* Process a command assuming our command where our command building
  * function is redis_<cmdname>_cmd */
 #define REDIS_PROCESS_CMD(cmdname, resp_func) \
-    RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
+    RedisSock *redis_sock; char *cmd; size_t cmd_len; void *ctx=NULL; \
     if(redis_sock_get(getThis(), &redis_sock TSRMLS_CC, 0)<0 || \
        redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,redis_sock, \
                              &cmd, &cmd_len, NULL, &ctx)==FAILURE) { \
@@ -216,7 +216,7 @@ typedef enum _PUBSUB_TYPE {
 /* Process a command but with a specific command building function
  * and keyword which is passed to us*/
 #define REDIS_PROCESS_KW_CMD(kw, cmdfunc, resp_func) \
-    RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
+    RedisSock *redis_sock; char *cmd; size_t cmd_len; void *ctx=NULL; \
     if(redis_sock_get(getThis(), &redis_sock TSRMLS_CC, 0)<0 || \
        cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, kw, &cmd, \
                &cmd_len, NULL, &ctx)==FAILURE) { \
@@ -280,7 +280,7 @@ typedef struct {
     long           dbNumber;
 
     char           *prefix;
-    int            prefix_len;
+    size_t            prefix_len;
 
     redis_mode     mode;
     fold_item      *head;

--- a/config.w32
+++ b/config.w32
@@ -22,6 +22,5 @@ if (PHP_REDIS != "no") {
 		}
 	}
 	EXTENSION("redis", sources);
-
 }
 

--- a/library.c
+++ b/library.c
@@ -435,7 +435,7 @@ redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS,
  */
 PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, size_t bytes TSRMLS_DC)
 {
-    int offset = 0;
+    size_t offset = 0;
     size_t got;
 
     char * reply;
@@ -572,7 +572,7 @@ redis_cmd_format_header(char **ret, char *keyword, int arg_count) {
 	smart_string buf = {0};
 
 	/* Keyword length */
-	int l = strlen(keyword);
+	size_t l = strlen(keyword);
 
     smart_string_appendc(&buf, '*');
     smart_string_append_long(&buf, arg_count + 1);

--- a/library.c
+++ b/library.c
@@ -1573,15 +1573,19 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
         redis_sock_disconnect(redis_sock TSRMLS_CC);
     }
 
-    tv.tv_sec  = (time_t)redis_sock->timeout;
+    tv.tv_sec  = (long)redis_sock->timeout;
     tv.tv_usec = (int)((redis_sock->timeout - tv.tv_sec) * 1000000);
     if(tv.tv_sec != 0 || tv.tv_usec != 0) {
         tv_ptr = &tv;
     }
 
+#ifdef PHP_WIN32
+    read_tv.tv_sec  = (long)redis_sock->read_timeout;
+    read_tv.tv_usec = (long)((redis_sock->read_timeout-read_tv.tv_sec)*1000000);
+#else
     read_tv.tv_sec  = (time_t)redis_sock->read_timeout;
     read_tv.tv_usec = (int)((redis_sock->read_timeout-read_tv.tv_sec)*1000000);
-
+#endif
     if(redis_sock->host[0] == '/' && redis_sock->port < 1) {
         host_len = spprintf(&host, 0, "unix://%s", redis_sock->host);
     } else {

--- a/library.c
+++ b/library.c
@@ -198,7 +198,7 @@ PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC)
 
 PHP_REDIS_API int
 redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                           REDIS_SCAN_TYPE type, long *iter)
+                           REDIS_SCAN_TYPE type, zend_long *iter)
 {
     REDIS_REPLY_TYPE reply_type;
     long reply_info;
@@ -550,7 +550,7 @@ void add_constant_long(zend_class_entry *ce, char *name, int value) {
 	zend_declare_class_constant_long(ce, name, strlen(name), value);
 }
 
-int
+size_t
 integer_length(int i) {
     int sz = 0;
     int ci = abs(i);
@@ -566,7 +566,7 @@ integer_length(int i) {
     return sz;
 }
 
-int
+size_t
 redis_cmd_format_header(char **ret, char *keyword, int arg_count) {
 	/* Our return buffer */
 	smart_string buf = {0};
@@ -590,7 +590,7 @@ redis_cmd_format_header(char **ret, char *keyword, int arg_count) {
 	return buf.len;
 }
 
-int
+size_t
 redis_cmd_format_static(char **ret, char *keyword, char *format, ...)
 {
     char *p = format;
@@ -671,7 +671,7 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...)
  *      Their data and their size (strlen).
  *      Supported formats are: %d, %i, %s, %l
  */
-int
+size_t
 redis_cmd_format(char **ret, char *format, ...) {
 
     smart_string buf = {0};
@@ -728,7 +728,7 @@ redis_cmd_format(char **ret, char *format, ...) {
 /*
  * Append a command sequence to a Redis command
  */
-int redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len) {
+size_t redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len) {
 	/* Smart string buffer */
 	smart_string buf = {0};
 
@@ -756,7 +756,7 @@ int redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append
  * Given a smart string, number of arguments, a keyword, and the length of the keyword
  * initialize our smart string with the proper Redis header for the command to follow
  */
-int redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len) {
+size_t redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len) {
     smart_string_appendc(str, '*');
     smart_string_append_long(str, num_args + 1);
     smart_string_appendl(str, _NL, sizeof(_NL) -1);
@@ -771,7 +771,7 @@ int redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_
 /*
  * Append a command sequence to a smart_string
  */
-int redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len) {
+size_t redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len) {
     smart_string_appendc(str, '$');
     smart_string_append_long(str, append_len);
     smart_string_appendl(str, _NL, sizeof(_NL) - 1);
@@ -785,7 +785,7 @@ int redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len) {
 /*
  * Append an integer to a smart string command
  */
-int redis_cmd_append_sstr_int(smart_string *str, int append) {
+size_t redis_cmd_append_sstr_int(smart_string *str, int append) {
     char int_buf[32];
     int int_len = snprintf(int_buf, sizeof(int_buf), "%d", append);
     return redis_cmd_append_sstr(str, int_buf, int_len);
@@ -794,7 +794,7 @@ int redis_cmd_append_sstr_int(smart_string *str, int append) {
 /*
  * Append a long to a smart string command
  */
-int redis_cmd_append_sstr_long(smart_string *str, zend_long append) {
+size_t redis_cmd_append_sstr_long(smart_string *str, zend_long append) {
     char long_buf[32];
     int long_len = snprintf(long_buf, sizeof(long_buf), ZEND_LONG_FMT, append);
     return redis_cmd_append_sstr(str, long_buf, long_len);
@@ -803,7 +803,7 @@ int redis_cmd_append_sstr_long(smart_string *str, zend_long append) {
 /*
  * Append a double to a smart string command
  */
-int redis_cmd_append_sstr_dbl(smart_string *str, double value) {
+size_t redis_cmd_append_sstr_dbl(smart_string *str, double value) {
     zend_string *dbl_str;
     int retval;
 
@@ -823,7 +823,7 @@ int redis_cmd_append_sstr_dbl(smart_string *str, double value) {
 /*
  * Append an integer command to a Redis command
  */
-int redis_cmd_append_int(char **cmd, size_t cmd_len, int append) {
+size_t redis_cmd_append_int(char **cmd, size_t cmd_len, int append) {
     char int_buf[32];
     int int_len;
 

--- a/library.c
+++ b/library.c
@@ -475,7 +475,7 @@ PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes 
 /**
  * redis_sock_read
  */
-PHP_REDIS_API char *redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC)
+PHP_REDIS_API char *redis_sock_read(RedisSock *redis_sock, size_t *buf_len TSRMLS_DC)
 {
     char inbuf[1024];
     char *resp = NULL;
@@ -1716,7 +1716,7 @@ PHP_REDIS_API void redis_send_discard(INTERNAL_FUNCTION_PARAMETERS,
  * redis_sock_set_err
  */
 PHP_REDIS_API int redis_sock_set_err(RedisSock *redis_sock, const char *msg,
-                              int msg_len)
+                              size_t msg_len)
 {
     // Allocate/Reallocate our last error member
     if(msg != NULL && msg_len > 0) {

--- a/library.c
+++ b/library.c
@@ -596,7 +596,7 @@ redis_cmd_format_static(char **ret, char *keyword, char *format, ...)
     char *p = format;
     va_list ap;
     smart_string buf = {0};
-    int l = strlen(keyword);
+    size_t l = strlen(keyword);
     zend_string *dbl_str;
 
     va_start(ap, format);

--- a/library.c
+++ b/library.c
@@ -433,7 +433,7 @@ redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS,
 /**
  * redis_sock_read_bulk_reply
  */
-PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC)
+PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, size_t bytes TSRMLS_DC)
 {
     int offset = 0;
     size_t got;
@@ -805,7 +805,7 @@ size_t redis_cmd_append_sstr_long(smart_string *str, zend_long append) {
  */
 size_t redis_cmd_append_sstr_dbl(smart_string *str, double value) {
     zend_string *dbl_str;
-    int retval;
+    size_t retval;
 
     /* Convert to double */
     REDIS_DOUBLE_TO_STRING(dbl_str, value);
@@ -837,7 +837,7 @@ size_t redis_cmd_append_int(char **cmd, size_t cmd_len, int append) {
 PHP_REDIS_API void redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
 
     char *response;
-    int response_len;
+    size_t response_len;
     double ret;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
@@ -860,7 +860,7 @@ PHP_REDIS_API void redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, Redi
 
 PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
     char *response;
-    int response_len;
+    size_t response_len;
     long l;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
@@ -895,7 +895,7 @@ PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
 
 PHP_REDIS_API void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
     char *response;
-    int response_len;
+    size_t response_len;
     zval z_ret;
 
     /* Read bulk response */
@@ -978,7 +978,7 @@ PHP_REDIS_API void redis_parse_info_response(char *response, zval *z_ret) {
  */
 PHP_REDIS_API void redis_client_list_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab) {
     char *resp;
-    int resp_len;
+    size_t resp_len;
     zval z_ret;
 
     /* Make sure we can read the bulk response from Redis */
@@ -1003,7 +1003,8 @@ PHP_REDIS_API void redis_client_list_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSo
 PHP_REDIS_API void redis_parse_client_list_response(char *response, zval *z_result) {
     zval z_sub_result;
     char *p, *lpos, *kpos = NULL, *vpos = NULL, *p2, *key, *value;
-    int klen = 0, done = 0, is_numeric;
+    int done = 0, is_numeric;
+	size_t klen = 0;
 
     // Allocate memory for our response
     array_init(z_result);
@@ -1109,7 +1110,7 @@ redis_boolean_response_impl(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 {
 
     char *response;
-    int response_len;
+    size_t response_len;
     char ret;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
@@ -1157,7 +1158,7 @@ PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS,
 {
 
     char *response;
-    int response_len;
+    size_t response_len;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
                                     == NULL)
@@ -1220,7 +1221,7 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
 
         char *hkey, *hval;
 		zend_string *tablekey;
-        int hkey_len;
+        size_t hkey_len;
         zend_ulong idx;
         zval *z_key_p, *z_value_p;
 
@@ -1349,7 +1350,7 @@ PHP_REDIS_API void redis_1_response(INTERNAL_FUNCTION_PARAMETERS,
 {
 
     char *response;
-    int response_len;
+    size_t response_len;
     char ret;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
@@ -1383,7 +1384,7 @@ PHP_REDIS_API void redis_1_response(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API void redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
 
     char *response;
-    int response_len;
+    size_t response_len;
     zval z;
 
     /* Handle null response */
@@ -1420,7 +1421,7 @@ redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 {
 
     char *response;
-    int response_len;
+    size_t response_len;
 
     if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
                                     == NULL)
@@ -1446,7 +1447,8 @@ PHP_REDIS_API void redis_debug_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock 
                                         zval *z_tab, void *ctx)
 {
     char *resp, *p, *p2, *p3, *p4;
-    int is_numeric,  resp_len;
+    int is_numeric;
+	size_t resp_len;
     zval z_result;
 
     /* Add or return false if we can't read from the socket */
@@ -1518,7 +1520,7 @@ redis_sock_create(char *host, size_t host_len, unsigned short port, double timeo
     redis_sock->status = REDIS_SOCK_STATUS_DISCONNECTED;
     redis_sock->watching = 0;
     redis_sock->dbNumber = 0;
-    redis_sock->retry_interval = retry_interval * 1000;
+    redis_sock->retry_interval = (long)retry_interval * 1000;
     redis_sock->persistent = persistent;
     redis_sock->lazy_connect = lazy_connect;
 
@@ -1562,7 +1564,8 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
     struct timeval tv, read_tv, *tv_ptr = NULL;
     char *host = NULL, *persistent_id = NULL;
 	zend_string *errstr;
-    int host_len, err = 0;
+    int err = 0;
+	size_t host_len;
     php_netstream_data_t *sock;
     int tcp_flag = 1;
 
@@ -1729,7 +1732,7 @@ PHP_REDIS_API int redis_sock_set_err(RedisSock *redis_sock, const char *msg,
         // Copy in our new error message, set new length, and null terminate
         memcpy(redis_sock->err, msg, msg_len);
         redis_sock->err[msg_len] = '\0';
-        redis_sock->err_len = msg_len;
+        redis_sock->err_len = (int)msg_len;
     } else {
         // Free our last error
         if(redis_sock->err != NULL) {
@@ -1753,7 +1756,8 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
                                            void *ctx)
 {
     char inbuf[1024];
-    int numElems, err_len;
+    int numElems;
+	size_t err_len;
     zval z_multi_result;
 
     if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
@@ -1802,7 +1806,8 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API int redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx)
 {
     char inbuf[1024];
-    int numElems, err_len;
+    int numElems;
+	size_t err_len;
     zval z_multi_result;
 
     if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
@@ -1849,7 +1854,7 @@ redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                        zval *z_tab, int count, int unserialize)
 {
     char *line;
-    int len;
+    size_t len;
 
     while(count > 0) {
         line = redis_sock_read(redis_sock, &len TSRMLS_CC);
@@ -1883,7 +1888,7 @@ redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx)
 {
     char inbuf[1024], *response;
-    int response_len;
+    size_t response_len;
     int i, numElems;
     zval z_multi_result;
 
@@ -1942,7 +1947,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 /**
  * redis_sock_write
  */
-PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz
+PHP_REDIS_API size_t redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz
                             TSRMLS_DC)
 {
     if(redis_sock && redis_sock->status == REDIS_SOCK_STATUS_DISCONNECTED) {
@@ -2084,7 +2089,7 @@ redis_unserialize(RedisSock* redis_sock, const char *val, size_t val_len,
 
 PHP_REDIS_API int
 redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len) {
-    int ret_len;
+    size_t ret_len;
     char *ret;
 
     if(redis_sock->prefix == NULL || redis_sock->prefix_len == 0) {

--- a/library.c
+++ b/library.c
@@ -46,7 +46,7 @@ extern zend_class_entry *spl_ce_RuntimeException;
 /* Helper to reselect the proper DB number when we reconnect */
 static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
     char *cmd, *response;
-    int cmd_len, response_len;
+    size_t cmd_len, response_len;
 
     cmd_len = redis_cmd_format_static(&cmd, "SELECT", "d", redis_sock->dbNumber);
 
@@ -73,7 +73,7 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
 /* Helper to resend AUTH <password> in the case of a reconnect */
 static int resend_auth(RedisSock *redis_sock TSRMLS_DC) {
     char *cmd, *response;
-    int cmd_len, response_len;
+    size_t cmd_len, response_len;
 
     cmd_len = redis_cmd_format_static(&cmd, "AUTH", "s", redis_sock->auth,
         strlen(redis_sock->auth));
@@ -728,7 +728,7 @@ redis_cmd_format(char **ret, char *format, ...) {
 /*
  * Append a command sequence to a Redis command
  */
-int redis_cmd_append_str(char **cmd, int cmd_len, char *append, int append_len) {
+int redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len) {
 	/* Smart string buffer */
 	smart_string buf = {0};
 
@@ -756,7 +756,7 @@ int redis_cmd_append_str(char **cmd, int cmd_len, char *append, int append_len) 
  * Given a smart string, number of arguments, a keyword, and the length of the keyword
  * initialize our smart string with the proper Redis header for the command to follow
  */
-int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyword_len) {
+int redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len) {
     smart_string_appendc(str, '*');
     smart_string_append_long(str, num_args + 1);
     smart_string_appendl(str, _NL, sizeof(_NL) -1);
@@ -771,7 +771,7 @@ int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyw
 /*
  * Append a command sequence to a smart_string
  */
-int redis_cmd_append_sstr(smart_string *str, char *append, int append_len) {
+int redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len) {
     smart_string_appendc(str, '$');
     smart_string_append_long(str, append_len);
     smart_string_appendl(str, _NL, sizeof(_NL) - 1);
@@ -794,9 +794,9 @@ int redis_cmd_append_sstr_int(smart_string *str, int append) {
 /*
  * Append a long to a smart string command
  */
-int redis_cmd_append_sstr_long(smart_string *str, long append) {
+int redis_cmd_append_sstr_long(smart_string *str, zend_long append) {
     char long_buf[32];
-    int long_len = snprintf(long_buf, sizeof(long_buf), "%ld", append);
+    int long_len = snprintf(long_buf, sizeof(long_buf), ZEND_LONG_FMT, append);
     return redis_cmd_append_sstr(str, long_buf, long_len);
 }
 
@@ -823,7 +823,7 @@ int redis_cmd_append_sstr_dbl(smart_string *str, double value) {
 /*
  * Append an integer command to a Redis command
  */
-int redis_cmd_append_int(char **cmd, int cmd_len, int append) {
+int redis_cmd_append_int(char **cmd, size_t cmd_len, int append) {
     char int_buf[32];
     int int_len;
 
@@ -1506,8 +1506,8 @@ PHP_REDIS_API void redis_debug_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock 
  * redis_sock_create
  */
 PHP_REDIS_API RedisSock*
-redis_sock_create(char *host, int host_len, unsigned short port, double timeout,
-                  int persistent, char *persistent_id, long retry_interval,
+redis_sock_create(char *host, size_t host_len, unsigned short port, double timeout,
+                  int persistent, char *persistent_id, zend_long retry_interval,
                   zend_bool lazy_connect)
 {
     RedisSock *redis_sock;
@@ -1690,7 +1690,7 @@ PHP_REDIS_API void redis_send_discard(INTERNAL_FUNCTION_PARAMETERS,
                                RedisSock *redis_sock)
 {
     char *cmd;
-    int response_len, cmd_len;
+    size_t response_len, cmd_len;
     char * response;
 
     cmd_len = redis_cmd_format_static(&cmd, "DISCARD", "");
@@ -2046,7 +2046,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
 }
 
 PHP_REDIS_API int
-redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
+redis_unserialize(RedisSock* redis_sock, const char *val, size_t val_len,
                   zval *return_value TSRMLS_DC)
 {
 

--- a/library.h
+++ b/library.h
@@ -6,12 +6,12 @@ int integer_length(int i);
 int redis_cmd_format(char **ret, char *format, ...);
 int redis_cmd_format_static(char **ret, char *keyword, char *format, ...);
 int redis_cmd_format_header(char **ret, char *keyword, int arg_count);
-int redis_cmd_append_str(char **cmd, int cmd_len, char *append, int append_len);
-int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyword_len);
-int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);
+int redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len);
+int redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len);
+int redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len);
 int redis_cmd_append_sstr_int(smart_string *str, int append);
-int redis_cmd_append_sstr_long(smart_string *str, long append);
-int redis_cmd_append_int(char **cmd, int cmd_len, int append);
+int redis_cmd_append_sstr_long(smart_string *str, zend_long append);
+int redis_cmd_append_int(char **cmd, size_t cmd_len, int append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
 
 PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
@@ -28,7 +28,7 @@ PHP_REDIS_API void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
 PHP_REDIS_API void redis_parse_info_response(char *resp, zval *z_ret);
 PHP_REDIS_API void redis_parse_client_list_response(char *resp, zval *z_result);
 PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
-PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, int persistent, char *persistent_id, long retry_interval, zend_bool lazy_connect);
+PHP_REDIS_API RedisSock* redis_sock_create(char *host, size_t host_len, unsigned short port, double timeout, int persistent, char *persistent_id, zend_long retry_interval, zend_bool lazy_connect);
 PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock, int force_connect TSRMLS_DC);
 PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC);
@@ -65,7 +65,7 @@ PHP_REDIS_API int
 redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len);
 
 PHP_REDIS_API int
-redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval *return_value TSRMLS_DC);
+redis_unserialize(RedisSock *redis_sock, const char *val, size_t val_len, zval *return_value TSRMLS_DC);
 
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_send_discard(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);

--- a/library.h
+++ b/library.h
@@ -14,7 +14,7 @@ size_t redis_cmd_append_sstr_long(smart_string *str, zend_long append);
 size_t redis_cmd_append_int(char **cmd, size_t cmd_len, int append);
 size_t redis_cmd_append_sstr_dbl(smart_string *str, double value);
 
-PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
+PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, size_t *buf_len TSRMLS_DC);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len TSRMLS_DC);
 PHP_REDIS_API void redis_1_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval* z_tab, void *ctx);
@@ -61,7 +61,6 @@ PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC)
 PHP_REDIS_API int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, int nothrow);
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_send_discard(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
-PHP_REDIS_API int redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len);
 
 PHP_REDIS_API int
 redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len TSRMLS_DC);
@@ -73,7 +72,7 @@ redis_unserialize(RedisSock *redis_sock, const char *val, size_t val_len, zval *
 
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_send_discard(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
-PHP_REDIS_API int redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len);
+PHP_REDIS_API int redis_sock_set_err(RedisSock *redis_sock, const char *msg, size_t msg_len);
 
 
 /*

--- a/library.h
+++ b/library.h
@@ -2,17 +2,17 @@
 #define REDIS_LIBRARY_H
 
 void add_constant_long(zend_class_entry *ce, char *name, int value);
-int integer_length(int i);
-int redis_cmd_format(char **ret, char *format, ...);
-int redis_cmd_format_static(char **ret, char *keyword, char *format, ...);
-int redis_cmd_format_header(char **ret, char *keyword, int arg_count);
-int redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len);
-int redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len);
-int redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len);
-int redis_cmd_append_sstr_int(smart_string *str, int append);
-int redis_cmd_append_sstr_long(smart_string *str, zend_long append);
-int redis_cmd_append_int(char **cmd, size_t cmd_len, int append);
-int redis_cmd_append_sstr_dbl(smart_string *str, double value);
+size_t integer_length(int i);
+size_t redis_cmd_format(char **ret, char *format, ...);
+size_t redis_cmd_format_static(char **ret, char *keyword, char *format, ...);
+size_t redis_cmd_format_header(char **ret, char *keyword, int arg_count);
+size_t redis_cmd_append_str(char **cmd, size_t cmd_len, char *append, size_t append_len);
+size_t redis_cmd_init_sstr(smart_string *str, size_t num_args, char *keyword, size_t keyword_len);
+size_t redis_cmd_append_sstr(smart_string *str, char *append, size_t append_len);
+size_t redis_cmd_append_sstr_int(smart_string *str, int append);
+size_t redis_cmd_append_sstr_long(smart_string *str, zend_long append);
+size_t redis_cmd_append_int(char **cmd, size_t cmd_len, int append);
+size_t redis_cmd_append_sstr_dbl(smart_string *str, double value);
 
 PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len TSRMLS_DC);
@@ -44,7 +44,8 @@ PHP_REDIS_API int redis_mbulk_reply_zipped_keys_int(INTERNAL_FUNCTION_PARAMETERS
 PHP_REDIS_API int redis_mbulk_reply_zipped_keys_dbl(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 
-PHP_REDIS_API int redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, REDIS_SCAN_TYPE type, long *iter);
+PHP_REDIS_API int redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, REDIS_SCAN_TYPE type, zend_long *iter);
+PHP_REDIS_API size_t redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len, int iter, char *pattern, size_t pattern_len, int count);
 
 PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/library.h
+++ b/library.h
@@ -46,6 +46,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 
 PHP_REDIS_API int redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, REDIS_SCAN_TYPE type, zend_long *iter);
 PHP_REDIS_API size_t redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len, int iter, char *pattern, size_t pattern_len, int count);
+PHP_REDIS_API size_t redis_build_script_exists_cmd(char **ret, zval *argv, int argc);
 
 PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/library.h
+++ b/library.h
@@ -33,7 +33,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock, int force_connect TSRMLS_DC);
 PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API void redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab);
-PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC);
+PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, size_t bytes TSRMLS_DC);
 PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
 PHP_REDIS_API void redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, int count, int unserialize);
 
@@ -55,7 +55,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);
 
-PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC);
+PHP_REDIS_API size_t redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC);
 PHP_REDIS_API void redis_stream_close(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC);
 PHP_REDIS_API int redis_sock_get(zval *id, RedisSock **redis_sock TSRMLS_DC, int nothrow);

--- a/library.h
+++ b/library.h
@@ -47,6 +47,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 PHP_REDIS_API int redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, REDIS_SCAN_TYPE type, zend_long *iter);
 PHP_REDIS_API size_t redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len, int iter, char *pattern, size_t pattern_len, int count);
 PHP_REDIS_API size_t redis_build_script_exists_cmd(char **ret, zval *argv, int argc);
+PHP_REDIS_API size_t redis_build_eval_cmd(RedisSock *redis_sock, char **ret, char *keyword, char *value, size_t val_len, zval *args, int keys_count TSRMLS_DC);
 
 PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/library.h
+++ b/library.h
@@ -48,6 +48,7 @@ PHP_REDIS_API int redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, Redis
 PHP_REDIS_API size_t redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len, int iter, char *pattern, size_t pattern_len, int count);
 PHP_REDIS_API size_t redis_build_script_exists_cmd(char **ret, zval *argv, int argc);
 PHP_REDIS_API size_t redis_build_eval_cmd(RedisSock *redis_sock, char **ret, char *keyword, char *value, size_t val_len, zval *args, int keys_count TSRMLS_DC);
+PHP_REDIS_API size_t redis_build_pubsub_cmd(RedisSock *redis_sock, char **ret, PUBSUB_TYPE type, zval *arg TSRMLS_DC);
 
 PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/php_redis.h
+++ b/php_redis.h
@@ -273,7 +273,7 @@ struct redis_queued_item {
     zval * (*fun)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, ...);
 
     char *cmd; 
-    int cmd_len;
+    size_t cmd_len;
 
     struct redis_queued_item *next;
 };

--- a/redis.c
+++ b/redis.c
@@ -387,7 +387,7 @@ static int send_discard_static(RedisSock *redis_sock TSRMLS_DC) {
 
     int result = FAILURE;
     char *cmd, *resp;
-    int resp_len, cmd_len;
+    size_t resp_len, cmd_len;
 
     /* format our discard command */
     cmd_len = redis_cmd_format_static(&cmd, "DISCARD", "");
@@ -1729,7 +1729,7 @@ PHP_METHOD(Redis, info) {
     zval *object;
     RedisSock *redis_sock;
     char *cmd, *opt = NULL;
-    int cmd_len;
+    size_t cmd_len;
     size_t opt_len;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -1768,7 +1768,7 @@ PHP_METHOD(Redis, select) {
     RedisSock *redis_sock;
 
     char *cmd;
-    int cmd_len;
+    size_t cmd_len;
     zend_long dbNumber;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol",
@@ -1805,7 +1805,8 @@ generic_mset(INTERNAL_FUNCTION_PARAMETERS, char *kw, ResultCallback fun) {
     RedisSock *redis_sock;
 
     char *cmd = NULL, *p = NULL;
-    int cmd_len = 0, argc = 0, kw_len = strlen(kw);
+    size_t cmd_len = 0, kw_len = strlen(kw);
+	int argc = 0;
     int step = 0;    // 0: compute size; 1: copy strings.
     zval *z_array;
 
@@ -1946,7 +1947,7 @@ static void generic_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw,
                                zrange_cb fun)
 {
     char *cmd;
-    int cmd_len;
+    size_t cmd_len;
     RedisSock *redis_sock;
     int withscores=0;
 
@@ -2205,7 +2206,7 @@ PHP_METHOD(Redis, multi)
 
     RedisSock *redis_sock;
     char *cmd;
-    int response_len, cmd_len;
+    size_t response_len, cmd_len;
     char * response;
     zval *object;
     zend_long multi_value = MULTI;
@@ -2363,7 +2364,7 @@ PHP_METHOD(Redis, exec)
 {
     RedisSock *redis_sock;
     char *cmd;
-    int cmd_len;
+    size_t cmd_len;
     zval *object;
     struct request_item *ri;
 
@@ -2551,7 +2552,8 @@ PHP_REDIS_API void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS,
     HashPosition pointer;
     RedisSock *redis_sock;
     char *cmd = "", *old_cmd = NULL;
-    int cmd_len, array_count;
+    size_t cmd_len;
+	int array_count;
 
     int i;
     zval z_tab, *z_channel;
@@ -2645,7 +2647,7 @@ PHP_METHOD(Redis, slaveof)
     zval *object;
     RedisSock *redis_sock;
     char *cmd = "", *host = NULL;
-    int cmd_len;
+    size_t cmd_len;
     size_t host_len;
     zend_long port = 6379;
 
@@ -2744,7 +2746,7 @@ PHP_METHOD(Redis, config)
     RedisSock *redis_sock;
     char *key = NULL, *val = NULL, *cmd, *op = NULL;
     size_t key_len, val_len, op_len;
-    int cmd_len;
+    size_t cmd_len;
     enum {CFG_GET, CFG_SET} mode;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -2799,7 +2801,7 @@ PHP_METHOD(Redis, slowlog) {
     zval *object;
     RedisSock *redis_sock;
     char *arg, *cmd;
-    int cmd_len;
+    size_t cmd_len;
     size_t arg_len;
     zend_long option;
     enum {SLOWLOG_GET, SLOWLOG_LEN, SLOWLOG_RESET} mode;
@@ -2857,7 +2859,7 @@ PHP_METHOD(Redis, wait) {
     RedisSock *redis_sock;
     zend_long num_slaves, timeout;
     char *cmd;
-    int cmd_len;
+    size_t cmd_len;
 
     /* Make sure arguments are valid */
     if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oll",
@@ -2992,7 +2994,7 @@ PHP_METHOD(Redis, pubsub) {
     zval *object;
     RedisSock *redis_sock;
     char *keyword, *cmd;
-    int cmd_len;
+    size_t cmd_len;
     size_t kw_len;
     PUBSUB_TYPE type;
     zval *arg=NULL;
@@ -3068,7 +3070,8 @@ redis_build_eval_cmd(RedisSock *redis_sock, char **ret, char *keyword,
     zval *elem;
     HashTable *args_hash;
     HashPosition hash_pos;
-    int cmd_len, args_count = 0;
+    size_t cmd_len;
+	int args_count = 0;
     int eval_cmd_count = 2;
 
     // If we've been provided arguments, we'll want to include those in our eval
@@ -3152,7 +3155,7 @@ PHP_METHOD(Redis, evalsha)
 {
     zval *object, *args= NULL;
     char *cmd, *sha;
-    int cmd_len;
+    size_t cmd_len;
     size_t sha_len;
     zend_long keys_count = 0;
     RedisSock *redis_sock;
@@ -3190,7 +3193,7 @@ PHP_METHOD(Redis, eval)
     zval *object, *args = NULL;
     RedisSock *redis_sock;
     char *script, *cmd = "";
-    int cmd_len;
+    size_t cmd_len;
     size_t script_len;
     zend_long keys_count = 0;
 
@@ -3254,7 +3257,8 @@ redis_build_script_exists_cmd(char **ret, zval *argv, int argc) {
 PHP_METHOD(Redis, script) {
     zval *z_args;
     RedisSock *redis_sock;
-    int cmd_len, argc;
+    size_t cmd_len;
+	int argc;
     char *cmd;
 
     /* Attempt to grab our socket */
@@ -3633,8 +3637,7 @@ PHP_METHOD(Redis, client) {
     zval *object;
     RedisSock *redis_sock;
     char *cmd, *opt = NULL, *arg = NULL;
-    int cmd_len = 0;
-    size_t opt_len = 0, arg_len = 0;
+    size_t  cmd_len = 0, opt_len = 0, arg_len = 0;
 
     // Parse our method parameters
     if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -3679,7 +3682,8 @@ PHP_METHOD(Redis, client) {
 
 /* {{{ proto mixed Redis::rawcommand(string $command, [ $arg1 ... $argN]) */
 PHP_METHOD(Redis, rawcommand) {
-    int argc = ZEND_NUM_ARGS(), cmd_len = 0;
+    int argc = ZEND_NUM_ARGS();
+	size_t cmd_len = 0;
     char *cmd = NULL;
     RedisSock *redis_sock;
     zval *z_args;

--- a/redis.c
+++ b/redis.c
@@ -2902,7 +2902,8 @@ redis_build_pubsub_cmd(RedisSock *redis_sock, char **ret, PUBSUB_TYPE type,
     zval *z_ele;
     char *key;
     size_t key_len;
-    int cmd_len, key_free;
+    int key_free;
+	size_t cmd_len;
     smart_string cmd = {0};
 
     if(type == PUBSUB_CHANNELS) {
@@ -3226,10 +3227,11 @@ PHP_METHOD(Redis, eval)
     REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
 }
 
-PHP_REDIS_API int
+PHP_REDIS_API size_t
 redis_build_script_exists_cmd(char **ret, zval *argv, int argc) {
     /* Our command length and iterator */
-    int cmd_len = 0, i;
+    int i;
+	size_t cmd_len = 0;
 
     // Start building our command
     cmd_len = redis_cmd_format_header(ret, "SCRIPT", argc + 1);
@@ -3353,7 +3355,8 @@ PHP_METHOD(Redis, migrate) {
     RedisSock *redis_sock;
     char *cmd, *host, *key;
     size_t host_len, key_len;
-    int cmd_len, key_free;
+    int key_free;
+	size_t cmd_len;
     zend_bool copy=0, replace=0;
     zend_long port, dest_db, timeout;
 

--- a/redis.c
+++ b/redis.c
@@ -759,7 +759,7 @@ PHP_REDIS_API int redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent) {
         }
     }
 
-    redis_sock = redis_sock_create(host, host_len, port, timeout, persistent,
+    redis_sock = redis_sock_create(host, host_len, (unsigned short) port, timeout, persistent,
         persistent_id, retry_interval, 0);
 
     if (redis_sock_server_open(redis_sock, 1 TSRMLS_CC) < 0) {

--- a/redis.c
+++ b/redis.c
@@ -1285,7 +1285,7 @@ PHP_METHOD(Redis, sPop)
 PHP_METHOD(Redis, sRandMember)
 {
     char *cmd;
-    int cmd_len;
+    size_t cmd_len;
     short have_count;
     RedisSock *redis_sock;
 
@@ -3729,12 +3729,13 @@ PHP_METHOD(Redis, command) {
 /* }}} */
 
 /* Helper to format any combination of SCAN arguments */
-PHP_REDIS_API int
-redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
-                     int iter, char *pattern, int pattern_len, int count)
+PHP_REDIS_API size_t
+redis_build_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len,
+                     int iter, char *pattern, size_t pattern_len, int count)
 {
     char *keyword;
-    int arg_count = 0, cmd_len;
+    int arg_count = 0;
+	size_t cmd_len;
 
     /* Count our arguments +1 for key if it's got one, and + 2 for pattern */
     /* or count given that they each carry keywords with them. */
@@ -3794,9 +3795,10 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
     HashTable *hash;
     char *pattern=NULL, *cmd, *key=NULL;
     size_t key_len = 0, pattern_len = 0;
-    int cmd_len, num_elements, key_free=0;
+    int num_elements, key_free=0;
+	size_t cmd_len;
     zend_long count=0;
-	long iter;
+	zend_long iter;
 
     /* Different prototype depending on if this is a key based scan */
     if(type != TYPE_SCAN) {
@@ -3869,7 +3871,7 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
 
         // Format our SCAN command
         cmd_len = redis_build_scan_cmd(&cmd, type, key, key_len, (int)iter,
-                                   pattern, pattern_len, count);
+                                   pattern, pattern_len, (int)count);
 
         /* Execute our command getting our new iterator value */
         REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);

--- a/redis.c
+++ b/redis.c
@@ -3063,9 +3063,9 @@ PHP_METHOD(Redis, pubsub) {
 
 // Construct an EVAL or EVALSHA command, with option argument array and number
 // of arguments that are keys parameter
-PHP_REDIS_API int
+PHP_REDIS_API size_t
 redis_build_eval_cmd(RedisSock *redis_sock, char **ret, char *keyword,
-                     char *value, int val_len, zval *args, int keys_count
+                     char *value, size_t val_len, zval *args, int keys_count
                      TSRMLS_DC)
 {
     zval *elem;
@@ -3214,7 +3214,7 @@ PHP_METHOD(Redis, eval)
 
     // Construct our EVAL command
     cmd_len = redis_build_eval_cmd(redis_sock, &cmd, "EVAL", script, script_len,
-        args, keys_count TSRMLS_CC);
+        args, (int)keys_count TSRMLS_CC);
 
     REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
     IF_ATOMIC() {

--- a/redis.c
+++ b/redis.c
@@ -2893,7 +2893,7 @@ PHP_METHOD(Redis, wait) {
 }
 
 /* Construct a PUBSUB command */
-PHP_REDIS_API int
+PHP_REDIS_API size_t
 redis_build_pubsub_cmd(RedisSock *redis_sock, char **ret, PUBSUB_TYPE type,
                        zval *arg TSRMLS_DC)
 {
@@ -3175,7 +3175,7 @@ PHP_METHOD(Redis, evalsha)
 
     // Construct our EVALSHA command
     cmd_len = redis_build_eval_cmd(redis_sock, &cmd, "EVALSHA", sha, sha_len,
-        args, keys_count TSRMLS_CC);
+        args, (int)keys_count TSRMLS_CC);
 
     REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
     IF_ATOMIC() {

--- a/redis_array.c
+++ b/redis_array.c
@@ -206,7 +206,7 @@ PHP_METHOD(RedisArray, __construct)
     RedisArray *ra = NULL;
     zend_bool b_index = 0, b_autorehash = 0, b_pconnect = 0;
     HashTable *hPrev = NULL, *hOpts = NULL;
-    long l_retry_interval = 0;
+    zend_long l_retry_interval = 0;
     zend_bool b_lazy_connect = 0;
     double d_connect_timeout = 0;
 
@@ -282,7 +282,7 @@ PHP_METHOD(RedisArray, __construct)
             if (Z_TYPE_P(z_connect_timeout_p) == IS_DOUBLE) {
                 d_connect_timeout = Z_DVAL_P(z_connect_timeout_p);
             } else if (Z_TYPE_P(z_connect_timeout_p) == IS_LONG) {
-                d_connect_timeout = Z_LVAL_P(z_connect_timeout_p);
+                d_connect_timeout = (double)Z_LVAL_P(z_connect_timeout_p);
             } else {
                 d_connect_timeout = atof(Z_STRVAL_P(z_connect_timeout_p));
             }
@@ -332,11 +332,11 @@ static void free_zval_array(zval *array, size_t len) {
 }
 
 static void
-ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd, int cmd_len, zval *z_args, zval *z_new_target) {
+ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd, size_t cmd_len, zval *z_args, zval *z_new_target) {
 
     zval *zp_tmp, z_tmp;
     char *key = NULL; /* set to avoid "unused-but-set-variable" */
-    int key_len;
+    size_t key_len;
     int i;
     zval *redis_inst;
     zval z_fun, *z_callargs;

--- a/redis_array.c
+++ b/redis_array.c
@@ -866,7 +866,7 @@ PHP_METHOD(RedisArray, mget)
             zend_hash_move_forward_ex(h_keys, &pointer), ++i)
     {
         /* If we need to represent a long key as a string */
-        unsigned int key_len;
+        size_t key_len;
         char kbuf[40], *key_lookup;
 
         /* phpredis proper can only use string or long keys, so restrict to that here */
@@ -977,7 +977,7 @@ PHP_METHOD(RedisArray, mset)
     zval *redis_inst, **redis_instances, **argv;
     char *key, **keys, **key_free, kbuf[40];
     zend_string *key_zstr;
-    unsigned int key_len;
+    size_t key_len;
     int free_idx = 0;
     int type, *key_lens;
     zend_ulong idx;
@@ -1115,7 +1115,7 @@ PHP_METHOD(RedisArray, del)
     HashTable *h_keys;
     HashPosition pointer;
     zval *redis_inst, **redis_instances, **argv;;
-    long total = 0;
+    size_t total = 0;
     int free_zkeys = 0;
 
     /* Multi/exec support */

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -466,7 +466,7 @@ ra_find_node(RedisArray *ra, const char *key, size_t key_len, int *out_pos TSRML
 }
 
 zval *
-ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC) {
+ra_find_node_by_name(RedisArray *ra, const char *host, size_t host_len TSRMLS_DC) {
 
     int i;
     for(i = 0; i < ra->count; ++i) {

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -30,9 +30,10 @@ extern int le_redis_sock;
 extern zend_class_entry *redis_ce;
 
 RedisArray*
-ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b_lazy_connect TSRMLS_DC)
+ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_long retry_interval, zend_bool b_lazy_connect TSRMLS_DC)
 {
-    int i = 0, host_len;
+    int i = 0;
+	size_t host_len;
     zval *id;
     char *host, *p;
     short port;
@@ -171,7 +172,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     RedisArray *ra = NULL;
 
     zend_bool b_index = 0, b_autorehash = 0, b_pconnect = 0;
-    long l_retry_interval = 0;
+    zend_long l_retry_interval = 0;
     zend_bool b_lazy_connect = 0;
     double d_connect_timeout = 0;
     HashTable *hHosts = NULL, *hPrev = NULL;
@@ -269,7 +270,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
         if (Z_TYPE_P(z_data_p) == IS_DOUBLE) {
             d_connect_timeout = Z_DVAL_P(z_data_p);
         } else if (Z_TYPE_P(z_data_p) == IS_LONG) {
-            d_connect_timeout = Z_LVAL_P(z_data_p);
+            d_connect_timeout = (double) Z_LVAL_P(z_data_p);
         } else {
             d_connect_timeout = atof(Z_STRVAL_P(z_data_p));
         }
@@ -297,7 +298,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
 
 RedisArray *
 ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev,
-              zend_bool b_index, zend_bool b_pconnect, long retry_interval,
+              zend_bool b_index, zend_bool b_pconnect, zend_long retry_interval,
               zend_bool b_lazy_connect, double connect_timeout TSRMLS_DC)
 {
     int count = zend_hash_num_elements(hosts);
@@ -341,7 +342,7 @@ ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev
 
 /* call userland key extraction function */
 char *
-ra_call_extractor(RedisArray *ra, const char *key, int key_len, int *out_len TSRMLS_DC) {
+ra_call_extractor(RedisArray *ra, const char *key, size_t key_len, size_t *out_len TSRMLS_DC) {
 
     char *out;
     zval z_ret;
@@ -374,7 +375,7 @@ ra_call_extractor(RedisArray *ra, const char *key, int key_len, int *out_len TSR
 }
 
 static char *
-ra_extract_key(RedisArray *ra, const char *key, int key_len, int *out_len TSRMLS_DC) {
+ra_extract_key(RedisArray *ra, const char *key, size_t key_len, size_t *out_len TSRMLS_DC) {
 
     char *start, *end, *out;
     *out_len = key_len;
@@ -401,7 +402,7 @@ ra_extract_key(RedisArray *ra, const char *key, int key_len, int *out_len TSRMLS
 
 /* call userland key distributor function */
 zend_bool
-ra_call_distributor(RedisArray *ra, const char *key, int key_len, int *pos TSRMLS_DC) {
+ra_call_distributor(RedisArray *ra, const char *key, size_t key_len, int *pos TSRMLS_DC) {
 
     zval z_ret;
     zval z_argv0;
@@ -424,16 +425,17 @@ ra_call_distributor(RedisArray *ra, const char *key, int key_len, int *pos TSRML
 
     zval_dtor(&z_argv0);
 
-    *pos = Z_LVAL(z_ret);
+    *pos = (int)Z_LVAL(z_ret);
     zval_dtor(&z_ret);
     return 1;
 }
 
 zval *
-ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_DC) {
+ra_find_node(RedisArray *ra, const char *key, size_t key_len, int *out_pos TSRMLS_DC) {
     uint32_t hash;
     char *out;
-    int pos, out_len;
+    int pos;
+	size_t out_len;
 
     /* extract relevant part of the key */
     out = ra_extract_key(ra, key, key_len, &out_len TSRMLS_CC);
@@ -477,7 +479,7 @@ ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC) {
 
 
 char *
-ra_find_key(RedisArray *ra, zval *z_args, const char *cmd, int *key_len) {
+ra_find_key(RedisArray *ra, zval *z_args, const char *cmd, size_t *key_len) {
 
     zval *zp_tmp;
     int key_pos = 0; /* TODO: change this depending on the command */
@@ -583,7 +585,7 @@ ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC) {
 }
 
 void
-ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC) {
+ra_index_key(const char *key, size_t key_len, zval *z_redis TSRMLS_DC) {
 
     zval z_fun_sadd, z_ret, z_args[2];
 
@@ -650,10 +652,10 @@ ra_index_unwatch(zval *z_redis, zval *return_value TSRMLS_DC) {
 }
 
 zend_bool
-ra_is_write_cmd(RedisArray *ra, const char *cmd, int cmd_len) {
+ra_is_write_cmd(RedisArray *ra, const char *cmd, size_t cmd_len) {
 
     zend_bool ret;
-    int i;
+    size_t i;
     char *cmd_up = emalloc(1 + cmd_len);
 
     /* convert to uppercase */
@@ -670,14 +672,14 @@ ra_is_write_cmd(RedisArray *ra, const char *cmd, int cmd_len) {
 
 /* list keys from array index */
 static long
-ra_rehash_scan(zval *z_redis, char ***keys, int **key_lens, const char *cmd, const char *arg TSRMLS_DC) {
+ra_rehash_scan(zval *z_redis, char ***keys, size_t **key_lens, const char *cmd, const char *arg TSRMLS_DC) {
 
     long count, i;
     zval z_fun_smembers, z_ret, z_arg, *z_data_p;
     HashTable *h_keys;
     HashPosition pointer;
     char *key;
-    int key_len;
+    size_t key_len;
 
     /* Function and argument */
     ZVAL_STRING(&z_fun_smembers, cmd);
@@ -693,7 +695,7 @@ ra_rehash_scan(zval *z_redis, char ***keys, int **key_lens, const char *cmd, con
     /* allocate key array */
     count = zend_hash_num_elements(h_keys);
     *keys = emalloc(count * sizeof(char*));
-    *key_lens = emalloc(count * sizeof(int));
+    *key_lens = emalloc(count * sizeof(size_t));
 
     for (i = 0, zend_hash_internal_pointer_reset_ex(h_keys, &pointer);
             (z_data_p = zend_hash_get_current_data_ex(h_keys, &pointer)) != NULL;
@@ -718,23 +720,23 @@ ra_rehash_scan(zval *z_redis, char ***keys, int **key_lens, const char *cmd, con
 }
 
 static long
-ra_rehash_scan_index(zval *z_redis, char ***keys, int **key_lens TSRMLS_DC) {
+ra_rehash_scan_index(zval *z_redis, char ***keys, size_t **key_lens TSRMLS_DC) {
     return ra_rehash_scan(z_redis, keys, key_lens, "SMEMBERS", PHPREDIS_INDEX_NAME TSRMLS_CC);
 }
 
 /* list keys using KEYS command */
 static long
-ra_rehash_scan_keys(zval *z_redis, char ***keys, int **key_lens TSRMLS_DC) {
+ra_rehash_scan_keys(zval *z_redis, char ***keys, size_t **key_lens TSRMLS_DC) {
     return ra_rehash_scan(z_redis, keys, key_lens, "KEYS", "*" TSRMLS_CC);
 }
 
 /* run TYPE to find the type */
 static zend_bool
-ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long *res TSRMLS_DC) {
+ra_get_key_type(zval *z_redis, const char *key, size_t key_len, zval *z_from, zend_long *res TSRMLS_DC) {
     int i;
     zval z_fun_type, z_ret, z_arg;
     zval *z_data;
-    long success = 1;
+    zend_bool success = 1;
 
     /* Pipelined */
     ra_index_multi(z_from, PIPELINE TSRMLS_CC);
@@ -788,7 +790,7 @@ ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long 
 
 /* delete key from source server index during rehashing */
 static void
-ra_remove_from_index(zval *z_redis, const char *key, int key_len TSRMLS_DC) {
+ra_remove_from_index(zval *z_redis, const char *key, size_t key_len TSRMLS_DC) {
 
     zval z_fun_srem, z_ret, z_args[2];
 
@@ -808,7 +810,7 @@ ra_remove_from_index(zval *z_redis, const char *key, int key_len TSRMLS_DC) {
 
 /* delete key from source server during rehashing */
 static zend_bool
-ra_del_key(const char *key, int key_len, zval *z_from TSRMLS_DC) {
+ra_del_key(const char *key, size_t key_len, zval *z_from TSRMLS_DC) {
     zval z_fun_del, z_ret, z_args;
 
     /* in a transaction */
@@ -834,7 +836,7 @@ ra_del_key(const char *key, int key_len, zval *z_from TSRMLS_DC) {
 }
 
 static zend_bool
-ra_expire_key(const char *key, int key_len, zval *z_to, long ttl TSRMLS_DC) {
+ra_expire_key(const char *key, size_t key_len, zval *z_to, zend_long ttl TSRMLS_DC) {
 
     zval z_fun_expire, z_ret, z_args[2];
 
@@ -851,7 +853,7 @@ ra_expire_key(const char *key, int key_len, zval *z_to, long ttl TSRMLS_DC) {
 }
 
 static zend_bool
-ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_zset(const char *key, size_t key_len, zval *z_from, zval *z_to, zend_long ttl TSRMLS_DC) {
     zval z_fun_zrange, z_fun_zadd, z_ret, z_ret_dest, z_args[4], *z_score_p, *z_zadd_args;
     int count;
     HashTable *h_zset_vals;
@@ -935,7 +937,7 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 }
 
 static zend_bool
-ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_string(const char *key, size_t key_len, zval *z_from, zval *z_to, zend_long ttl TSRMLS_DC) {
     zval z_fun_get, z_fun_set, z_ret, z_args[3];
     int i, argc = 0;
 
@@ -982,7 +984,7 @@ ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl 
 }
 
 static zend_bool
-ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_hash(const char *key, size_t key_len, zval *z_from, zval *z_to, zend_long ttl TSRMLS_DC) {
     zval z_fun_hgetall, z_fun_hmset, z_ret, z_ret_dest, z_args[2];
 
     /* run HGETALL on source */
@@ -1021,9 +1023,9 @@ ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 }
 
 static zend_bool
-ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
+ra_move_collection(const char *key, size_t key_len, zval *z_from, zval *z_to,
         int list_count, const char **cmd_list,
-        int add_count, const char **cmd_add, long ttl TSRMLS_DC) {
+        int add_count, const char **cmd_add, zend_long ttl TSRMLS_DC) {
     zval z_fun_retrieve, z_fun_sadd, z_ret, *z_data_p, *z_retrieve_args, *z_sadd_args;
     int count, i;
     HashTable *h_set_vals;
@@ -1095,22 +1097,22 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
 }
 
 static zend_bool
-ra_move_set(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_set(const char *key, size_t key_len, zval *z_from, zval *z_to, zend_long ttl TSRMLS_DC) {
     const char *cmd_list[] = {"SMEMBERS"};
     const char *cmd_add[] = {"SADD"};
     return ra_move_collection(key, key_len, z_from, z_to, 1, cmd_list, 1, cmd_add, ttl TSRMLS_CC);
 }
 
 static zend_bool
-ra_move_list(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_list(const char *key, size_t key_len, zval *z_from, zval *z_to, zend_long ttl TSRMLS_DC) {
     const char *cmd_list[] = {"LRANGE", "0", "-1"};
     const char *cmd_add[] = {"RPUSH"};
     return ra_move_collection(key, key_len, z_from, z_to, 3, cmd_list, 1, cmd_add, ttl TSRMLS_CC);
 }
 
 void
-ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to TSRMLS_DC) {
-    long res[2], type, ttl;
+ra_move_key(const char *key, size_t key_len, zval *z_from, zval *z_to TSRMLS_DC) {
+    zend_long res[2], type, ttl;
     zend_bool success = 0;
 
     if (ra_get_key_type(z_from, key, key_len, z_from, res TSRMLS_CC)) {
@@ -1179,7 +1181,7 @@ static void
 ra_rehash_server(RedisArray *ra, zval *z_redis, const char *hostname, zend_bool b_index,
         zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache TSRMLS_DC) {
     char **keys;
-    int *key_lens;
+    size_t *key_lens;
     long count, i;
     int target_pos;
     zval *z_target;

--- a/redis_array_impl.h
+++ b/redis_array_impl.h
@@ -10,24 +10,24 @@
 #include "common.h"
 #include "redis_array.h"
 
-RedisArray *ra_load_hosts(RedisArray *ra, HashTable *hosts, long retry_interval, zend_bool b_lazy_connect TSRMLS_DC);
+RedisArray *ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_long retry_interval, zend_bool b_lazy_connect TSRMLS_DC);
 RedisArray *ra_load_array(const char *name TSRMLS_DC);
-RedisArray *ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, long retry_interval, zend_bool b_lazy_connect, double connect_timeout TSRMLS_DC);
+RedisArray *ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, zend_long retry_interval, zend_bool b_lazy_connect, double connect_timeout TSRMLS_DC);
 zval *ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC);
-zval *ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_DC);
+zval *ra_find_node(RedisArray *ra, const char *key, size_t key_len, int *out_pos TSRMLS_DC);
 void ra_init_function_table(RedisArray *ra);
 
-void ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to TSRMLS_DC);
-char * ra_find_key(RedisArray *ra, zval *z_args, const char *cmd, int *key_len);
+void ra_move_key(const char *key, size_t key_len, zval *z_from, zval *z_to TSRMLS_DC);
+char * ra_find_key(RedisArray *ra, zval *z_args, const char *cmd, size_t *key_len);
 void ra_index_multi(zval *z_redis, long multi_value TSRMLS_DC);
 
-void ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC);
+void ra_index_key(const char *key, size_t key_len, zval *z_redis TSRMLS_DC);
 void ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC);
 void ra_index_del(zval *z_keys, zval *z_redis TSRMLS_DC);
 void ra_index_exec(zval *z_redis, zval *return_value, int keep_all TSRMLS_DC);
 void ra_index_discard(zval *z_redis, zval *return_value TSRMLS_DC);
 void ra_index_unwatch(zval *z_redis, zval *return_value TSRMLS_DC);
-zend_bool ra_is_write_cmd(RedisArray *ra, const char *cmd, int cmd_len);
+zend_bool ra_is_write_cmd(RedisArray *ra, const char *cmd, size_t cmd_len);
 
 void ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache TSRMLS_DC);
 

--- a/redis_array_impl.h
+++ b/redis_array_impl.h
@@ -13,7 +13,7 @@
 RedisArray *ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_long retry_interval, zend_bool b_lazy_connect TSRMLS_DC);
 RedisArray *ra_load_array(const char *name TSRMLS_DC);
 RedisArray *ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, zend_long retry_interval, zend_bool b_lazy_connect, double connect_timeout TSRMLS_DC);
-zval *ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC);
+zval *ra_find_node_by_name(RedisArray *ra, const char *host, size_t host_len TSRMLS_DC);
 zval *ra_find_node(RedisArray *ra, const char *key, size_t key_len, int *out_pos TSRMLS_DC);
 void ra_init_function_table(RedisArray *ra);
 

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -64,7 +64,7 @@ static inline redisCluster *php_redis_fetch_object(zend_object *obj) {
 #define CLUSTER_PROCESS_CMD(cmdname, resp_func, readcmd) \
     redisCluster *c = Z_REDIS_OBJ_P(getThis()); \
     c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
-    char *cmd; int cmd_len; short slot; void *ctx=NULL; \
+    char *cmd; size_t cmd_len; short slot; void *ctx=NULL; \
     if(redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,c->flags, &cmd, \
                              &cmd_len, &slot, &ctx)==FAILURE) { \
         RETURN_FALSE; \
@@ -84,7 +84,7 @@ static inline redisCluster *php_redis_fetch_object(zend_object *obj) {
 #define CLUSTER_PROCESS_KW_CMD(kw, cmdfunc, resp_func, readcmd) \
     redisCluster *c = Z_REDIS_OBJ_P(getThis()); \
     c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
-    char *cmd; int cmd_len; short slot; void *ctx=NULL; \
+    char *cmd; size_t cmd_len; short slot; void *ctx=NULL; \
     if(cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, kw, &cmd, &cmd_len,\
                &slot,&ctx)==FAILURE) { \
         RETURN_FALSE; \

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2953,9 +2953,16 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
         case REDIS_OPT_READ_TIMEOUT:
             redis_sock->read_timeout = atof(val_str);
             if(redis_sock->stream) {
-                read_tv.tv_sec  = (time_t)redis_sock->read_timeout;
+#ifdef PHP_WIN32
+                read_tv.tv_sec  = (long)redis_sock->read_timeout;
+                read_tv.tv_usec = (long)((redis_sock->read_timeout -
+                                         read_tv.tv_sec) * 1000000);
+#else
+				read_tv.tv_sec  = (time_t)redis_sock->read_timeout;
                 read_tv.tv_usec = (int)((redis_sock->read_timeout -
                                          read_tv.tv_sec) * 1000000);
+#endif
+
                 php_stream_set_option(redis_sock->stream,
                                       PHP_STREAM_OPTION_READ_TIMEOUT, 0,
                                       &read_tv);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -31,7 +31,7 @@
 
 /* A command that takes no arguments */
 int redis_empty_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char *kw, char **cmd, int *cmd_len, short *slot,
+                    char *kw, char **cmd, size_t *cmd_len, short *slot,
                     void **ctx)
 {
     *cmd_len = redis_cmd_format_static(cmd, kw, "");
@@ -41,7 +41,7 @@ int redis_empty_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 /* Helper to construct a raw command.  Given that the cluster and non cluster
  * versions are different (RedisCluster needs an additional argument to direct
  * the command) we take the start of our array and count */
-int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_DC)
+int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, size_t *cmd_len TSRMLS_DC)
 {
     smart_string cmdstr = {0};
     int i;
@@ -85,7 +85,7 @@ int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_
 
 /* Generic command where we just take a string and do nothing to it*/
 int redis_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw,
-                  char **cmd, int *cmd_len, short *slot, void **ctx)
+                  char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *arg;
     size_t arg_len;
@@ -105,7 +105,7 @@ int redis_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw,
 
 /* Key, long, zval (serialized) */
 int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                           char *kw, char **cmd, int *cmd_len, short *slot,
+                           char *kw, char **cmd, size_t *cmd_len, short *slot,
                            void **ctx)
 {
     char *key = NULL, *val=NULL;
@@ -139,7 +139,7 @@ int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic key, long, string (unserialized) */
 int redis_key_long_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                           char *kw, char **cmd, int *cmd_len, short *slot,
+                           char *kw, char **cmd, size_t *cmd_len, short *slot,
                            void **ctx)
 {
     char *key, *val;
@@ -171,7 +171,7 @@ int redis_key_long_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command construction when we just take a key and value */
 int redis_kv_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                 char *kw, char **cmd, int *cmd_len, short *slot,
+                 char *kw, char **cmd, size_t *cmd_len, short *slot,
                  void **ctx)
 {
     char *key, *val;
@@ -203,7 +203,7 @@ int redis_kv_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command that takes a key and an unserialized value */
 int redis_key_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char *kw, char **cmd, int *cmd_len, short *slot,
+                      char *kw, char **cmd, size_t *cmd_len, short *slot,
                       void **ctx)
 {
     char *key, *val;
@@ -230,7 +230,7 @@ int redis_key_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Key, string, string without serialization (ZCOUNT, ZREMRANGEBYSCORE) */
 int redis_key_str_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char *kw, char **cmd, int *cmd_len, short *slot,
+                          char *kw, char **cmd, size_t *cmd_len, short *slot,
                           void **ctx)
 {
     char *key, *val1, *val2;
@@ -262,7 +262,7 @@ int redis_key_str_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command that takes two keys */
 int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char *kw, char **cmd, int *cmd_len, short *slot,
+                      char *kw, char **cmd, size_t *cmd_len, short *slot,
                       void **ctx)
 {
     char *key1, *key2;
@@ -307,7 +307,7 @@ int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command construction where we take a key and a long */
 int redis_key_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                       char *kw, char **cmd, int *cmd_len, short *slot,
+                       char *kw, char **cmd, size_t *cmd_len, short *slot,
                        void **ctx)
 {
     char *key;
@@ -342,7 +342,7 @@ int redis_key_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* key, long, long */
 int redis_key_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                            char *kw, char **cmd, int *cmd_len, short *slot,
+                            char *kw, char **cmd, size_t *cmd_len, short *slot,
                             void **ctx)
 {
     char *key;
@@ -373,7 +373,7 @@ int redis_key_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command where we take a single key */
 int redis_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                  char *kw, char **cmd, int *cmd_len, short *slot,
+                  char *kw, char **cmd, size_t *cmd_len, short *slot,
                   void **ctx)
 {
     char *key;
@@ -402,7 +402,7 @@ int redis_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command where we take a key and a double */
 int redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char *kw, char **cmd, int *cmd_len, short *slot,
+                      char *kw, char **cmd, size_t *cmd_len, short *slot,
                       void **ctx)
 {
     char *key;
@@ -431,8 +431,8 @@ int redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 }
 
 /* Generic to construct SCAN and variant commands */
-int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
-                       long it, char *pat, int pat_len, long count)
+size_t redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len,
+                       zend_long it, char *pat, size_t pat_len, zend_long count)
 {
     static char *kw[] = {"SCAN","SSCAN","HSCAN","ZSCAN"};
     int argc;
@@ -470,7 +470,7 @@ int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
 
 /* ZRANGE/ZREVRANGE */
 int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char *kw, char **cmd, int *cmd_len, int *withscores,
+                     char *kw, char **cmd, size_t *cmd_len, int *withscores,
                      short *slot, void **ctx)
 {
     char *key;
@@ -505,7 +505,7 @@ int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZRANGEBYSCORE/ZREVRANGEBYSCORE */
 int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                            char *kw, char **cmd, int *cmd_len, int *withscores,
+                            char *kw, char **cmd, size_t *cmd_len, int *withscores,
                             short *slot, void **ctx)
 {
     char *key;
@@ -513,7 +513,7 @@ int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *start, *end;
     size_t key_len, start_len, end_len;
     int has_limit=0;
-    long limit_low, limit_high;
+    zend_long limit_low, limit_high;
     zval *z_opt=NULL, *z_ele;
     HashTable *ht_opt;
 
@@ -580,7 +580,7 @@ int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZUNIONSTORE, ZINTERSTORE */
 int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char *kw, char **cmd, int *cmd_len, short *slot,
+                     char *kw, char **cmd, size_t *cmd_len, short *slot,
                      void **ctx)
 {
     char *key, *agg_op=NULL;
@@ -747,7 +747,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SUBSCRIBE/PSUBSCRIBE */
 int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                        char *kw, char **cmd, int *cmd_len, short *slot,
+                        char *kw, char **cmd, size_t *cmd_len, short *slot,
                         void **ctx)
 {
     zval *z_arr, *z_chan;
@@ -811,7 +811,7 @@ int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* UNSUBSCRIBE/PUNSUBSCRIBE */
 int redis_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char *kw, char **cmd, int *cmd_len, short *slot,
+                          char *kw, char **cmd, size_t *cmd_len, short *slot,
                           void **ctx)
 {
     zval *z_arr, *z_chan;
@@ -857,7 +857,7 @@ int redis_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZRANGEBYLEX/ZREVRANGEBYLEX */
 int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char *kw, char **cmd, int *cmd_len, short *slot,
+                          char *kw, char **cmd, size_t *cmd_len, short *slot,
                           void **ctx)
 {
     char *key, *min, *max;
@@ -915,7 +915,7 @@ int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZLEXCOUNT/ZREMRANGEBYLEX */
 int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                       char *kw, char **cmd, int *cmd_len, short *slot,
+                       char *kw, char **cmd, size_t *cmd_len, short *slot,
                        void **ctx)
 {
     char *key, *min, *max;
@@ -957,7 +957,7 @@ int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 /* Commands that take a key followed by a variable list of serializable
  * values (RPUSH, LPUSH, SADD, SREM, etc...) */
 int redis_key_varval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                         char *kw, char **cmd, int *cmd_len, short *slot,
+                         char *kw, char **cmd, size_t *cmd_len, short *slot,
                          void **ctx)
 {
     zval *z_args;
@@ -1014,7 +1014,7 @@ int redis_key_varval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Commands that take a key and then an array of values */
 int redis_key_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char *kw, char **cmd, int *cmd_len, short *slot,
+                      char *kw, char **cmd, size_t *cmd_len, short *slot,
                       void **ctx)
 {
     zval *z_arr, *z_val;
@@ -1064,7 +1064,7 @@ int redis_key_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
  * commands. */
 static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                           char *kw, int kw_len, int min_argc, int has_timeout,
-                          char **cmd, int *cmd_len, short *slot)
+                          char **cmd, size_t *cmd_len, short *slot)
 {
     zval *z_args, *z_ele;
     HashTable *ht_arr;
@@ -1073,7 +1073,7 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 	size_t key_len;
     int single_array = 0, argc = ZEND_NUM_ARGS();
     smart_string cmdstr = {0};
-    long timeout;
+    zend_long timeout;
     short kslot = -1;
 
     if(argc < min_argc) {
@@ -1195,13 +1195,13 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SET */
 int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                  char **cmd, int *cmd_len, short *slot, void **ctx)
+                  char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     zval *z_value, *z_opts=NULL;
     char *key = NULL, *val = NULL, *exp_type = NULL, *set_type = NULL;
     int key_free, val_free;
     size_t key_len, val_len;
-    long expire = -1;
+    zend_long expire = -1;
 
     // Make sure the function is being called correctly
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|z", &key, &key_len,
@@ -1298,7 +1298,7 @@ int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BRPOPLPUSH */
 int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                         char **cmd, int *cmd_len, short *slot, void **ctx)
+                         char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key1, *key2;
     size_t key1_len, key2_len;
@@ -1353,7 +1353,7 @@ int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 /* Handle INCR(BY) and DECR(BY) depending on optional increment value */
 static int
 redis_atomic_increment(INTERNAL_FUNCTION_PARAMETERS, int type,
-                       RedisSock *redis_sock, char **cmd, int *cmd_len,
+                       RedisSock *redis_sock, char **cmd, size_t *cmd_len,
                        short *slot, void **ctx)
 {
     char *key;
@@ -1398,7 +1398,7 @@ redis_atomic_increment(INTERNAL_FUNCTION_PARAMETERS, int type,
 
 /* INCR */
 int redis_incr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU,
         TYPE_INCR, redis_sock, cmd, cmd_len, slot, ctx);
@@ -1406,7 +1406,7 @@ int redis_incr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* DECR */
 int redis_decr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU,
         TYPE_DECR, redis_sock, cmd, cmd_len, slot, ctx);
@@ -1414,7 +1414,7 @@ int redis_decr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HINCRBY */
 int redis_hincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key, *mem;
     size_t key_len, mem_len;
@@ -1445,7 +1445,7 @@ int redis_hincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HINCRBYFLOAT */
 int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                           char **cmd, int *cmd_len, short *slot, void **ctx)
+                           char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key, *mem;
     size_t key_len, mem_len;
@@ -1477,7 +1477,7 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HMGET */
 int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key;
     zval *z_arr, *z_mem, *z_mems;
@@ -1563,7 +1563,7 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HMSET */
 int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key;
     int key_free, count, ktype;
@@ -1605,7 +1605,7 @@ int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         zend_string *mem_zstring;
         int val_free;
 		size_t val_len;
-        unsigned int mem_len;
+        size_t mem_len;
         zval *z_val;
 
         // Grab our key, and value for this element in our input
@@ -1649,7 +1649,7 @@ int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BITPOS */
 int redis_bitpos_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key;
     int argc;
@@ -1691,7 +1691,7 @@ int redis_bitpos_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BITOP */
 int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     zval *z_args;
     char *key;
@@ -1754,7 +1754,7 @@ int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BITCOUNT */
 int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key;
     size_t key_len;
@@ -1785,7 +1785,7 @@ int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
  * and in the other case we key prefix */
 static int redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                             char *kw, int kw_len, int is_keys, char **cmd,
-                            int *cmd_len, short *slot)
+                            size_t *cmd_len, short *slot)
 {
     zval *z_arr, *z_ele;
     HashTable *ht_arr;
@@ -1896,7 +1896,7 @@ static int redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* PFADD */
 int redis_pfadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "PFADD", sizeof("PFADD")-1, 0, cmd, cmd_len, slot);
@@ -1904,7 +1904,7 @@ int redis_pfadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* PFMERGE */
 int redis_pfmerge_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "PFMERGE", sizeof("PFMERGE")-1, 1, cmd, cmd_len, slot);
@@ -1912,7 +1912,7 @@ int redis_pfmerge_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* PFCOUNT */
 int redis_pfcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     zval *z_keys, *z_key, z_tmp;
     HashTable *ht_keys;
@@ -2024,7 +2024,7 @@ int redis_pfcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 }
 
 int redis_auth_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *pw;
     size_t pw_len;
@@ -2048,7 +2048,7 @@ int redis_auth_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SETBIT */
 int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key;
     size_t key_len;
@@ -2082,7 +2082,7 @@ int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* LINSERT */
 int redis_linsert_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key, *pivot, *pos, *val;
     size_t key_len, pos_len;
@@ -2127,7 +2127,7 @@ int redis_linsert_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* LREM */
 int redis_lrem_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key, *val;
     size_t key_len;
@@ -2162,7 +2162,7 @@ int redis_lrem_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 }
 
 int redis_smove_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *src, *dst, *val;
     size_t src_len, dst_len, val_len;
@@ -2209,7 +2209,7 @@ int redis_smove_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic command construction for HSET and HSETNX */
 static int gen_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                        char *kw, char **cmd, int *cmd_len, short *slot)
+                        char *kw, char **cmd, size_t *cmd_len, short *slot)
 {
     char *key, *mem, *val;
     size_t mem_len, key_len, val_len;
@@ -2243,7 +2243,7 @@ static int gen_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HSET */
 int redis_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_hset_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, "HSET",
         cmd, cmd_len, slot);
@@ -2251,7 +2251,7 @@ int redis_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HSETNX */
 int redis_hsetnx_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_hset_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, "HSETNX",
         cmd, cmd_len, slot);
@@ -2259,7 +2259,7 @@ int redis_hsetnx_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SRANDMEMBER */
 int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char **cmd, int *cmd_len, short *slot, void **ctx,
+                          char **cmd, size_t *cmd_len, short *slot, void **ctx,
                           short *have_count)
 {
     char *key;
@@ -2299,7 +2299,7 @@ int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZINCRBY */
 int redis_zincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *key, *mem;
     size_t key_len, mem_len;
@@ -2331,7 +2331,7 @@ int redis_zincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SORT */
 int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   int *using_store, char **cmd, int *cmd_len, short *slot,
+                   int *using_store, char **cmd, size_t *cmd_len, short *slot,
                    void **ctx)
 {
     zval *z_opts=NULL, *z_ele, z_argv;
@@ -2499,6 +2499,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     {
         HashTable *ht_off = Z_ARRVAL_P(z_ele);
         zval *z_off, *z_cnt;
+        zend_long low, high;
 
         if((z_off = zend_hash_index_find(ht_off, 0)) != NULL &&
            (z_cnt = zend_hash_index_find(ht_off, 1)) != NULL)
@@ -2516,7 +2517,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             // Add LIMIT argument
             add_next_index_stringl(&z_argv,"LIMIT",sizeof("LIMIT")-1);
 
-            long low, high;
+
             if(Z_TYPE_P(z_off) == IS_STRING) {
                 low = atol(Z_STRVAL_P(z_off));
             } else {
@@ -2565,7 +2566,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* HDEL */
 int redis_hdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     zval *z_args;
     smart_string cmdstr = {0};
@@ -2620,7 +2621,7 @@ int redis_hdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* ZADD */
 int redis_zadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                   char **cmd, int *cmd_len, short *slot, void **ctx)
+                   char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     zval *z_args;
     char *key, *val;
@@ -2682,7 +2683,7 @@ int redis_zadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* OBJECT */
 int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     REDIS_REPLY_TYPE *rtype, char **cmd, int *cmd_len,
+                     REDIS_REPLY_TYPE *rtype, char **cmd, size_t *cmd_len,
                      short *slot, void **ctx)
 {
     char *key, *subcmd;
@@ -2726,7 +2727,7 @@ int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* DEL */
 int redis_del_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                  char **cmd, int *cmd_len, short *slot, void **ctx)
+                  char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "DEL", sizeof("DEL")-1, 1, 0, cmd, cmd_len, slot);
@@ -2734,7 +2735,7 @@ int redis_del_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* WATCH */
 int redis_watch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "WATCH", sizeof("WATCH")-1, 1, 0, cmd, cmd_len, slot);
@@ -2742,7 +2743,7 @@ int redis_watch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BLPOP */
 int redis_blpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "BLPOP", sizeof("BLPOP")-1, 2, 1, cmd, cmd_len, slot);
@@ -2750,7 +2751,7 @@ int redis_blpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* BRPOP */
 int redis_brpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "BRPOP", sizeof("BRPOP")-1, 1, 1, cmd, cmd_len, slot);
@@ -2758,7 +2759,7 @@ int redis_brpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SINTER */
 int redis_sinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "SINTER", sizeof("SINTER")-1, 1, 0, cmd, cmd_len, slot);
@@ -2766,7 +2767,7 @@ int redis_sinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SINTERSTORE */
 int redis_sinterstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char **cmd, int *cmd_len, short *slot, void **ctx)
+                          char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "SINTERSTORE", sizeof("SINTERSTORE")-1, 1, 0, cmd, cmd_len, slot);
@@ -2774,7 +2775,7 @@ int redis_sinterstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SUNION */
 int redis_sunion_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+                     char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "SUNION", sizeof("SUNION")-1, 1, 0, cmd, cmd_len, slot);
@@ -2782,7 +2783,7 @@ int redis_sunion_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SUNIONSTORE */
 int redis_sunionstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char **cmd, int *cmd_len, short *slot, void **ctx)
+                          char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "SUNIONSTORE", sizeof("SUNIONSTORE")-1, 2, 0, cmd, cmd_len, slot);
@@ -2790,7 +2791,7 @@ int redis_sunionstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SDIFF */
 int redis_sdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
+                    char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, "SDIFF",
         sizeof("SDIFF")-1, 1, 0, cmd, cmd_len, slot);
@@ -2798,7 +2799,7 @@ int redis_sdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* SDIFFSTORE */
 int redis_sdiffstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                         char **cmd, int *cmd_len, short *slot, void **ctx)
+                         char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         "SDIFFSTORE", sizeof("SDIFFSTORE")-1, 2, 0, cmd, cmd_len, slot);
@@ -2806,7 +2807,7 @@ int redis_sdiffstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* COMMAND */
 int redis_command_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                      char **cmd, int *cmd_len, short *slot, void **ctx)
+                      char **cmd, size_t *cmd_len, short *slot, void **ctx)
 {
     char *kw=NULL;
     zval *z_arg;
@@ -2974,7 +2975,7 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 val_long == REDIS_FAILOVER_ERROR ||
                 val_long == REDIS_FAILOVER_DISTRIBUTE)
             {
-                c->failover = val_long;
+                c->failover = (short) val_long;
                 RETURN_TRUE;
             } else {
                 RETURN_FALSE;

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -34,84 +34,84 @@ typedef struct subscribeContext {
 } subscribeContext;
 
 /* Construct a raw command */
-int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_DC);
+int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, size_t *cmd_len TSRMLS_DC);
 
 /* Redis command generics.  Many commands share common prototypes meaning that
  * we can write one function to handle all of them.  For example, there are
  * many COMMAND key value commands, or COMMAND key commands. */
 
 int redis_empty_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_long_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_kv_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_str_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_varval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_key_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 /* Construct SCAN and similar commands, as well as check iterator  */
 int redis_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    REDIS_SCAN_TYPE type, char **cmd, int *cmd_len);
+    REDIS_SCAN_TYPE type, char **cmd, size_t *cmd_len);
 
 /* ZRANGE, ZREVRANGE, ZRANGEBYSCORE, and ZREVRANGEBYSCORE callback type */
 typedef int (*zrange_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                         char *,char**,int*,int*,short*,void**);
+                         char *,char**,size_t*,int*,short*,void**);
 
 int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot,
+    char *kw, char **cmd, size_t *cmd_len, int *withscores, short *slot,
     void **ctx);
 
 int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot,
+    char *kw, char **cmd, size_t *cmd_len, int *withscores, short *slot,
     void **ctx);
 
 int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
+    char *kw, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 /* Commands which need a unique construction mechanism.  This is either because
  * they don't share a signature with any other command, or because there is
@@ -119,122 +119,122 @@ int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
  * unique */
 
 int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_incr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_decr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_bitpos_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_pfcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_pfadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_pfmerge_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_auth_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_linsert_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_lrem_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_smove_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hsetnx_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx, short *have_count);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx, short *have_count);
 
 int redis_zincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    int *using_store, char **cmd, int *cmd_len, short *slot, void **ctx);
+    int *using_store, char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_hdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_zadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    REDIS_REPLY_TYPE *rtype, char **cmd, int *cmd_len, short *slot,
+    REDIS_REPLY_TYPE *rtype, char **cmd, size_t *cmd_len, short *slot,
     void **ctx);
 
 int redis_del_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_watch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_blpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_brpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sinterstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sunion_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sunionstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_sdiffstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
 int redis_command_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, size_t *cmd_len, short *slot, void **ctx);
 
-int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
-                       long it, char *pat, int pat_len, long count);
+size_t redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, size_t key_len,
+                       zend_long it, char *pat, size_t pat_len, zend_long count);
 
 /* Commands that don't communicate with Redis at all (such as getOption,
  * setOption, _prefix, _serialize, etc).  These can be handled in one place

--- a/redis_session.c
+++ b/redis_session.c
@@ -206,7 +206,7 @@ PS_OPEN_FUNC(redis)
             int persistent = 0;
             int database = -1;
             char *prefix = NULL, *auth = NULL, *persistent_id = NULL;
-            long retry_interval = 0;
+            zend_long retry_interval = 0;
 
             /* translate unix: into file: */
             if (!strncmp(save_path+i, "unix:", sizeof("unix:")-1)) {


### PR DESCRIPTION
Work in progress to actually support 64bit in a cross platform manner  with php7.

long should be avoided at any price and zend_long should be used instead when interacting with php's integer.

size_t must be used for any buffer/string length or carefully casted.

work in progress, but 70% of the errors or warnings are fixed with that patch, will kill the rest as soon as possible so tests can be ran. It should not affect linux+gcc as it only uses internal php types for portability instead of using gcc moving targets for the  long types.

size_t usage may solve a couple of flaws on numerous platfroms incl linux
