### PR TITLE
Partial fix for #836 + additional checking params

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -1795,7 +1795,7 @@ PHP_METHOD(Redis, select) {
         RETURN_FALSE;
     }
 
-    if (redis_sock_get(object, &redis_sock TSRMLS_CC, 0) < 0) {
+    if (dbNumber < 0 || redis_sock_get(object, &redis_sock TSRMLS_CC, 0) < 0) {
         RETURN_FALSE;
     }
 
@@ -2681,7 +2681,7 @@ PHP_METHOD(Redis, slaveof)
     {
         RETURN_FALSE;
     }
-    if (redis_sock_get(object, &redis_sock TSRMLS_CC, 0) < 0) {
+    if (port < 0 || redis_sock_get(object, &redis_sock TSRMLS_CC, 0) < 0) {
         RETURN_FALSE;
     }
 
@@ -3707,13 +3707,13 @@ PHP_METHOD(Redis, rawcommand) {
     zval **z_args;
 
     /* Sanity check on arguments */
-    z_args = emalloc(argc * sizeof(zval*));
     if (argc < 1) {
         php_error_docref(NULL TSRMLS_CC, E_WARNING,
             "Must pass at least one command keyword");
-        efree(z_args);
         RETURN_FALSE;
-    } else if (zend_get_parameters_array(ht, argc, z_args) == FAILURE) {
+    }
+    z_args = emalloc(argc * sizeof(zval*));
+    if (zend_get_parameters_array(ht, argc, z_args) == FAILURE) {
         php_error_docref(NULL TSRMLS_CC, E_WARNING,
             "Internal PHP error parsing arguments");
         efree(z_args);


### PR DESCRIPTION
Now it is difficult to set dbNumber after server reply... This PR partially fixed issue #836 (negative values are definitely incorrect).
I also added checking for negative port in `slaveof` command and memory allocation after `argc` checking in `rawcommand`
@michael-grunder, review please :)