### PR TITLE
fixed duplicate 'install' typo and update the homebrew-php link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,9 +72,9 @@ Taken from [Compiling phpredis on Zend Server CE/OSX ](http://www.tumblr.com/tag
 
 See also: [Install Redis & PHP Extension PHPRedis with Macports](http://www.lecloud.net/post/3378834922/install-redis-php-extension-phpredis-with-macports).
 
-You can install install it using Homebrew:
+You can install it using Homebrew:
 
-- [Get homebrew-php](https://github.com/josegonzalez/homebrew-php)
+- [Get homebrew-php](https://github.com/Homebrew/homebrew-php)
 - `brew install php55-redis` (or php53-redis, php54-redis)
 
 ## PHP Session handler


### PR DESCRIPTION
1. delete the duplicate "install"
2. update the homebrew-php link