### PR TITLE
Use static declarations for spl_ce_RuntimeException decl

### DIFF
--- a/library.c
+++ b/library.c
@@ -38,7 +38,6 @@
 
 extern zend_class_entry *redis_ce;
 extern zend_class_entry *redis_exception_ce;
-extern zend_class_entry *spl_ce_RuntimeException;
 
 /* Helper to reselect the proper DB number when we reconnect */
 static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {

--- a/redis.c
+++ b/redis.c
@@ -60,7 +60,7 @@ extern zend_class_entry *redis_cluster_ce;
 zend_class_entry *redis_ce;
 zend_class_entry *redis_exception_ce;
 extern zend_class_entry *redis_cluster_exception_ce;
-zend_class_entry *spl_ce_RuntimeException = NULL;
+static zend_class_entry *spl_ce_RuntimeException = NULL;
 
 extern zend_function_entry redis_array_functions[];
 extern zend_function_entry redis_cluster_functions[];

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -36,7 +36,7 @@ zend_class_entry *redis_cluster_ce;
 
 /* Exception handler */
 zend_class_entry *redis_cluster_exception_ce;
-zend_class_entry *spl_rte_ce = NULL;
+static zend_class_entry *spl_rte_ce = NULL;
 
 /* Argument info for HSCAN, SSCAN, HSCAN */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_kscan_cl, 0, 0, 2)


### PR DESCRIPTION
The null assignment to spl_ce_RuntimeException was causing a "missing symbol" error for other extensions that depend on the extern definitions in [`spl_exceptions.h`](https://github.com/php/php-src/blob/master/ext/spl/spl_exceptions.h). Similar to the Redis extension, PDO also has a function that resolves the SPL class on-demand (see: [here](https://github.com/php/php-src/blob/php-5.6.23/ext/pdo/pdo.c#L74)); however, they use a [static decl](https://github.com/php/php-src/blob/php-5.6.23/ext/pdo/pdo.c#L36) to avoid conflicting with SPL.

The second commit in this PR is just cleaning up an unused extern decl I came across. It's not related to the issue at hand.

See: https://github.com/mongodb/mongo-php-driver/issues/353