### PR TITLE
memory leak in redis cluster

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1477,9 +1477,8 @@ PHP_REDIS_API void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
                               TSRMLS_CC) == 0)
         {
             CLUSTER_RETURN_STRING(c, resp, c->reply_len);
-        } else {
-            efree(resp);
         }
+        efree(resp);
     } else {
         zval z;
         if (redis_unserialize(c->flags, resp, c->reply_len, &z TSRMLS_CC)) {

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -116,7 +116,7 @@
 /* Helper to return a string value */
 #define CLUSTER_RETURN_STRING(c, str, len) \
     if(CLUSTER_IS_ATOMIC(c)) { \
-        RETURN_STRINGL(str, len); \
+        RETVAL_STRINGL(str, len); \
     } else { \
         add_next_index_stringl(&c->multi_resp, str, len); \
     } \


### PR DESCRIPTION
Reproduces on any cluster setup. Script to reproduce:

```
<?php

$redis = new \RedisCluster(NULL, ['localhost:6371'], 5, 5);

while (true) {
        $redis->get('key');
}
```
