### PR TITLE
Add msgpack serializer support to php7 branch

### DIFF
--- a/common.h
+++ b/common.h
@@ -75,6 +75,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_SERIALIZER_NONE        0
 #define REDIS_SERIALIZER_PHP         1
 #define REDIS_SERIALIZER_IGBINARY    2
+#define REDIS_SERIALIZER_MSGPACK     3
 
 /* SCAN options */
 #define REDIS_SCAN_NORETRY 0

--- a/library.h
+++ b/library.h
@@ -35,6 +35,7 @@ PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API void redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab);
 PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC);
 PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
+PHP_REDIS_API int redis_sock_read_multibulk_reply_vals(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
 PHP_REDIS_API void redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, int count, int unserialize);
 
 PHP_REDIS_API int redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -522,8 +522,13 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) 
         zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_ERROR"), REDIS_FAILOVER_ERROR TSRMLS_CC);
         zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_DISTRIBUTE"), REDIS_FAILOVER_DISTRIBUTE TSRMLS_CC);
     }
+
 #ifdef HAVE_REDIS_IGBINARY
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY TSRMLS_CC);
+#endif
+
+#ifdef HAVE_REDIS_MSGPACK
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_MSGPACK"), REDIS_SERIALIZER_MSGPACK TSRMLS_CC);
 #endif
 
     zend_declare_class_constant_stringl(ce, "AFTER", 5, "after", 5 TSRMLS_CC);

--- a/redis.c
+++ b/redis.c
@@ -1197,14 +1197,14 @@ PHP_METHOD(Redis, rPop)
 /* {{{ proto string Redis::blPop(string key1, string key2, ..., int timeout) */
 PHP_METHOD(Redis, blPop)
 {
-    REDIS_PROCESS_CMD(blpop, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_CMD(blpop, redis_sock_read_multibulk_reply_vals);
 }
 /* }}} */
 
 /* {{{ proto string Redis::brPop(string key1, string key2, ..., int timeout) */
 PHP_METHOD(Redis, brPop)
 {
-    REDIS_PROCESS_CMD(brpop, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_CMD(brpop, redis_sock_read_multibulk_reply_vals);
 }
 /* }}} */
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2928,6 +2928,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
 #ifdef HAVE_REDIS_IGBINARY
                 || val_long == REDIS_SERIALIZER_IGBINARY
 #endif
+#ifdef HAVE_REDIS_MSGPACK
+                || val_long == REDIS_SERIALIZER_MSGPACK
+#endif
                 || val_long == REDIS_SERIALIZER_PHP)
                 {
                     redis_sock->serializer = val_long;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3895,6 +3895,17 @@ class Redis_Test extends TestSuite
         }
     }
 
+    public function testSerializerMsgPack() {
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $this->checkSerializer(Redis::SERIALIZER_MSGPACK);
+
+            // with prefix
+            $this->redis->setOption(Redis::OPT_PREFIX, "test:");
+            $this->checkSerializer(Redis::SERIALIZER_MSGPACK);
+            $this->redis->setOption(Redis::OPT_PREFIX, "");
+        }
+    }
+
     private function checkSerializer($mode) {
 
         $this->redis->del('key');
@@ -4366,8 +4377,13 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->_serialize(new stdClass) === 'Object');
 
         $arr_serializers = Array(Redis::SERIALIZER_PHP);
+
         if(defined('Redis::SERIALIZER_IGBINARY')) {
             $arr_serializers[] = Redis::SERIALIZER_IGBINARY;
+        }
+
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $arr_serializers[] = Redis::SERIALIZER_MSGPACK;
         }
 
         foreach($arr_serializers as $mode) {
@@ -4390,8 +4406,13 @@ class Redis_Test extends TestSuite
         );
 
         $serializers = Array(Redis::SERIALIZER_PHP);
+
         if(defined('Redis::SERIALIZER_IGBINARY')) {
             $serializers[] = Redis::SERIALIZER_IGBINARY;
+        }
+
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $serializers[] = Redis::SERIALIZER_MSGPACK;
         }
 
         foreach($serializers as $mode) {


### PR DESCRIPTION
This adds working msgpack serializer support to the php7 branch

This is particularly useful for those who previously relied on igbinary and were left without a decent serializer when moving to php 7.

I'm currently testing in dev with no issues; will report updates after further testing, and on moving to production.
