### PR TITLE
rebase msgpack pull request (#801) on develop branch

### DIFF
--- a/common.h
+++ b/common.h
@@ -436,6 +436,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_SERIALIZER_NONE        0
 #define REDIS_SERIALIZER_PHP         1
 #define REDIS_SERIALIZER_IGBINARY    2
+#define REDIS_SERIALIZER_MSGPACK     3
 
 /* SCAN options */
 #define REDIS_SCAN_NORETRY 0

--- a/config.m4
+++ b/config.m4
@@ -3,14 +3,16 @@ dnl config.m4 for extension redis
 
 PHP_ARG_ENABLE(redis, whether to enable redis support,
 dnl Make sure that the comment is aligned:
-[  --enable-redis           Enable redis support])
+[  --enable-redis               Enable redis support])
 
-PHP_ARG_ENABLE(redis-session, whether to enable sessions,
+PHP_ARG_ENABLE(redis-session, whether to disable sessions,
 [  --disable-redis-session      Disable session support], yes, no)
 
 PHP_ARG_ENABLE(redis-igbinary, whether to enable igbinary serializer support,
 [  --enable-redis-igbinary      Enable igbinary serializer support], no, no)
 
+PHP_ARG_ENABLE(redis-msgpack, whether to enable msgpack serializer support,
+[  --enable-redis-msgpack       Enable msgpack serializer support], no, no)
 
 if test "$PHP_REDIS" != "no"; then
 
@@ -30,7 +32,7 @@ dnl Check for igbinary
     elif test -f "$phpincludedir/ext/igbinary/igbinary.h"; then
       igbinary_inc_path="$phpincludedir"
     else
-      for i in php php4 php5 php6; do
+      for i in php php4 php5 php6 php7; do
         if test -f "$prefix/include/$i/ext/igbinary/igbinary.h"; then
           igbinary_inc_path="$prefix/include/$i"
         fi
@@ -57,6 +59,48 @@ dnl Check for igbinary
     PHP_ADD_INCLUDE($IGBINARY_EXT_DIR)
   else
     IGBINARY_INCLUDES=""
+    AC_MSG_RESULT([disabled])
+  fi
+
+dnl Check for msgpack
+  if test "$PHP_REDIS_MSGPACK" != "no"; then
+    AC_MSG_CHECKING([for msgpack includes])
+    msgpack_inc_path=""
+
+    if test -f "$abs_srcdir/include/php/ext/msgpack/php_msgpack.h"; then
+      msgpack_inc_path="$abs_srcdir/include/php"
+    elif test -f "$abs_srcdir/ext/msgpack/php_msgpack.h"; then
+      msgpack_inc_path="$abs_srcdir"
+    elif test -f "$phpincludedir/ext/msgpack/php_msgpack.h"; then
+      msgpack_inc_path="$phpincludedir"
+    else
+      for i in php php4 php5 php6 php7; do
+        if test -f "$prefix/include/$i/ext/msgpack/php_msgpack.h"; then
+          msgpack_inc_path="$prefix/include/$i"
+        fi
+      done
+    fi
+
+    if test "$msgpack_inc_path" = ""; then
+      AC_MSG_ERROR([Cannot find php_msgpack.h])
+    else
+      AC_MSG_RESULT([$msgpack_inc_path])
+    fi
+  fi
+
+  AC_MSG_CHECKING([for redis msgpack support])
+  if test "$PHP_REDIS_MSGPACK" != "no"; then
+    AC_MSG_RESULT([enabled])
+    AC_DEFINE(HAVE_REDIS_MSGPACK,1,[Whether redis msgpack serializer is enabled])
+    MSGPACK_INCLUDES="-I$msgpack_inc_path"
+    MSGPACK_EXT_DIR="$msgpack_inc_path/ext"
+    ifdef([PHP_ADD_EXTENSION_DEP],
+    [
+      PHP_ADD_EXTENSION_DEP(redis, msgpack)
+    ])
+    PHP_ADD_INCLUDE($MSGPACK_EXT_DIR)
+  else
+    MSGPACK_INCLUDES=""
     AC_MSG_RESULT([disabled])
   fi
 

--- a/library.c
+++ b/library.c
@@ -11,6 +11,9 @@
 #ifdef HAVE_REDIS_IGBINARY
 #include "igbinary/igbinary.h"
 #endif
+#ifdef HAVE_REDIS_MSGPACK
+#include "msgpack/php_msgpack.h"
+#endif
 #include <zend_exceptions.h>
 #include "php_redis.h"
 #include "library.h"
@@ -1733,6 +1736,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
     if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
         return -1;
     }
+
     if(php_stream_gets(redis_sock->stream, inbuf, 1024) == NULL) {
         REDIS_STREAM_CLOSE_MARK_FAILED(redis_sock);
         zend_throw_exception(redis_exception_ce, "read error on connection", 0 
@@ -1752,6 +1756,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
         }
         return -1;
     }
+
     numElems = atoi(inbuf+1);
     zval zv, *z_multi_result = &zv;
 #if (PHP_MAJOR_VERSION < 7)
@@ -1770,6 +1775,67 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
     /*zval_copy_ctor(return_value); */
     return 0;
 }
+
+/**
+ * redis_sock_read_multibulk_reply_vals
+ *
+ * This is identical to redis_sock_read_multibulk_reply except that it unserializes vals only, rather than rely on
+ * the chosen unserializer to silently return 0 after a failed attempt (which msgpack does not do).
+ *
+ * Perhaps not the optimal solution, but the easiest way to resolve the problem of failed attempts to
+ * unserialize a key that hadn't been serialized to begin with in blpop, brpop.
+ *
+ */
+PHP_REDIS_API int redis_sock_read_multibulk_reply_vals(INTERNAL_FUNCTION_PARAMETERS,
+                                                  RedisSock *redis_sock, zval *z_tab,
+                                                  void *ctx)
+{
+    char inbuf[1024];
+    int numElems, err_len;
+
+    if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
+        return -1;
+    }
+
+    if(php_stream_gets(redis_sock->stream, inbuf, 1024) == NULL) {
+        REDIS_STREAM_CLOSE_MARK_FAILED(redis_sock);
+        zend_throw_exception(redis_exception_ce, "read error on connection", 0
+        TSRMLS_CC);
+        return -1;
+    }
+
+    if(inbuf[0] != '*') {
+        IF_MULTI_OR_PIPELINE() {
+            add_next_index_bool(z_tab, 0);
+        } else {
+            if (inbuf[0] == '-') {
+                err_len = strlen(inbuf+1) - 2;
+                redis_sock_set_err(redis_sock, inbuf+1, err_len);
+            }
+            RETVAL_FALSE;
+        }
+        return -1;
+    }
+
+    numElems = atoi(inbuf+1);
+    zval zv, *z_multi_result = &zv;
+#if (PHP_MAJOR_VERSION < 7)
+    MAKE_STD_ZVAL(z_multi_result);
+#endif
+    array_init(z_multi_result); /* pre-allocate array for multi's results. */
+
+    redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
+                           z_multi_result, numElems, UNSERIALIZE_VALS);
+
+    IF_MULTI_OR_PIPELINE() {
+        add_next_index_zval(z_tab, z_multi_result);
+    } else {
+        RETVAL_ZVAL(z_multi_result, 0, 1);
+    }
+    /*zval_copy_ctor(return_value); */
+    return 0;
+}
+
 
 /* Like multibulk reply, but don't touch the values, they won't be unserialized
  * (this is used by HKEYS). */
@@ -2024,6 +2090,16 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len
 
             return 1;
 
+        case REDIS_SERIALIZER_MSGPACK:
+#ifdef HAVE_REDIS_MSGPACK
+            php_msgpack_serialize(&sstr, z TSRMLS_CC);
+            *val = estrndup(sstr.s->val, sstr.s->len);
+            *val_len = sstr.s->len;
+            smart_str_free(&sstr);
+
+            return 1;
+#endif
+            break;
         case REDIS_SERIALIZER_IGBINARY:
 #ifdef HAVE_REDIS_IGBINARY
             if(igbinary_serialize(&val8, (size_t *)&sz, z TSRMLS_CC) == 0) {
@@ -2034,6 +2110,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len
 #endif
             break;
     }
+
     return 0;
 }
 
@@ -2061,6 +2138,19 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
             PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 #else
             var_destroy(&var_hash);
+#endif
+            break;
+
+        case REDIS_SERIALIZER_MSGPACK:
+#ifdef HAVE_REDIS_MSGPACK
+            /*
+             * Would like to be able to check to see if a string is msgpack'd (like with igbinary, below),
+             * but I don't believe there's an easy way to do that as there's no consistent header or
+             * other simple indication of packed-ness in msgpacked binary sequences, as far as I know.
+             */
+
+            php_msgpack_unserialize(z_ret, (char *)val, (size_t)val_len TSRMLS_CC);
+            ret = 1;
 #endif
             break;
 
@@ -2098,6 +2188,7 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
 #endif
             break;
     }
+
     return ret;
 }
 

--- a/library.h
+++ b/library.h
@@ -40,6 +40,7 @@ PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock TSRMLS_DC);
 PHP_REDIS_API zval *redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab);
 PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC);
 PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
+PHP_REDIS_API int redis_sock_read_multibulk_reply_vals(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
 PHP_REDIS_API void redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, int count, int unserialize);
 
 PHP_REDIS_API int redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -551,6 +551,10 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) 
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY TSRMLS_CC);
 #endif
 
+#ifdef HAVE_REDIS_MSGPACK
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_MSGPACK"), REDIS_SERIALIZER_MSGPACK TSRMLS_CC);
+#endif
+
     zend_declare_class_constant_stringl(ce, "AFTER", 5, "after", 5 TSRMLS_CC);
     zend_declare_class_constant_stringl(ce, "BEFORE", 6, "before", 6 TSRMLS_CC);
 }
@@ -1200,14 +1204,14 @@ PHP_METHOD(Redis, rPop)
 /* {{{ proto string Redis::blPop(string key1, string key2, ..., int timeout) */
 PHP_METHOD(Redis, blPop)
 {
-    REDIS_PROCESS_CMD(blpop, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_CMD(blpop, redis_sock_read_multibulk_reply_vals);
 }
 /* }}} */
 
 /* {{{ proto string Redis::brPop(string key1, string key2, ..., int timeout) */
 PHP_METHOD(Redis, brPop)
 {
-    REDIS_PROCESS_CMD(brpop, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_CMD(brpop, redis_sock_read_multibulk_reply_vals);
 }
 /* }}} */
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3108,9 +3108,15 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
         case REDIS_OPT_SERIALIZER:
             val_long = atol(val_str);
             test_val = val_long == REDIS_SERIALIZER_NONE || val_long == REDIS_SERIALIZER_PHP;
+
 #ifdef HAVE_REDIS_IGBINARY
             test_val = test_val || val_long == REDIS_SERIALIZER_IGBINARY;
 #endif
+
+#ifdef HAVE_REDIS_MSGPACK
+        test_val = test_val || val_long == REDIS_SERIALIZER_MSGPACK;
+#endif
+
                 if(test_val)
                 {
                     redis_sock->serializer = val_long;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3927,6 +3927,17 @@ class Redis_Test extends TestSuite
         }
     }
 
+    public function testSerializerMsgPack() {
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $this->checkSerializer(Redis::SERIALIZER_MSGPACK);
+
+            // with prefix
+            $this->redis->setOption(Redis::OPT_PREFIX, "test:");
+            $this->checkSerializer(Redis::SERIALIZER_MSGPACK);
+            $this->redis->setOption(Redis::OPT_PREFIX, "");
+        }
+    }
+
     private function checkSerializer($mode) {
 
         $this->redis->del('key');
@@ -4398,8 +4409,13 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->_serialize(new stdClass) === 'Object');
 
         $arr_serializers = Array(Redis::SERIALIZER_PHP);
+
         if(defined('Redis::SERIALIZER_IGBINARY')) {
             $arr_serializers[] = Redis::SERIALIZER_IGBINARY;
+        }
+
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $arr_serializers[] = Redis::SERIALIZER_MSGPACK;
         }
 
         foreach($arr_serializers as $mode) {
@@ -4422,8 +4438,13 @@ class Redis_Test extends TestSuite
         );
 
         $serializers = Array(Redis::SERIALIZER_PHP);
+
         if(defined('Redis::SERIALIZER_IGBINARY')) {
             $serializers[] = Redis::SERIALIZER_IGBINARY;
+        }
+
+        if(defined('Redis::SERIALIZER_MSGPACK')) {
+            $serializers[] = Redis::SERIALIZER_MSGPACK;
         }
 
         foreach($serializers as $mode) {


### PR DESCRIPTION
Rebased PR #801 against develop branch - implementing msgpack serializer support - per request by @yatsukhnenko.

Limited testing indicates this works fine, though I have yet to put it on a development server; I'll plan to do that next week and will update here.

Also, would like to find a way to determine if a string/val is msgpacked so we know whether to unserialize it (like is now being done with igbinary in `redis_unserialize()`).  This would obviate the need for the `redis_sock_read_multibulk_reply_vals()` kluge.  Anyone have any ideas?  I looked at the msgpack spec., etc., for a bit, but don't have time for a deep dive.
