### PR TITLE
redis_array_object

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -43,7 +43,6 @@
 #define R_SUB_CLOSURE_TYPE 3
 
 int le_redis_sock;
-extern int le_redis_array;
 
 #ifdef PHP_SESSION
 extern ps_module ps_mod_redis;
@@ -583,23 +582,14 @@ PHP_MINIT_FUNCTION(redis)
     redis_ce = zend_register_internal_class(&redis_class_entry TSRMLS_CC);
 
     /* RedisArray class */
-    INIT_CLASS_ENTRY(redis_array_class_entry, "RedisArray",
-        redis_array_functions);
-    redis_array_ce = zend_register_internal_class(&redis_array_class_entry
-        TSRMLS_CC);
+    INIT_CLASS_ENTRY(redis_array_class_entry, "RedisArray", redis_array_functions);
+    redis_array_ce = zend_register_internal_class(&redis_array_class_entry TSRMLS_CC);
+    redis_array_ce->create_object = create_redis_array_object;
 
     /* RedisCluster class */
-    INIT_CLASS_ENTRY(redis_cluster_class_entry, "RedisCluster",
-        redis_cluster_functions);
-    redis_cluster_ce = zend_register_internal_class(&redis_cluster_class_entry
-        TSRMLS_CC);
+    INIT_CLASS_ENTRY(redis_cluster_class_entry, "RedisCluster", redis_cluster_functions);
+    redis_cluster_ce = zend_register_internal_class(&redis_cluster_class_entry TSRMLS_CC);
     redis_cluster_ce->create_object = create_cluster_context;
-
-    le_redis_array = zend_register_list_destructors_ex(
-        redis_destructor_redis_array,
-        NULL,
-        "Redis Array", module_number
-    );
 
     /* RedisException class */
     INIT_CLASS_ENTRY(redis_exception_class_entry, "RedisException", NULL);

--- a/redis_array.h
+++ b/redis_array.h
@@ -58,5 +58,13 @@ typedef struct RedisArray_ {
 
 uint32_t rcrc32(const char *s, size_t sz);
 
+#if (PHP_MAJOR_VERSION < 7)
+zend_object_value create_redis_array_object(zend_class_entry *ce TSRMLS_DC);
+void free_redis_array_object(void *object TSRMLS_DC);
+#else
+zend_object *create_redis_array_object(zend_class_entry *ce TSRMLS_DC);
+void free_redis_array_object(zend_object *object);
+#endif
+
 
 #endif

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -1176,6 +1176,8 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, const char *hostname, zend_bool 
 		count = ra_rehash_scan(z_redis, &keys, &key_lens, "KEYS", "*" TSRMLS_CC);
 	}
 
+    if (count < 0) return;
+
 	/* callback */
 	if(z_cb && z_cb_cache) {
         ZVAL_NULL(&z_ret);


### PR DESCRIPTION
Using custom objects instead of zend list entry for storing RedisArray data structure.
This avoid double hash lookup every call