### PR TITLE
Various minor

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -343,7 +343,12 @@ static zend_function_entry redis_functions[] = {
 
      PHP_MALIAS(Redis, evaluate, eval, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, evaluateSha, evalsha, NULL, ZEND_ACC_PUBLIC)
+/* PHP_FE_END exists since 5.3.7 */
+#ifdef PHP_FE_END
+     PHP_FE_END
+#else
      {NULL, NULL, NULL}
+#endif
 };
 
 static const zend_module_dep redis_deps[] = {

--- a/redis.c
+++ b/redis.c
@@ -675,6 +675,11 @@ PHP_MINFO_FUNCTION(redis)
     php_info_print_table_start();
     php_info_print_table_header(2, "Redis Support", "enabled");
     php_info_print_table_row(2, "Redis Version", PHP_REDIS_VERSION);
+#ifdef HAVE_REDIS_IGBINARY
+    php_info_print_table_row(2, "Available serializers", "php, igbinary");
+#else
+    php_info_print_table_row(2, "Available serializers", "php");
+#endif
     php_info_print_table_end();
 }
 

--- a/redis.c
+++ b/redis.c
@@ -346,9 +346,18 @@ static zend_function_entry redis_functions[] = {
      {NULL, NULL, NULL}
 };
 
+static const zend_module_dep redis_deps[] = {
+#ifdef HAVE_REDIS_IGBINARY
+     ZEND_MOD_REQUIRED("igbinary")
+#endif
+     ZEND_MOD_END
+};
+
 zend_module_entry redis_module_entry = {
 #if ZEND_MODULE_API_NO >= 20010901
-     STANDARD_MODULE_HEADER,
+     STANDARD_MODULE_HEADER_EX,
+     NULL,
+     redis_deps,
 #endif
      "redis",
      NULL,


### PR DESCRIPTION
1/ add module dependency to not allow to load redis extension when igbinary is needed and disable

STANDARD_MODULE_HEADER_EX exists since 5.1.0
(probably the ZEND_MODULE_API_NO >= 20010901 can be removed... 4.2.0...)

2/ display serializers info

3/ use PHP_FE_END

Was {NULL, NULL, NULL} up to 5.3.6
PHP_FE_END exists since 5.3.7 and is define differently (as { NULL, NULL, NULL, 0, 0 })