### PR TITLE
Replace malloc/calloc/free with emalloc/ecalloc/efree

### DIFF
--- a/common.h
+++ b/common.h
@@ -114,7 +114,7 @@ typedef enum _PUBSUB_TYPE {
 
 #define MULTI_RESPONSE(callback) IF_MULTI_OR_PIPELINE() { \
     fold_item *f1, *current; \
-    f1 = malloc(sizeof(fold_item)); \
+    f1 = emalloc(sizeof(fold_item)); \
     f1->fun = (void *)callback; \
     f1->next = NULL; \
     current = redis_sock->current;\
@@ -124,8 +124,8 @@ typedef enum _PUBSUB_TYPE {
 
 #define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) request_item *tmp; \
     struct request_item *current_request;\
-    tmp = malloc(sizeof(request_item));\
-    tmp->request_str = calloc(cmd_len, 1);\
+    tmp = emalloc(sizeof(request_item));\
+    tmp->request_str = ecalloc(cmd_len, 1);\
     memcpy(tmp->request_str, cmd, cmd_len);\
     tmp->request_size = cmd_len;\
     tmp->next = NULL;\
@@ -147,7 +147,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_SAVE_CALLBACK(callback, closure_context) \
     IF_MULTI_OR_PIPELINE() { \
         fold_item *f1, *current; \
-        f1 = malloc(sizeof(fold_item)); \
+        f1 = emalloc(sizeof(fold_item)); \
         f1->fun = (void *)callback; \
         f1->ctx = closure_context; \
         f1->next = NULL; \

--- a/redis.c
+++ b/redis.c
@@ -2374,7 +2374,7 @@ free_reply_callbacks(zval *z_this, RedisSock *redis_sock) {
 
     for(fi = head; fi; ) {
         fold_item *fi_next = fi->next;
-        free(fi);
+        efree(fi);
         fi = fi_next;
     }
     redis_sock->head = NULL;
@@ -2382,8 +2382,8 @@ free_reply_callbacks(zval *z_this, RedisSock *redis_sock) {
 
     for(ri = redis_sock->pipeline_head; ri; ) {
         struct request_item *ri_next = ri->next;
-        free(ri->request_str);
-        free(ri);
+        efree(ri->request_str);
+        efree(ri);
         ri = ri_next;
     }
     redis_sock->pipeline_head = NULL;
@@ -2441,7 +2441,7 @@ PHP_METHOD(Redis, exec)
             total += ri->request_size;
         }
         if(total) {
-            request = malloc(total);
+            request = emalloc(total);
         }
 
         /* concatenate individual elements one by one in the target buffer */
@@ -2452,12 +2452,12 @@ PHP_METHOD(Redis, exec)
 
         if(request != NULL) {
             if (redis_sock_write(redis_sock, request, total TSRMLS_CC) < 0) {
-                free(request);
+                efree(request);
                 free_reply_callbacks(object, redis_sock);
                 redis_sock->mode = ATOMIC;
                 RETURN_FALSE;
             }
-               free(request);
+               efree(request);
         } else {
                 redis_sock->mode = ATOMIC;
                 free_reply_callbacks(object, redis_sock);


### PR DESCRIPTION
Any reasons to not use emalloc/efree here?