### PR TITLE
WIP for 875 on php7

### DIFF
--- a/common.h
+++ b/common.h
@@ -527,6 +527,7 @@ typedef enum _PUBSUB_TYPE {
                &cmd_len, NULL, &ctx)==FAILURE) { \
             RETURN_FALSE; \
     } \
+    get_persistent(redis_sock);\
     REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len); \
     IF_ATOMIC() { \
         resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx); \

--- a/common.h
+++ b/common.h
@@ -527,7 +527,7 @@ typedef enum _PUBSUB_TYPE {
                &cmd_len, NULL, &ctx)==FAILURE) { \
             RETURN_FALSE; \
     } \
-    get_persistent(redis_sock);\
+    get_persistent_redis(redis_sock);\
     REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len); \
     IF_ATOMIC() { \
         resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx); \

--- a/library.c
+++ b/library.c
@@ -66,7 +66,7 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
 
 
 /* Helper to ensure we always get the latest persistent stream in case its been closed */
- int get_persistent(RedisSock *redis_sock TSRMLS_DC) {
+ int get_persistent_redis(RedisSock *redis_sock TSRMLS_DC) {
     php_stream *stream = NULL;
     char *persistent_id;
     if (!redis_sock->persistent){

--- a/library.c
+++ b/library.c
@@ -78,7 +78,7 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
 
 
 /* Helper to ensure we always get the latest persistent stream in case its been closed */
- int get_persistent_redis(RedisSock *redis_sock TSRMLS_DC) {
+ int get_persistent_redis(RedisSock *redis_sock TSRMLS_CC) {
     php_stream *stream = NULL;
     char *persistent_id;
     if (!redis_sock->persistent){
@@ -94,7 +94,7 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
                 redis_sock->timeout);
         }
     }
-    switch(php_stream_from_persistent_id(persistent_id, &stream TSRMLS_DC)) {
+    switch(php_stream_from_persistent_id(persistent_id, &stream TSRMLS_CC)) {
       case PHP_STREAM_PERSISTENT_SUCCESS:
             /* use a 0 second timeout when checking if the socket
  *            * has already died */

--- a/library.c
+++ b/library.c
@@ -94,7 +94,7 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
                 redis_sock->timeout);
         }
     }
-    switch(php_stream_from_persistent_id(persistent_id, &stream)) {
+    switch(php_stream_from_persistent_id(persistent_id, &stream TSRMLS_DC)) {
       case PHP_STREAM_PERSISTENT_SUCCESS:
             /* use a 0 second timeout when checking if the socket
  *            * has already died */

--- a/library.h
+++ b/library.h
@@ -18,6 +18,7 @@ int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
 int redis_cmd_append_int(char **cmd, int cmd_len, int append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
+int get_persistent(RedisSock *redis_sock);
 
 PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len TSRMLS_DC);

--- a/library.h
+++ b/library.h
@@ -18,7 +18,7 @@ int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
 int redis_cmd_append_int(char **cmd, int cmd_len, int append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
-int get_persistent(RedisSock *redis_sock);
+int get_persistent_redis(RedisSock *redis_sock);
 
 PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len TSRMLS_DC);


### PR DESCRIPTION
Adding checking to make sure we don't close the stream  #965   Tested with:

```
<?php
//step 1
try{
    $redis1 = testRedis();
    if($redis1) {
        var_dump($redis1->get('xiyuan_test1'));
        echo "\n";
    }
}catch(\RedisException $e){
    echo 'redis error1: errno='.$e->getCode().' errmsg='.$e->getMessage()."\n";
}

//step 2
try{
    $redis2 = testRedis();
    sleep(10);
    if($redis2) {
        var_dump($redis2->get('xiyuan_test2'));   //  kill redis-server(/home/redis/bin/redis-server /home/redis/redis.conf && sleep 5 && ps -ef |grep redis |awk '{print $2}'|xargs kill -9) , force redis connection lost .
        echo "\n";
    }
}catch(\RedisException $e){
    echo 'redis error2: errno='.$e->getCode().' errmsg='.$e->getMessage()."\n";
}

//step 3
try{
    if($redis1){
        var_dump($redis1->get('xiyuan_test3'));  // at this line , core 
        echo "\n";
    }
}catch(\RedisException $e){
    echo 'redis error3: errno='.$e->getCode().' errmsg='.$e->getMessage()."\n";
}

function testRedis($ip='127.0.0.1',$port=6379,$timeout=0,$index=0){
    try{
        $instance = new \Redis();
        $instance->pconnect($ip, $port, $timeout);
        if($instance->select($index)){
            return $instance;
        }
    }catch(\RedisException $e){
        echo 'redis error4: errno='.$e->getCode().' errmsg='.$e->getMessage()."\n";
        return false;
    }
}
```

Output

```
 php redis.php
bool(false)

redis error2: errno=0 errmsg=Connection lost
redis error3: errno=0 errmsg=Connection lost
```
