### PR TITLE
php7 compatibility

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -862,7 +862,7 @@ PHP_REDIS_API void cluster_free(redisCluster *c) {
 /* Takes our input hash table and returns a straigt C array with elements,
  * which have been randomized.  The return value needs to be freed. */
 static zval **cluster_shuffle_seeds(HashTable *seeds, int *len) {
-    zval **z_seeds;
+    zval **z_seeds, *z_ele;
     int *map, i, count, index=0;
 
     /* How many */
@@ -877,12 +877,9 @@ static zval **cluster_shuffle_seeds(HashTable *seeds, int *len) {
     fyshuffle(map, count);
 
     /* Iterate over our source array and use our map to create a random list */
-    for (zend_hash_internal_pointer_reset(seeds);
-         zend_hash_has_more_elements(seeds) == SUCCESS;
-         zend_hash_move_forward(seeds))
-    {
-        z_seeds[map[index++]] = zend_hash_get_current_data(seeds);
-    }
+    ZEND_HASH_FOREACH_VAL(seeds, z_ele) {
+        z_seeds[map[index++]] = z_ele;
+    } ZEND_HASH_FOREACH_END();
 
     efree(map);
 

--- a/redis.c
+++ b/redis.c
@@ -1423,7 +1423,7 @@ PHP_REDIS_API void generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, char *sort,
     RedisSock *redis_sock;
     char *key = NULL, *pattern = NULL, *get = NULL, *store = NULL, *cmd;
     int cmd_len, key_free;
-    long sort_start = -1, sort_count = -1;
+    zend_long sort_start = -1, sort_count = -1;
     strlen_t key_len, pattern_len, get_len, store_len;
 
     int cmd_elements;
@@ -1773,7 +1773,7 @@ PHP_METHOD(Redis, select) {
 
     char *cmd;
     int cmd_len;
-    long dbNumber;
+    zend_long dbNumber;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol",
                                      &object, redis_ce, &dbNumber) == FAILURE) {
@@ -2199,7 +2199,7 @@ PHP_METHOD(Redis, multi)
     int response_len, cmd_len;
     char * response;
     zval *object;
-    long multi_value = MULTI;
+    zend_long multi_value = MULTI;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
                                      "O|l", &object, redis_ce, &multi_value)
@@ -2599,7 +2599,7 @@ PHP_METHOD(Redis, slaveof)
     RedisSock *redis_sock;
     char *cmd = "", *host = NULL;
     strlen_t host_len;
-    long port = 6379;
+    zend_long port = 6379;
     int cmd_len;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -2754,7 +2754,7 @@ PHP_METHOD(Redis, slowlog) {
     char *arg, *cmd;
     int cmd_len;
     strlen_t arg_len;
-    long option;
+    zend_long option;
     enum {SLOWLOG_GET, SLOWLOG_LEN, SLOWLOG_RESET} mode;
 
     // Make sure we can get parameters
@@ -2808,7 +2808,7 @@ PHP_METHOD(Redis, slowlog) {
 PHP_METHOD(Redis, wait) {
     zval *object;
     RedisSock *redis_sock;
-    long num_slaves, timeout;
+    zend_long num_slaves, timeout;
     char *cmd;
     int cmd_len;
 
@@ -3086,7 +3086,7 @@ PHP_METHOD(Redis, evalsha)
     char *cmd, *sha;
     int cmd_len;
     strlen_t sha_len;
-    long keys_count = 0;
+    zend_long keys_count = 0;
     RedisSock *redis_sock;
 
     if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -3124,7 +3124,7 @@ PHP_METHOD(Redis, eval)
     char *script, *cmd = "";
     int cmd_len;
     strlen_t script_len;
-    long keys_count = 0;
+    zend_long keys_count = 0;
 
     // Attempt to parse parameters
     if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -3283,7 +3283,7 @@ PHP_METHOD(Redis, migrate) {
     int cmd_len, key_free;
     strlen_t host_len, key_len;
     zend_bool copy=0, replace=0;
-    long port, dest_db, timeout;
+    zend_long port, dest_db, timeout;
 
     // Parse arguments
     if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -3723,7 +3723,7 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
     char *pattern=NULL, *cmd, *key=NULL;
     int cmd_len, num_elements, key_free=0;
     strlen_t key_len = 0, pattern_len = 0;
-    long count=0, iter;
+    zend_long count=0, iter;
 
     /* Different prototype depending on if this is a key based scan */
     if(type != TYPE_SCAN) {

--- a/redis_array.c
+++ b/redis_array.c
@@ -394,7 +394,7 @@ ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd, i
 	}
 
 	/* pass call through */
-	ZVAL_STRING(&z_fun, cmd);	/* method name */
+	ZVAL_STRINGL(&z_fun, cmd, cmd_len); /* method name */
 	z_callargs = ecalloc(argc + 1, sizeof(zval));
 
 	/* copy args to array */
@@ -714,7 +714,7 @@ PHP_METHOD(RedisArray, getOption)
 	zval *object, z_fun, z_args[1];
 	int i;
 	RedisArray *ra;
-	long opt;
+	zend_long opt;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol",
 				&object, redis_array_ce, &opt) == FAILURE) {
@@ -751,7 +751,7 @@ PHP_METHOD(RedisArray, setOption)
 	zval *object, z_fun, z_args[2];
 	int i;
 	RedisArray *ra;
-	long opt;
+	zend_long opt;
 	char *val_str;
 	strlen_t val_len;
 
@@ -792,7 +792,7 @@ PHP_METHOD(RedisArray, select)
     zval *object, z_fun, z_args[1];
 	int i;
 	RedisArray *ra;
-	long opt;
+	zend_long opt;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol",
 				&object, redis_array_ce, &opt) == FAILURE) {
@@ -1292,7 +1292,7 @@ PHP_METHOD(RedisArray, multi)
 	zval *z_redis;
 	char *host;
 	strlen_t host_len;
-	long multi_value = MULTI;
+	zend_long multi_value = MULTI;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Os|l",
 				&object, redis_array_ce, &host, &host_len, &multi_value) == FAILURE) {

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1902,7 +1902,7 @@ static void cluster_eval_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     int key_free, args_count=0, key_len;
     zval *z_arr=NULL, *z_ele;
     HashTable *ht_arr;
-    long num_keys = 0;
+    zend_long num_keys = 0;
     short slot = 0;
     smart_string cmdstr = {0};
     strlen_t lua_len;
@@ -2470,7 +2470,8 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
     short slot;
     zval *z_it;
     HashTable *hash;
-    long it, num_ele, count=0;
+    long it, num_ele;
+    zend_long count = 0;
 
     // Can't be in MULTI mode
     if(!CLUSTER_IS_ATOMIC(c)) {
@@ -2561,7 +2562,8 @@ PHP_METHOD(RedisCluster, scan) {
     int cmd_len;
     short slot;
     zval *z_it, *z_node;
-    long it, num_ele, count=0;
+    long it, num_ele;
+    zend_long count = 0;
 
     /* Treat as read-only */
     c->readonly = CLUSTER_IS_ATOMIC(c);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -111,7 +111,7 @@ int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key = NULL, *val=NULL;
     int val_len, val_free, key_free;
     strlen_t key_len;
-    long expire;
+    zend_long expire;
     zval *z_val;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slz", &key, &key_len,
@@ -145,7 +145,7 @@ int redis_key_long_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *val;
     strlen_t key_len, val_len;
     int key_free;
-    long lval;
+    zend_long lval;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sls", &key, &key_len,
                              &lval, &val, &val_len)==FAILURE)
@@ -316,7 +316,7 @@ int redis_key_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     int key_free;
     strlen_t key_len;
-    long lval;
+    zend_long lval;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &key, &key_len,
                              &lval)==FAILURE)
@@ -351,7 +351,7 @@ int redis_key_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     int key_free;
     strlen_t key_len;
-    long val1, val2;
+    zend_long val1, val2;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll", &key, &key_len,
                              &val1, &val2)==FAILURE)
@@ -479,7 +479,7 @@ int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     int key_free;
     strlen_t key_len;
-    long start, end;
+    zend_long start, end;
     zend_bool ws=0;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll|b", &key, &key_len,
@@ -857,7 +857,7 @@ int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *min, *max;
     strlen_t key_len, min_len, max_len;
     int key_free, argc = ZEND_NUM_ARGS();
-    long offset, count;
+    zend_long offset, count;
 
     /* We need either 3 or 5 arguments for this to be valid */
     if(argc != 3 && argc != 5) {
@@ -1285,7 +1285,7 @@ int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     strlen_t key1_len, key2_len;
     int key1_free, key2_free;
     short slot1, slot2;
-    long timeout;
+    zend_long timeout;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssl", &key1, &key1_len,
                              &key2, &key2_len, &timeout)==FAILURE)
@@ -1340,7 +1340,7 @@ redis_atomic_increment(INTERNAL_FUNCTION_PARAMETERS, int type,
     char *key;
     int key_free;
     strlen_t key_len;
-    long val = 1;
+    zend_long val = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &key, &key_len,
                               &val)==FAILURE)
@@ -1400,7 +1400,7 @@ int redis_hincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *mem;
     strlen_t key_len, mem_len;
     int key_free;
-    long byval;
+    zend_long byval;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssl", &key, &key_len,
                              &mem, &mem_len, &byval)==FAILURE)
@@ -1622,7 +1622,7 @@ int redis_bitpos_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 {
     char *key;
     int argc, key_free;
-    long bit, start, end;
+    zend_long bit, start, end;
     strlen_t key_len;
 
     argc = ZEND_NUM_ARGS();
@@ -1732,7 +1732,7 @@ int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     int key_free;
     strlen_t key_len;
-    long start = 0, end = -1;
+    zend_long start = 0, end = -1;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &key, &key_len,
                              &start, &end)==FAILURE)
@@ -2008,7 +2008,7 @@ int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     strlen_t key_len;
     int key_free;
-    long offset;
+    zend_long offset;
     zend_bool val;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slb", &key, &key_len,
@@ -2086,7 +2086,7 @@ int redis_lrem_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *val;
     strlen_t key_len, val_len;
     int key_free, val_free;
-    long count = 0;
+    zend_long count = 0;
     zval *z_val;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|l", &key, &key_len,
@@ -2218,7 +2218,7 @@ int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     strlen_t key_len;
     int key_free;
-    long count;
+    zend_long count;
 
     if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &key, &key_len,
                              &count)==FAILURE)
@@ -3048,7 +3048,7 @@ int redis_command_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                              RedisSock *redis_sock, redisCluster *c)
 {
-    long option;
+    zend_long option;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &option)
                               == FAILURE)
@@ -3079,7 +3079,8 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
 void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                              RedisSock *redis_sock, redisCluster *c)
 {
-    long option, val_long;
+    long val_long;
+    zend_long option;
     char *val_str;
     struct timeval read_tv;
     strlen_t val_len;


### PR DESCRIPTION
The 'l' specifier now expects a zend_long instead of a long
for zend_parse_parameters.