### PR TITLE
Before unserializing a Redis value with igbinary, check if it actually contains the correct header

### DIFF
--- a/library.c
+++ b/library.c
@@ -2159,7 +2159,7 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
             /*
              * Check if the given string starts with an igbinary header.
              *
-             * An igbinary string consists of the following format:
+             * A modern igbinary string consists of the following format:
              *
              * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
              * | header (4) | type (1) | ... (n) |  NUL (1) |
@@ -2167,8 +2167,11 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
              *
              * With header being either 0x00000001 or 0x00000002
              * (encoded as big endian).
+             *
+             * Not all versions contain the trailing NULL byte though, so
+             * do not check for that.
              */
-            if (val_len < 6
+            if (val_len < 5
                     || (memcmp(val, "\x00\x00\x00\x01", 4) != 0
                     && memcmp(val, "\x00\x00\x00\x02", 4) != 0))
             {


### PR DESCRIPTION
The bug can be reproduced with this script:

```php
<?php
$r = new Redis();
$r->connect('localhost', 6379);
$r->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);

for ($i=0; $i < 1000; $i++) {
  $r->incr('a', -1);
}
var_dump($r->get('a'));
$r->del('a');
```

and will result in this output:

```
PHP Warning:  igbinary_unserialize_header: unsupported version: 758198320, should be 1 or 2 in /Users/mcuelenaere/Projects/phpredis/test.php on line 10
PHP Stack trace:
PHP   1. {main}() /Users/mcuelenaere/Projects/phpredis/test.php:0
PHP   2. Redis->get() /Users/mcuelenaere/Projects/phpredis/test.php:10

Warning: igbinary_unserialize_header: unsupported version: 758198320, should be 1 or 2 in /Users/mcuelenaere/Projects/phpredis/test.php on line 10

Call Stack:
    0.0007     232768   1. {main}() /Users/mcuelenaere/Projects/phpredis/test.php:0
    0.0404     242624   2. Redis->get() /Users/mcuelenaere/Projects/phpredis/test.php:10

string(5) "-1000"
```