### PR TITLE
Bugfix in node_add_slot_range procedure

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -690,6 +690,7 @@ static void node_add_slot_range(redisClusterNode *node, unsigned short low,
         node->slots = node->slotstail = rl;
     } else {
         node->slotstail->next = rl;
+        node->slotstail = rl;
     }
 }
 


### PR DESCRIPTION
The loss of updating the 'slotstail' field will result in the loss of slot ranges if one master is in charge of several  separate slot-ranges, and then segment fault will happen.