### PR TITLE
Fix to optional parameter (EX/NX) ordering for set command

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1258,9 +1258,9 @@ int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     /* Now let's construct the command we want */
     if(exp_type && set_type) {
         /* SET <key> <value> NX|XX PX|EX <timeout> */
-        *cmd_len = redis_cmd_format_static(cmd, "SET", "ssssl", key, key_len,
-                                           val, val_len, set_type, 2, exp_type,
-                                           2, expire);
+        *cmd_len = redis_cmd_format_static(cmd, "SET", "sssls", key, key_len,
+                                           val, val_len, exp_type, 2, expire,
+                                           set_type, 2);
     } else if(exp_type) {
         /* SET <key> <value> PX|EX <timeout> */
         *cmd_len = redis_cmd_format_static(cmd, "SET", "sssl", key, key_len,


### PR DESCRIPTION
When using `set` with a given key and value and with `EX`/`PX` and `NX` parameters, nothing actually gets set. A Redis query will return `nil` for that key. This is because Redis expects the `set` command in the following format: `SET key value [EX seconds] [PX milliseconds] [NX|XX]`.
Phpredis sends `NX`/`XX` before `EX`/`PX` , i.e. in the format: `SET key value [NX|XX] [EX seconds] [PX milliseconds]`. Reported in issue #793 
