### PR TITLE
refactoring

### DIFF
--- a/common.h
+++ b/common.h
@@ -434,9 +434,9 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_PREFIX             2
 #define REDIS_OPT_READ_TIMEOUT       3
 #define REDIS_OPT_SCAN               4
+#define REDIS_OPT_FAILOVER           5
 
 /* cluster options */
-#define REDIS_OPT_FAILOVER               5
 #define REDIS_FAILOVER_NONE              0
 #define REDIS_FAILOVER_ERROR             1
 #define REDIS_FAILOVER_DISTRIBUTE        2

--- a/redis.c
+++ b/redis.c
@@ -38,10 +38,6 @@
 
 #include "library.h"
 
-#define R_SUB_CALLBACK_CLASS_TYPE 1
-#define R_SUB_CALLBACK_FT_TYPE 2
-#define R_SUB_CLOSURE_TYPE 3
-
 #ifdef PHP_SESSION
 extern ps_module ps_mod_redis;
 extern ps_module ps_mod_redis_cluster;
@@ -2366,7 +2362,7 @@ PHP_METHOD(Redis, exec)
 {
     RedisSock *redis_sock;
     char *cmd;
-    int cmd_len;
+    int cmd_len, ret;
     zval *object;
 
     if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
@@ -2381,19 +2377,15 @@ PHP_METHOD(Redis, exec)
         SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len)
         efree(cmd);
 
-        if(redis_sock_read_multibulk_multi_reply(
-           INTERNAL_FUNCTION_PARAM_PASSTHRU,
-           redis_sock) < 0)
-        {
-            zval_dtor(return_value);
-            free_reply_callbacks(redis_sock);
-            redis_sock->mode = ATOMIC;
-            redis_sock->watching = 0;
-            RETURN_FALSE;
-        }
+        ret = redis_sock_read_multibulk_multi_reply(
+            INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
         free_reply_callbacks(redis_sock);
         redis_sock->mode = ATOMIC;
         redis_sock->watching = 0;
+        if (ret < 0) {
+            zval_dtor(return_value);
+            RETURN_FALSE;
+        }
     }
 
     IF_PIPELINE() {

--- a/redis_array.h
+++ b/redis_array.h
@@ -8,8 +8,6 @@
 #endif
 #include "common.h"
 
-void redis_destructor_redis_array(zend_resource * rsrc TSRMLS_DC);
-
 PHP_METHOD(RedisArray, __construct);
 PHP_METHOD(RedisArray, __call);
 PHP_METHOD(RedisArray, _hosts);


### PR DESCRIPTION
Fix memory leak in `redis_long_response` when LONG_MAX overflow.
Add return -1 in `redis_read_reply_type` when `php_stream_getc` returns EOF.
Code formatting in `PHP_METHOD(Redis, exec)`.