### PR TITLE
Fix various memory leaks in allocating strings.

### DIFF
--- a/library.c
+++ b/library.c
@@ -1047,10 +1047,11 @@ PHP_REDIS_API void redis_parse_client_list_response(char *response, zval *z_resu
                     /* Add as a long or string, depending */
                     if(is_numeric == 1) {
                         add_assoc_long(&z_sub_result, key, atol(value));
-                        efree(value);
                     } else {
                         add_assoc_string(&z_sub_result, key, value);
                     }
+                    efree(value); // Either way, it doesn't use the original string.
+
                     // If we hit a '\n', then we can add this user to our list
                     if(*p == '\n') {
                         /* Add our user */


### PR DESCRIPTION
The fixes are limited to what are covered by tests/TestRedis.php

Command used to detect memory leaks (Anything mentioning redis):

```bash
USE_ZEND_ALLOC=0 ZEND_DONT_UNLOAD_MODULES=1 valgrind --leak-check=full \
    php --php-ini php.ini tests/TestRedis.php
```

- USE_ZEND_ALLOC uses malloc/free/etc instead of Zend's custom allocator
- ZEND_DONT_UNLOAD_MODULES allows valgrind to print the file and line
  numbers for a shared library (this extension)
- about valgrind: http://valgrind.org/docs/manual/quick-start.html

While the allocated memory would be cleaned up after the end of a request,
memory leaks might cause problems for long-running CLI scripts dealing
with hundreds of thousands of keys.

zval_get_string will do one of the following for a ZVAL:

1. If it is of type IS_STRING, it will increase the refcount and return that string (Unless the string isn't refcounted)
2. If it is not a string, it will create a new string with refcount 1 (Or a constant string which isn't refcounted)

In both cases, zend_string_release should be called on the result.

Several other places not listed in this PR should also be using zval_get_string instead of convert_to_string.

- In the case of zend_get_parameters and convert_to_string, the code efrees the array of parameters, but doesn't free the string that was created (e.g. if a number was converted to a string, the string wouldn't be garbage collected).