### PR TITLE
Fix Null Bulk String response parsing in cluster library

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1870,10 +1870,10 @@ PHP_REDIS_API void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisClust
                 RETVAL_TRUE;
                 break;
             case TYPE_BULK:
-                if (r->len > 0) {
-                    RETVAL_STRINGL(r->str, r->len);
-                } else {
+                if (r->len < 0) {
                     RETVAL_NULL();
+                } else {
+                    RETVAL_STRINGL(r->str, r->len);
                 }
                 break;
             case TYPE_MULTIBULK:
@@ -1900,8 +1900,12 @@ PHP_REDIS_API void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisClust
                 add_next_index_bool(&c->multi_resp, 1);
                 break;
             case TYPE_BULK:
-                add_next_index_stringl(&c->multi_resp, r->str, r->len);
-                efree(r->str);
+                if (r->len < 0) {
+                    add_next_index_null(&c->multi_resp);
+                } else {
+                    add_next_index_stringl(&c->multi_resp, r->str, r->len);
+                    efree(r->str);
+                }
                 break;
             case TYPE_MULTIBULK:
                 cluster_mbulk_variant_resp(r, &c->multi_resp);

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1870,7 +1870,7 @@ PHP_REDIS_API void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisClust
                 RETVAL_TRUE;
                 break;
             case TYPE_BULK:
-                if (r->len > -1) {
+                if (r->len > 0) {
                     RETVAL_STRINGL(r->str, r->len);
                 } else {
                     RETVAL_NULL();

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1870,7 +1870,11 @@ PHP_REDIS_API void cluster_variant_resp(INTERNAL_FUNCTION_PARAMETERS, redisClust
                 RETVAL_TRUE;
                 break;
             case TYPE_BULK:
-                RETVAL_STRINGL(r->str, r->len);
+                if (r->len > -1) {
+                    RETVAL_STRINGL(r->str, r->len);
+                } else {
+                    RETVAL_NULL();
+                }
                 break;
             case TYPE_MULTIBULK:
                 array_init(z_arr);

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -345,6 +345,21 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue(1 === $this->redis->eval($scr,Array($str_key), 1));
         $this->assertTrue(1 === $this->redis->evalsha($sha,Array($str_key), 1));
     }
+    
+    public function testEvalBulkResponse() {
+        $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';
+        $str_key2 = uniqid() . '-' . rand(1,1000) . '{hash}';
+
+        $this->redis->script($str_key1, 'flush');
+        $this->redis->script($str_key2, 'flush');
+
+        $scr = "return {KEYS[1],KEYS[2]}";
+
+        $result = $this->redis->eval($scr,Array($str_key1, $str_key2), 2);
+
+        $this->assertTrue($str_key1 === $result[0]);
+        $this->assertTrue($str_key2 === $result[1]);
+    }
 
     public function testEvalBulkEmptyResponse() {
         $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -361,6 +361,24 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue($str_key2 === $result[1]);
     }
 
+    public function testEvalBulkResponseMulti() {
+        $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';
+        $str_key2 = uniqid() . '-' . rand(1,1000) . '{hash}';
+
+        $this->redis->script($str_key1, 'flush');
+        $this->redis->script($str_key2, 'flush');
+
+        $scr = "return {KEYS[1],KEYS[2]}";
+
+        $this->redis->multi();
+        $this->redis->eval($scr,Array($str_key1, $str_key2), 2);
+
+        $result = $this->redis->exec();
+
+        $this->assertTrue($str_key1 === $result[0][0]);
+        $this->assertTrue($str_key2 === $result[0][1]);
+    }
+
     public function testEvalBulkEmptyResponse() {
         $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';
         $str_key2 = uniqid() . '-' . rand(1,1000) . '{hash}';
@@ -373,6 +391,22 @@ class Redis_Cluster_Test extends Redis_Test {
         $result = $this->redis->eval($scr,Array($str_key1, $str_key2), 2);
 
         $this->assertTrue(null === $result);
+    }
+
+    public function testEvalBulkEmptyResponseMulti() {
+        $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';
+        $str_key2 = uniqid() . '-' . rand(1,1000) . '{hash}';
+
+        $this->redis->script($str_key1, 'flush');
+        $this->redis->script($str_key2, 'flush');
+
+        $scr = "for _,key in ipairs(KEYS) do redis.call('SET', key, 'value') end";
+
+        $this->redis->multi();
+        $this->redis->eval($scr,Array($str_key1, $str_key2), 2);
+        $result = $this->redis->exec();
+
+        $this->assertTrue(null === $result[0]);
     }
 
     /* Cluster specific introspection stuff */

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -346,6 +346,20 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue(1 === $this->redis->evalsha($sha,Array($str_key), 1));
     }
 
+    public function testEvalBulkEmptyResponse() {
+        $str_key1 = uniqid() . '-' . rand(1,1000) . '{hash}';
+        $str_key2 = uniqid() . '-' . rand(1,1000) . '{hash}';
+
+        $this->redis->script($str_key1, 'flush');
+        $this->redis->script($str_key2, 'flush');
+
+        $scr = "for _,key in ipairs(KEYS) do redis.call('SET', key, 'value') end";
+
+        $result = $this->redis->eval($scr,Array($str_key1, $str_key2), 2);
+
+        $this->assertTrue(null === $result);
+    }
+
     /* Cluster specific introspection stuff */
     public function testIntrospection() {
         $arr_masters = $this->redis->_masters();


### PR DESCRIPTION
This PR fixes an issue when running LUA commands that don't return any values in a cluster context. In these cases, Redis will return a Null Bulk String as specified in the protocol:

> RESP Bulk Strings can also be used in order to signal non-existence of a value using a special format that is used to represent a Null value. In this special format the length is -1, and there is no data, so a Null is represented as:
> 
> "$-1\r\n"
> 
> This is called a Null Bulk String.
> 
> The client library API should not return an empty string, but a nil object, when the server replies with a Null Bulk String. For example a Ruby library should return 'nil' while a C library should return NULL (or set a special flag in the reply object), and so forth.

Right now, this case is not handled and it causes and immediate Segmentation fault, because the RETVAL_STRINGL is trying to make sense of a bulk string response with no length at all. The issue is easily reproducible: just pick the failing test commit and run the test against your cluster. You should see an immediate Segmentation fault.

The issue is solved by returning a NULL value when the length is -1, as specified in the Redis protocol documentation.

Maintainers of this repository will probably know a better and more proper way of solving this issue, but here is my two-cents.

Props to @ajdiaz and @josledp for helping to find this issue!