### PR TITLE
BF: fix the 'Timed out attempting...' because of NULL stream using

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -53,9 +53,13 @@
 
 /* Lazy connect logic */
 #define CLUSTER_LAZY_CONNECT(s) \
-    if(s->lazy_connect) { \
-        s->lazy_connect = 0; \
+    if(!s->stream) { \
+      redis_sock_connect(s TSRMLS_CC); \
+    } else if(s->lazy_connect) { \
         redis_sock_server_open(s, 1 TSRMLS_CC); \
+    } \
+    if (s->stream) { \
+        s->lazy_connect = 0; \
     }
 
 /* Clear out our "last error" */


### PR DESCRIPTION
In our online long connection practice, sometimes there are persistent "Timed out attempting to find data in the correct node!" errors (which is report in cluster_library.c:1619)。
The reason path that causing this error is: when a connection is bad for some reasons, the 'redis_check_eof' procedure in CLUSTER_SEND_PAYLOAD macro will detect the error connection, and rebuild the connection, but if the connect cannot still be established after 10 times tries, 'redis_check_eof' procedure will exit with 'stream' being NULL, 'lazy_connect' being 0, 'status' being REDIS_SOCK_STATUS_FAILED, then this connect has no chance to be rebuilded again, even if the connection could be established。
So I add a stream NULL branch in CLUSTER_LAZY_CONNECT macro， and it works。
