### PR TITLE
Fix bug of unclosed socket stream in RedisCluster's construction

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -922,6 +922,7 @@ cluster_map_keyspace(redisCluster *c TSRMLS_DC) {
         if(!mapped && slots) {
             memset(c->master, 0, sizeof(redisClusterNode*)*REDIS_CLUSTER_SLOTS);
         }
+        redis_sock_disconnect(*seed TSRMLS_CC);
     }
 
     // Clean up slots reply if we got one


### PR DESCRIPTION
The socket stream in RedisCluster.seeds leave unclosed incorrectly.

Which cause crash when creating RedisCluster repeatedly，even if call close function in the loop.

And the error message show "Couldn't map cluster keyspace using any provided seed"