### PR TITLE
Using ZVAL_DEREF macros for dereference input variables.

### DIFF
--- a/common.h
+++ b/common.h
@@ -373,6 +373,9 @@ typedef int strlen_t;
 #define PHP_FE_END { NULL, NULL, NULL }
 #endif
 
+/* References don't need any actions */
+#define ZVAL_DEREF(v) PHPREDIS_NOTUSED(v)
+
 #else
 #include <zend_smart_str.h>
 #include <ext/standard/php_smart_string.h>

--- a/redis.c
+++ b/redis.c
@@ -2379,6 +2379,7 @@ PHP_REDIS_API void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS,
     }
 
     ZEND_HASH_FOREACH_VAL(arr_hash, data) {
+        ZVAL_DEREF(data);
         if (Z_TYPE_P(data) == IS_STRING) {
             char *old_cmd = NULL;
             if(*cmd) {

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -439,7 +439,7 @@ int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         ZEND_HASH_FOREACH_KEY_VAL(ht_opt, idx, zkey, z_ele) {
            /* All options require a string key type */
            if (!zkey) continue;
-
+           ZVAL_DEREF(z_ele);
            /* Check for withscores and limit */
            if (IS_WITHSCORES_ARG(zkey->val, zkey->len)) {
                *withscores = zval_is_true(z_ele);
@@ -587,7 +587,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         // Process our weights
         ZEND_HASH_FOREACH_VAL(ht_weights, z_ele) {
             // Ignore non numeric args unless they're inf/-inf
-
+            ZVAL_DEREF(z_ele);
             switch (Z_TYPE_P(z_ele)) {
                 case IS_LONG:
                     redis_cmd_append_sstr_long(&cmdstr, Z_LVAL_P(z_ele));
@@ -1146,6 +1146,7 @@ int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
         /* Iterate our option array */
         ZEND_HASH_FOREACH_KEY_VAL(kt, idx, zkey, v) {
+            ZVAL_DEREF(v);
             /* Detect PX or EX argument and validate timeout */
             if (zkey && IS_EX_PX_ARG(zkey->val)) {
                 /* Set expire type */
@@ -1381,6 +1382,7 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     // Iterate over our member array
     ZEND_HASH_FOREACH_VAL(ht_arr, z_mem) {
+        ZVAL_DEREF(z_mem);
         // We can only handle string or long values here
         if ((Z_TYPE_P(z_mem) == IS_STRING && Z_STRLEN_P(z_mem) > 0)
             || Z_TYPE_P(z_mem) == IS_LONG
@@ -2539,6 +2541,7 @@ static void get_georadius_opts(HashTable *ht, int *withcoord, int *withdist,
 
     /* Iterate over our argument array, collating which ones we have */
     ZEND_HASH_FOREACH_KEY_VAL(ht, idx, zkey, optval) {
+        ZVAL_DEREF(optval);
         /* If the key is numeric it's a non value option */
         if (zkey) {
             if (zkey->len == 5 && !strcasecmp(zkey->val, "count") && Z_TYPE_P(optval) == IS_LONG) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2047,6 +2047,11 @@ class Redis_Test extends TestSuite
         $this->assertTrue(array('val1', 'val2') === $this->redis->zRangeByScore('key', 0, 3, array('limit' => array(1, 2))));
         $this->assertTrue(array('val0', 'val1') === $this->redis->zRangeByScore('key', 0, 1, array('limit' => array(0, 100))));
 
+        // limits as references
+        $limit = array(0, 100);
+        foreach ($limit as &$val) {}
+        $this->assertTrue(array('val0', 'val1') === $this->redis->zRangeByScore('key', 0, 1, array('limit' => $limit)));
+
         $this->assertTrue(array('val3') === $this->redis->zRevRangeByScore('key', 3, 0, array('limit' => array(0, 1))));
         $this->assertTrue(array('val3', 'val2') === $this->redis->zRevRangeByScore('key', 3, 0, array('limit' => array(0, 2))));
         $this->assertTrue(array('val2', 'val1') === $this->redis->zRevRangeByScore('key', 3, 0, array('limit' => array(1, 2))));
@@ -2375,6 +2380,11 @@ class Redis_Test extends TestSuite
         $this->assertTrue('x' === $this->redis->hGet('h', '123'));
         $this->assertTrue('456' === $this->redis->hGet('h', 'y'));
         $this->assertTrue(array(123 => 'x', 'y' => '456') === $this->redis->hMget('h', array('123', 'y')));
+
+        // references
+        $keys = array(123, 'y');
+        foreach ($keys as &$key) {}
+        $this->assertTrue(array(123 => 'x', 'y' => '456') === $this->redis->hMget('h', $keys));
 
         // check non-string types.
         $this->redis->del('h1');


### PR DESCRIPTION
This PR fixes issues #946 and #1166.