### PR TITLE
refactoring

### DIFF
--- a/common.h
+++ b/common.h
@@ -22,7 +22,6 @@ typedef struct {
     char *val;
 } zend_string;
 
-
 #define zend_string_release(s) do { \
     if ((s) && (s)->gc) { \
         if ((s)->gc & 0x10 && (s)->val) efree((s)->val); \
@@ -475,18 +474,15 @@ typedef enum _PUBSUB_TYPE {
 #define IF_NOT_PIPELINE() if (redis_sock->mode != PIPELINE)
 
 #define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) do { \
-    request_item *tmp = malloc(sizeof(request_item)); \
-    tmp->request_str = calloc(cmd_len, 1);\
-    memcpy(tmp->request_str, cmd, cmd_len);\
-    tmp->request_size = cmd_len;\
-    tmp->next = NULL;\
-    if (redis_sock->pipeline_current) { \
-        redis_sock->pipeline_current->next = tmp; \
+    if (redis_sock->pipeline_cmd == NULL) { \
+        redis_sock->pipeline_cmd = estrndup(cmd, cmd_len); \
+    } else { \
+        redis_sock->pipeline_cmd = erealloc(redis_sock->pipeline_cmd, \
+            redis_sock->pipeline_len + cmd_len); \
+        memcpy(&redis_sock->pipeline_cmd[redis_sock->pipeline_len], \
+            cmd, cmd_len); \
     } \
-    redis_sock->pipeline_current = tmp; \
-    if(NULL == redis_sock->pipeline_head) { \
-        redis_sock->pipeline_head = redis_sock->pipeline_current;\
-    } \
+    redis_sock->pipeline_len += cmd_len; \
 } while (0)
 
 #define SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len) \
@@ -633,8 +629,8 @@ typedef struct {
     fold_item      *head;
     fold_item      *current;
 
-    request_item   *pipeline_head;
-    request_item   *pipeline_current;
+    char           *pipeline_cmd;
+    size_t         pipeline_len;
 
     char           *err;
     int            err_len;

--- a/library.c
+++ b/library.c
@@ -1522,8 +1522,9 @@ redis_sock_create(char *host, int host_len, unsigned short port, double timeout,
     redis_sock->mode = ATOMIC;
     redis_sock->head = NULL;
     redis_sock->current = NULL;
-    redis_sock->pipeline_head = NULL;
-    redis_sock->pipeline_current = NULL;
+
+    redis_sock->pipeline_cmd = NULL;
+    redis_sock->pipeline_len = 0;
 
     redis_sock->err = NULL;
     redis_sock->err_len = 0;
@@ -1938,6 +1939,9 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
 {
     if(redis_sock->prefix) {
         efree(redis_sock->prefix);
+    }
+    if (redis_sock->pipeline_cmd) {
+        efree(redis_sock->pipeline_cmd);
     }
     if(redis_sock->err) {
         efree(redis_sock->err);

--- a/redis.c
+++ b/redis.c
@@ -429,7 +429,6 @@ static void
 free_reply_callbacks(RedisSock *redis_sock)
 {
     fold_item *fi;
-    request_item *ri;
 
     for (fi = redis_sock->head; fi; ) {
         fold_item *fi_next = fi->next;
@@ -438,15 +437,6 @@ free_reply_callbacks(RedisSock *redis_sock)
     }
     redis_sock->head = NULL;
     redis_sock->current = NULL;
-
-    for (ri = redis_sock->pipeline_head; ri; ) {
-        struct request_item *ri_next = ri->next;
-        free(ri->request_str);
-        free(ri);
-        ri = ri_next;
-    }
-    redis_sock->pipeline_head = NULL;
-    redis_sock->pipeline_current = NULL;
 }
 
 #if (PHP_MAJOR_VERSION < 7)
@@ -2394,36 +2384,24 @@ PHP_METHOD(Redis, exec)
     }
 
     IF_PIPELINE() {
-        char *request = NULL;
-        int total = 0, offset = 0;
-        struct request_item *ri;
-
-        /* compute the total request size */
-        for(ri = redis_sock->pipeline_head; ri; ri = ri->next) {
-            total += ri->request_size;
-        }
-        if (total) {
-            request = emalloc(total + 1);
-            /* concatenate individual elements one by one in the target buffer */
-            for (ri = redis_sock->pipeline_head; ri; ri = ri->next) {
-                memcpy(request + offset, ri->request_str, ri->request_size);
-                offset += ri->request_size;
-            }
-            request[total] = '\0';
-            if (redis_sock_write(redis_sock, request, total TSRMLS_CC) < 0) {
+        if (redis_sock->pipeline_cmd == NULL) {
+            /* Empty array when no command was run. */
+            array_init(return_value);
+        } else {
+            if (redis_sock_write(redis_sock, redis_sock->pipeline_cmd,
+                    redis_sock->pipeline_len TSRMLS_CC) < 0) {
                 ZVAL_FALSE(return_value);
             } else {
                 array_init(return_value);
                 redis_sock_read_multibulk_multi_reply_loop(
                     INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, return_value, 0);
             }
-            efree(request);
-        } else {
-            /* Empty array when no command was run. */
-            array_init(return_value);
+            efree(redis_sock->pipeline_cmd);
+            redis_sock->pipeline_cmd = NULL;
+            redis_sock->pipeline_len = 0;
         }
-        redis_sock->mode = ATOMIC;
         free_reply_callbacks(redis_sock);
+        redis_sock->mode = ATOMIC;
     }
 }
 


### PR DESCRIPTION
In pipeline mode all commands are now stored in the buffer
the memory for which is allocated with emalloc.
There is no need to use a linked list.