### PR TITLE
Add locking functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ missing
 autom4te.cache
 mkinstalldirs
 run-tests.php
+idea/*

--- a/common.h
+++ b/common.h
@@ -15,6 +15,7 @@ typedef smart_str smart_string;
 #define smart_string_appendc(dest, c) smart_str_appendc(dest, c)
 #define smart_string_append_long(dest, val) smart_str_append_long(dest, val)
 #define smart_string_appendl(dest, src, len) smart_str_appendl(dest, src, len)
+#define smart_string_free(str) smart_str_free(str)
 
 typedef struct {
     short gc;

--- a/common.h
+++ b/common.h
@@ -15,7 +15,6 @@ typedef smart_str smart_string;
 #define smart_string_appendc(dest, c) smart_str_appendc(dest, c)
 #define smart_string_append_long(dest, val) smart_str_append_long(dest, val)
 #define smart_string_appendl(dest, src, len) smart_str_appendl(dest, src, len)
-#define smart_string_free(str) smart_str_free(str)
 
 typedef struct {
     short gc;

--- a/php_redis.h
+++ b/php_redis.h
@@ -260,9 +260,17 @@ PHP_REDIS_API int redis_sock_read_multibulk_multi_reply_loop(
     INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, 
     int numElems);
 
-#ifndef _MSC_VER
 ZEND_BEGIN_MODULE_GLOBALS(redis)
+    int lock_release_lua_script_uploaded;
+    char lock_release_lua_script_hash[41];
 ZEND_END_MODULE_GLOBALS(redis)
+
+ZEND_EXTERN_MODULE_GLOBALS(redis);
+
+#ifdef ZTS
+#define REDIS_G(v) TSRMG(redis_globals_id, zend_redis_globals *, v)
+#else
+#define REDIS_G(v) (redis_globals.v)
 #endif
 
 extern zend_module_entry redis_module_entry;

--- a/php_redis.h
+++ b/php_redis.h
@@ -262,7 +262,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_multi_reply_loop(
 
 ZEND_BEGIN_MODULE_GLOBALS(redis)
     int lock_release_lua_script_uploaded;
-    char lock_release_lua_script_hash[41];
+    char *lock_release_lua_script_hash;
 ZEND_END_MODULE_GLOBALS(redis)
 
 ZEND_EXTERN_MODULE_GLOBALS(redis);

--- a/redis.c
+++ b/redis.c
@@ -73,6 +73,12 @@ PHP_INI_BEGIN()
     PHP_INI_ENTRY("redis.clusters.read_timeout", "", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.clusters.seeds", "", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.clusters.timeout", "", PHP_INI_ALL, NULL)
+
+    /* redis session */
+    PHP_INI_ENTRY("redis.session.locking_enabled", "", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.lock_wait_time", "", PHP_INI_ALL, NULL)
+     PHP_INI_ENTRY("redis.session.lock_retries", "", PHP_INI_ALL, NULL)
+     PHP_INI_ENTRY("redis.session.lock_expire", "", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 /** {{{ Argument info for commands in redis 1.0 */
@@ -226,9 +232,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_kscan, 0, 0, 2)
     ZEND_ARG_INFO(0, i_count)
 ZEND_END_ARG_INFO()
 
-#ifdef ZTS
 ZEND_DECLARE_MODULE_GLOBALS(redis)
-#endif
 
 static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, __construct, arginfo_void, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
@@ -454,6 +458,13 @@ static const zend_module_dep redis_deps[] = {
      ZEND_MOD_END
 };
 
+static
+PHP_GINIT_FUNCTION(redis)
+{
+    redis_globals->lock_release_lua_script_uploaded = 0;
+    memset(redis_globals->lock_release_lua_script_hash, 0, 41);
+}
+
 zend_module_entry redis_module_entry = {
 #if ZEND_MODULE_API_NO >= 20010901
      STANDARD_MODULE_HEADER_EX,
@@ -470,7 +481,11 @@ zend_module_entry redis_module_entry = {
 #if ZEND_MODULE_API_NO >= 20010901
      PHP_REDIS_VERSION,
 #endif
-     STANDARD_MODULE_PROPERTIES
+     PHP_MODULE_GLOBALS(redis),
+     PHP_GINIT(redis),
+     NULL,
+     NULL,
+     STANDARD_MODULE_PROPERTIES_EX,
 };
 
 #ifdef COMPILE_DL_REDIS

--- a/redis.c
+++ b/redis.c
@@ -76,9 +76,9 @@ PHP_INI_BEGIN()
 
     /* redis session */
     PHP_INI_ENTRY("redis.session.locking_enabled", "", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.lock_expire", "", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.lock_retries", "", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.lock_wait_time", "", PHP_INI_ALL, NULL)
-     PHP_INI_ENTRY("redis.session.lock_retries", "", PHP_INI_ALL, NULL)
-     PHP_INI_ENTRY("redis.session.lock_expire", "", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 /** {{{ Argument info for commands in redis 1.0 */

--- a/redis.c
+++ b/redis.c
@@ -462,7 +462,7 @@ static
 PHP_GINIT_FUNCTION(redis)
 {
     redis_globals->lock_release_lua_script_uploaded = 0;
-    memset(redis_globals->lock_release_lua_script_hash, 0, 41);
+    redis_globals->lock_release_lua_script_hash = NULL;
 }
 
 zend_module_entry redis_module_entry = {
@@ -816,6 +816,7 @@ PHP_MINIT_FUNCTION(redis)
  */
 PHP_MSHUTDOWN_FUNCTION(redis)
 {
+    efree(REDIS_G(lock_release_lua_script_hash));
     return SUCCESS;
 }
 

--- a/redis_session.c
+++ b/redis_session.c
@@ -546,7 +546,10 @@ PS_READ_FUNC(redis)
     cmd_len = REDIS_SPPRINTF(&cmd, "GET", "s", resp, resp_len);
     efree(resp);
 
-    lock_acquire(redis_sock, pool->lock_status TSRMLS_CC);
+    if (!lock_acquire(redis_sock, pool->lock_status TSRMLS_CC)) {
+        php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Acquire of session lock was not successful");
+    }
+
     if(redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) < 0) {
         efree(cmd);
         return FAILURE;

--- a/redis_session.c
+++ b/redis_session.c
@@ -254,8 +254,11 @@ void refresh_lock_status(RedisSock *redis_sock, redis_session_lock_status *lock_
 
     cmd_len = REDIS_SPPRINTF(&cmd, "GET", "s", lock_status->lock_key.c, lock_status->lock_key.len);
 
-    redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC);
-    response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
+    if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC)) {
+        response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
+    } else {
+        php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to refresh sessiong locking status (socket write failed)");
+    }
 
     if (response != NULL) {
         lock_status->is_locked = (strcmp(response, lock_status->lock_secret.c) == 0);

--- a/redis_session.c
+++ b/redis_session.c
@@ -317,7 +317,7 @@ void lock_release(RedisSock *redis_sock, redis_session_lock_status *lock_status 
 
 int upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC)
 {
-    if (REDIS_G(lock_release_lua_script_uploaded)) return;
+    if (REDIS_G(lock_release_lua_script_uploaded)) return 1;
 
     char *cmd, *response, *release_script;
     int response_len, cmd_len;
@@ -337,9 +337,7 @@ int upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC)
     }
 
     if (response != NULL) {
-        memset(REDIS_G(lock_release_lua_script_hash), 0, 41);
-        strncpy(REDIS_G(lock_release_lua_script_hash), response, strlen(response));
-
+        REDIS_G(lock_release_lua_script_hash) = estrdup(response);
         REDIS_G(lock_release_lua_script_uploaded) = 1;
         upload_result = 1;
         efree(response);

--- a/redis_session.c
+++ b/redis_session.c
@@ -349,8 +349,8 @@ int upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC)
 
 void calculate_lock_secret(redis_session_lock_status *lock_status)
 {
-    char hostname[64] = {0};
-    gethostname(hostname, 64);
+    char hostname[HOST_NAME_MAX] = {0};
+    gethostname(hostname, HOST_NAME_MAX);
 
     // Concatenating the redis lock secret
     smart_string_appendl(&lock_status->lock_secret, hostname, strlen(hostname));

--- a/redis_session.c
+++ b/redis_session.c
@@ -254,7 +254,8 @@ void refresh_lock_status(RedisSock *redis_sock, redis_session_lock_status *lock_
     if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC)) {
         response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
     } else {
-        php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to refresh sessiong locking status (socket write failed)");
+        php_error_docref(0 TSRMLS_CC, E_WARNING,
+            "Unable to refresh sessiong locking status (socket write failed)");
     }
 
     if (response != NULL) {
@@ -286,7 +287,8 @@ void lock_release(RedisSock *redis_sock, redis_session_lock_status *lock_status 
         if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC)) {
             response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
         } else {
-            php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to release session lock (socket write failed)");
+            php_error_docref(0 TSRMLS_CC, E_WARNING,
+                "Unable to release session lock (socket write failed)");
         }
 
         // in case of redis script cache has been flushed
@@ -297,7 +299,8 @@ void lock_release(RedisSock *redis_sock, redis_session_lock_status *lock_status 
             if (upload_successful && redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC)) {
                 response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
             } else {
-                php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to release session lock (socket write failed)");
+                php_error_docref(0 TSRMLS_CC, E_WARNING,
+                    "Unable to release session lock (socket write failed)");
             }
             lock_status->is_locked = 0;
         }
@@ -327,10 +330,12 @@ int upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC)
         response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
         
         if (response == NULL) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to upload LUA script for releasing session lock (SCRIPT LOAD failed)");
+            php_error_docref(0 TSRMLS_CC, E_WARNING,
+                "Unable to upload LUA script for releasing session lock (SCRIPT LOAD failed)");
         }
     } else {
-        php_error_docref(0 TSRMLS_CC, E_WARNING, "Unable to upload LUA script for releasing session lock (socket write failed)");
+        php_error_docref(0 TSRMLS_CC, E_WARNING,
+            "Unable to upload LUA script for releasing session lock (socket write failed)");
     }
 
     if (response != NULL) {
@@ -547,7 +552,8 @@ PS_READ_FUNC(redis)
     efree(resp);
 
     if (!lock_acquire(redis_sock, pool->lock_status TSRMLS_CC)) {
-        php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Acquire of session lock was not successful");
+        php_error_docref(NULL TSRMLS_CC, E_NOTICE,
+            "Acquire of session lock was not successful");
     }
 
     if(redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) < 0) {

--- a/redis_session.c
+++ b/redis_session.c
@@ -541,9 +541,7 @@ PS_READ_FUNC(redis)
 #else
     resp = redis_session_key(rpm, ZSTR_VAL(key), ZSTR_LEN(key), &resp_len);
 #endif
-    pool->lock_status->session_key = (char *) emalloc(resp_len + 1);
-    memset(pool->lock_status->session_key, 0, resp_len + 1);
-    strncpy(pool->lock_status->session_key, resp, resp_len);
+    pool->lock_status->session_key = estrndup(resp, resp_len);
 
     cmd_len = REDIS_SPPRINTF(&cmd, "GET", "s", resp, resp_len);
     efree(resp);

--- a/redis_session.h
+++ b/redis_session.h
@@ -14,7 +14,7 @@ int lock_acquire(RedisSock *redis_sock, redis_session_lock_status *lock_status T
 void lock_release(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
 void refresh_lock_status(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
 int write_allowed(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
-void upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC);
+int upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC);
 void calculate_lock_secret(redis_session_lock_status *lock_status);
 
 PS_OPEN_FUNC(redis);

--- a/redis_session.h
+++ b/redis_session.h
@@ -6,8 +6,8 @@
 typedef struct {
     zend_bool is_locked;
     char *session_key;
-	smart_string lock_key;
-    smart_string lock_secret;
+    char *lock_key;
+    char *lock_secret;
 } redis_session_lock_status;
 
 int lock_acquire(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);

--- a/redis_session.h
+++ b/redis_session.h
@@ -3,6 +3,20 @@
 #ifdef PHP_SESSION
 #include "ext/session/php_session.h"
 
+typedef struct {
+    zend_bool is_locked;
+    char *session_key;
+	smart_string lock_key;
+    smart_string lock_secret;
+} redis_session_lock_status;
+
+int lock_acquire(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
+void lock_release(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
+void refresh_lock_status(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
+int write_allowed(RedisSock *redis_sock, redis_session_lock_status *lock_status TSRMLS_DC);
+void upload_lock_release_script(RedisSock *redis_sock TSRMLS_DC);
+void calculate_lock_secret(redis_session_lock_status *lock_status);
+
 PS_OPEN_FUNC(redis);
 PS_CLOSE_FUNC(redis);
 PS_READ_FUNC(redis);
@@ -19,4 +33,3 @@ PS_GC_FUNC(rediscluster);
 
 #endif
 #endif
-

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -23,6 +23,11 @@ class Redis_Cluster_Test extends Redis_Test {
         RedisCluster::FAILOVER_DISTRIBUTE
     );
 
+    /**
+     * @var string
+     */
+    protected $sessionPrefix = 'PHPREDIS_CLUSTER_SESSION:';
+
     /* Tests we'll skip all together in the context of RedisCluster.  The 
      * RedisCluster class doesn't implement specialized (non-redis) commands
      * such as sortAsc, or sortDesc and other commands such as SELECT are
@@ -34,6 +39,21 @@ class Redis_Cluster_Test extends Redis_Test {
     public function testReconnectSelect() { return $this->markTestSkipped(); }
     public function testMultipleConnect() { return $this->markTestSkipped(); }
     public function testDoublePipeNoOp() { return $this->markTestSkipped(); }
+
+    /* Session locking feature is currently not supported in in context of Redis Cluster.
+       The biggest issue for this is the distribution nature of Redis cluster */
+    public function testSession_savedToRedis() { return $this->markTestSkipped(); }
+    public function testSession_lockKeyCorrect() { return $this->markTestSkipped(); }
+    public function testSession_lockingDisabledByDefault() { return $this->markTestSkipped(); }
+    public function testSession_lockReleasedOnClose() { return $this->markTestSkipped(); }
+    public function testSession_ttlMaxExecutionTime() { return $this->markTestSkipped(); }
+    public function testSession_ttlLockExpire() { return $this->markTestSkipped(); }
+    public function testSession_lockHoldCheckBeforeWrite_otherProcessHasLock() { return $this->markTestSkipped(); }
+    public function testSession_lockHoldCheckBeforeWrite_nobodyHasLock() { return $this->markTestSkipped(); }
+    public function testSession_correctLockRetryCount() { return $this->markTestSkipped(); }
+    public function testSession_defaultLockRetryCount() { return $this->markTestSkipped(); }
+    public function testSession_noUnlockOfOtherProcess() { return $this->markTestSkipped(); }
+    public function testSession_lockWaitTime() { return $this->markTestSkipped(); }
 
     /* Load our seeds on construction */
     public function __construct() {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -21,6 +21,11 @@ class Redis_Test extends TestSuite
      */
     public $redis;
 
+    /**
+     * @var string
+     */
+    protected $sessionPrefix = 'PHPREDIS_SESSION:';
+
     public function setUp() {
         $this->redis = $this->newInstance();
         $info = $this->redis->info();
@@ -5102,15 +5107,175 @@ class Redis_Test extends TestSuite
         $this->assertEquals($this->redis->lrange('mylist', 0, -1), Array('A','B','C','D'));
     }
 
-    public function testSession()
+    public function testSession_savedToRedis()
     {
-        ini_set('session.save_handler', 'redis');
-        ini_set('session.save_path', 'tcp://localhost:6379');
-        if (!@session_start()) {
-            return $this->markTestSkipped();
-        }
-        session_write_close();
-        $this->assertTrue($this->redis->exists('PHPREDIS_SESSION:' . session_id()));
+        $this->setSessionHandler();
+
+        $sessionId = $this->generateSessionId();
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false);
+
+        $this->assertTrue($this->redis->exists($this->sessionPrefix . $sessionId));
+        $this->assertTrue($sessionSuccessful);
+    }
+
+    public function testSession_lockKeyCorrect()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 5, true);
+        usleep(100000);
+
+        $this->assertTrue($this->redis->exists($this->sessionPrefix . $sessionId . '_LOCK'));
+    }
+
+    public function testSession_lockingDisabledByDefault()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 5, true, 300, false);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, false);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertFalse($this->redis->exists($this->sessionPrefix . $sessionId . '_LOCK'));
+        $this->assertTrue($elapsedTime < 1);
+        $this->assertTrue($sessionSuccessful);
+    }
+
+    public function testSession_lockReleasedOnClose()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 1, true);
+        usleep(1100000);
+
+        $this->assertFalse($this->redis->exists($this->sessionPrefix . $sessionId . '_LOCK'));
+    }
+
+    public function testSession_ttlMaxExecutionTime()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 10, true, 2);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime < 3);
+        $this->assertTrue($sessionSuccessful);
+    }
+
+    public function testSession_ttlLockExpire()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 10, true, 300, true, null, -1, 2);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime < 3);
+        $this->assertTrue($sessionSuccessful);
+    }
+
+    public function testSession_lockHoldCheckBeforeWrite_otherProcessHasLock()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 2, true, 300, true, null, -1, 1, 'firstProcess');
+        usleep(1500000); // 1.5 sec
+        $writeSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 10, 'secondProcess');
+        sleep(1);
+
+        $this->assertTrue($writeSuccessful);
+        $this->assertEquals('secondProcess', $this->getSessionData($sessionId));
+    }
+
+    public function testSession_lockHoldCheckBeforeWrite_nobodyHasLock()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $writeSuccessful = $this->startSessionProcess($sessionId, 2, false, 300, true, null, -1, 1, 'firstProcess');
+
+        $this->assertFalse($writeSuccessful);
+        $this->assertTrue('firstProcess' !== $this->getSessionData($sessionId));
+    }
+
+    public function testSession_correctLockRetryCount()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 10, true);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 1000000, 3);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime > 3 && $elapsedTime < 4);
+        $this->assertFalse($sessionSuccessful);
+    }
+
+    public function testSession_defaultLockRetryCount()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 10, true);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 200000, 0);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime > 2 && $elapsedTime < 3);
+        $this->assertFalse($sessionSuccessful);
+    }
+
+    public function testSession_noUnlockOfOtherProcess()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 3, true, 1); // Process 1
+        usleep(100000);
+        $this->startSessionProcess($sessionId, 5, true);    // Process 2
+
+        $start = microtime(true);
+        // Waiting until TTL of process 1 ended and process 2 locked the session,
+        // because is not guaranteed which waiting process gets the next lock
+        sleep(1);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime > 5);
+        $this->assertTrue($sessionSuccessful);
+    }
+
+    public function testSession_lockWaitTime()
+    {
+        $this->setSessionHandler();
+        $sessionId = $this->generateSessionId();
+        $this->startSessionProcess($sessionId, 1, true, 300);
+        usleep(100000);
+
+        $start = microtime(true);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, 3000000);
+        $end = microtime(true);
+        $elapsedTime = $end - $start;
+
+        $this->assertTrue($elapsedTime > 2.5 && $elapsedTime < 3.5);
+        $this->assertTrue($sessionSuccessful);
     }
 
     public function testMultipleConnect() {
@@ -5121,6 +5286,77 @@ class Redis_Test extends TestSuite
             $this->redis->connect($host, $port);
             $this->assertEquals($this->redis->ping(), "+PONG");
         }
+    }
+
+    private function setSessionHandler()
+    {
+        $host = $this->getHost() ?: 'localhost';
+
+        ini_set('session.save_handler', 'redis');
+        ini_set('session.save_path', 'tcp://' . $host . ':6379');
+    }
+
+    /**
+     * @return string
+     */
+    private function generateSessionId()
+    {
+        if (function_exists('session_create_id')) {
+            return session_create_id();
+        } else {
+            $encoded = bin2hex(openssl_random_pseudo_bytes(8));
+            return $encoded;
+        }
+    }
+
+    /**
+     * @param string $sessionId
+     * @param int    $sleepTime
+     * @param bool   $background
+     * @param int    $maxExecutionTime
+     * @param bool   $locking_enabled
+     * @param int    $lock_wait_time
+     * @param int    $lock_retries
+     * @param int    $lock_expires
+     * @param string $sessionData
+     *
+     * @return bool
+     */
+    private function startSessionProcess($sessionId, $sleepTime, $background, $maxExecutionTime = 300, $locking_enabled = true, $lock_wait_time = null, $lock_retries = -1, $lock_expires = 0, $sessionData = '')
+    {
+        if (substr(php_uname(), 0, 7) == "Windows"){
+            $this->markTestSkipped();
+            return true;
+        } else {
+            $commandParameters = array($this->getHost(), $sessionId, $sleepTime, $maxExecutionTime, $lock_retries, $lock_expires, $sessionData);
+            if ($locking_enabled) {
+                $commandParameters[] = '1';
+
+                if ($lock_wait_time != null) {
+                    $commandParameters[] = $lock_wait_time;
+                }
+            }
+            $commandParameters = array_map('escapeshellarg', $commandParameters);
+
+            $command = 'php ' . __DIR__ . '/startSession.php ' . implode(' ', $commandParameters);
+            $command .= $background ? ' 2>/dev/null > /dev/null &' : ' 2>&1';
+
+            exec($command, $output);
+            return ($background || (count($output) == 1 && $output[0] == 'SUCCESS')) ? true : false;
+        }
+    }
+
+    /**
+     * @param string $sessionId
+     *
+     * @return string
+     */
+    private function getSessionData($sessionId)
+    {
+        $command = 'php ' . __DIR__ . '/getSessionData.php ' . escapeshellarg($this->getHost()) . ' ' . escapeshellarg($sessionId);
+        exec($command, $output);
+
+        return $output[0];
     }
 }
 ?>

--- a/tests/getSessionData.php
+++ b/tests/getSessionData.php
@@ -1,0 +1,17 @@
+<?php
+$redisHost = $argv[1];
+$sessionId = $argv[2];
+
+if (empty($redisHost)) {
+    $redisHost = 'localhost';
+}
+
+ini_set('session.save_handler', 'redis');
+ini_set('session.save_path', 'tcp://' . $redisHost . ':6379');
+
+session_id($sessionId);
+if (!session_start()) {
+    echo "session_start() was nut successful";
+} else {
+    echo isset($_SESSION['redis_test']) ? $_SESSION['redis_test'] : 'Key redis_test not found';
+}

--- a/tests/getSessionData.php
+++ b/tests/getSessionData.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(0);
+
 $redisHost = $argv[1];
 $sessionId = $argv[2];
 

--- a/tests/getSessionData.php
+++ b/tests/getSessionData.php
@@ -1,5 +1,5 @@
 <?php
-error_reporting(0);
+error_reporting(E_ERROR | E_WARNING);
 
 $redisHost = $argv[1];
 $sessionId = $argv[2];

--- a/tests/startSession.php
+++ b/tests/startSession.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(0);
+
 $redisHost = $argv[1];
 $sessionId = $argv[2];
 $sleepTime = $argv[3];

--- a/tests/startSession.php
+++ b/tests/startSession.php
@@ -1,0 +1,36 @@
+<?php
+$redisHost = $argv[1];
+$sessionId = $argv[2];
+$sleepTime = $argv[3];
+$maxExecutionTime = $argv[4];
+$lock_retries = $argv[5];
+$lock_expire = $argv[6];
+$sessionData = $argv[7];
+
+if (empty($redisHost)) {
+    $redisHost = 'localhost';
+}
+
+ini_set('session.save_handler', 'redis');
+ini_set('session.save_path', 'tcp://' . $redisHost . ':6379');
+ini_set('max_execution_time', $maxExecutionTime);
+ini_set('redis.session.lock_retries', $lock_retries);
+ini_set('redis.session.lock_expire', $lock_expire);
+
+if (isset($argv[8])) {
+    ini_set('redis.session.locking_enabled', $argv[8]);
+}
+
+if (isset($argv[9])) {
+    ini_set('redis.session.lock_wait_time', $argv[9]);
+}
+
+session_id($sessionId);
+$sessionStartSuccessful = session_start();
+sleep($sleepTime);
+if (!empty($sessionData)) {
+    $_SESSION['redis_test'] = $sessionData;
+}
+session_write_close();
+
+echo $sessionStartSuccessful ? 'SUCCESS' : 'FAILURE';

--- a/tests/startSession.php
+++ b/tests/startSession.php
@@ -1,5 +1,5 @@
 <?php
-error_reporting(0);
+error_reporting(E_ERROR | E_WARNING);
 
 $redisHost = $argv[1];
 $sessionId = $argv[2];


### PR DESCRIPTION
The goal of this patch is to add locking functionality as discussed in issue #37.
Only standalone / replicated server setups are supported, as locking in active/active clusters without race conditions or massive performance impact is not possible in my eyes.

The patch follows the approach of adding an additional time limited Redis key/value pair
- Key: <php_session_key>_LOCK
- Value: Process unique SHA1 hash (PID + Hostname)
And using LUA Script for releasing as described  in the official [Redis documentation.](https://redis.io/topics/distlock#correct-implementation-with-a-single-instance).

The current implementation makes use of four new INI parameters with the following default values:
```ini
# Enables/Disables locking at all
redis.session.locking_enabled=0

# Maximum retries of locking attempts until ignoring the current lock
redis.session.lock_retries=10

# Sleep time in microseconds between locking attempts 
redis.session.lock_wait_time=2000

# TTL of lock key/value pairs, if not set or Zero, then max_execution_time is used 
redis.session.lock_expire=
```

Thanks to @KiNgMaR for lots of support and concept creation.

As ny main competence is in PHP not in C, there is much space for improvement, so please code review has hard as you want :)