### PR TITLE
Add arginfo for ReflectionMethod to redis for some commands

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -68,9 +68,11 @@ PHP_INI_BEGIN()
     PHP_INI_ENTRY("redis.clusters.read_timeout", "", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
+/** Argument info for any function expecting 0 args */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+/** {{{ Argument info for commands in redis 1.0 */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_connect, 0, 0, 2)
     ZEND_ARG_INFO(0, host)
     ZEND_ARG_INFO(0, port)
@@ -99,12 +101,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_set, 0, 0, 2)
     ZEND_ARG_INFO(0, opt)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_setex, 0, 0, 3)
-    ZEND_ARG_INFO(0, key)
-    ZEND_ARG_INFO(0, expire)
-    ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_key_expire_value, 0, 0, 3)
     ZEND_ARG_INFO(0, key)
     ZEND_ARG_INFO(0, expire)
@@ -126,7 +122,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_mget, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_del, 0, 0, 1)
-    ZEND_ARG_INFO(0, ...)
+    ZEND_ARG_INFO(0, key)
+#if PHP_VERSION_ID >= 50600
+    ZEND_ARG_VARIADIC_INFO(0, other_keys)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_key_start_end, 0, 0, 3)
@@ -165,8 +164,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_generic_sort, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_blrpop, 0, 0, 2)
-    ZEND_ARG_INFO(0, ...)
-    ZEND_ARG_INFO(0, timeout)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, timeout_or_key)
+// Can't have variadic keys before timeout.
+#if PHP_VERSION_ID >= 50600
+    ZEND_ARG_VARIADIC_INFO(0, extra_args)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_lrem, 0, 0, 3)
@@ -217,13 +220,17 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_nkeys, 0, 0, 1)
     ZEND_ARG_INFO(0, key)
-    ZEND_ARG_INFO(0, ...)
+#if PHP_VERSION_ID >= 50600
+    ZEND_ARG_VARIADIC_INFO(0, other_keys)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dst_nkeys, 0, 0, 2)
     ZEND_ARG_INFO(0, dst)
     ZEND_ARG_INFO(0, key)
-    ZEND_ARG_INFO(0, ...)
+#if PHP_VERSION_ID >= 50600
+    ZEND_ARG_VARIADIC_INFO(0, other_keys)
+#endif
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_set_timeout, 0, 0, 2)
@@ -234,6 +241,59 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_auth, 0, 0, 1)
     ZEND_ARG_INFO(0, password)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_info, 0, 0, 0)
+    ZEND_ARG_INFO(0, option)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_select, 0, 0, 1)
+    ZEND_ARG_INFO(0, dbindex)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_move, 0, 0, 2)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, dbindex)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_slaveof, 0, 0, 0)
+    ZEND_ARG_INFO(0, host)
+    ZEND_ARG_INFO(0, port)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_object, 0, 0, 2)
+    ZEND_ARG_INFO(0, field)
+    ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_bitop, 0, 0, 3)
+    ZEND_ARG_INFO(0, operation)
+    ZEND_ARG_INFO(0, ret_key)
+    ZEND_ARG_INFO(0, key)
+#if PHP_VERSION_ID >= 50600
+    ZEND_ARG_VARIADIC_INFO(0, other_keys)
+#endif
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_bitpos, 0, 0, 2)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, bit)
+    ZEND_ARG_INFO(0, start)
+    ZEND_ARG_INFO(0, end)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_eval, 0, 0, 1)
+    ZEND_ARG_INFO(0, script)
+    ZEND_ARG_INFO(0, args)
+    ZEND_ARG_INFO(0, num_keys)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_evalsha, 0, 0, 1)
+    ZEND_ARG_INFO(0, script_sha)
+    ZEND_ARG_INFO(0, args)
+    ZEND_ARG_INFO(0, num_keys)
+ZEND_END_ARG_INFO()
+/* }}} */
+
 /**
  * Argument info for the SCAN proper
  */
@@ -336,15 +396,15 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, ttl, arginfo_key, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, pttl, arginfo_key, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, persist, arginfo_key, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, info, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, select, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, move, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, info, arginfo_info, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, select, arginfo_select, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, move, arginfo_move, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, bgrewriteaof, arginfo_void, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, slaveof, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, object, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, bitop, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, bitcount, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, bitpos, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, slaveof, arginfo_slaveof, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, object, arginfo_object, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, bitop, arginfo_bitop, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, bitcount, arginfo_key, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, bitpos, arginfo_bitpos, ZEND_ACC_PUBLIC)
 
      /* 1.1 */
      PHP_ME(Redis, mset, NULL, ZEND_ACC_PUBLIC)
@@ -404,10 +464,10 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, unsubscribe, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, punsubscribe, NULL, ZEND_ACC_PUBLIC)
 
-     PHP_ME(Redis, time, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, time, arginfo_void, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, role, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, eval, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, evalsha, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, eval, arginfo_eval, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, evalsha, arginfo_evalsha, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, script, NULL, ZEND_ACC_PUBLIC)
 
      PHP_ME(Redis, debug, NULL, ZEND_ACC_PUBLIC)
@@ -415,8 +475,8 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, restore, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, migrate, NULL, ZEND_ACC_PUBLIC)
 
-     PHP_ME(Redis, getLastError, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, clearLastError, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getLastError, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, clearLastError, arginfo_void, ZEND_ACC_PUBLIC)
 
      PHP_ME(Redis, _prefix, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _serialize, NULL, ZEND_ACC_PUBLIC)
@@ -458,24 +518,25 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, georadiusbymember, NULL, ZEND_ACC_PUBLIC)
 
      /* introspection */
-     PHP_ME(Redis, getHost, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getPort, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getDBNum, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getTimeout, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getReadTimeout, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getPersistentID, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, getAuth, NULL, ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, isConnected, NULL, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getHost, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getPort, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getDBNum, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getTimeout, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getReadTimeout, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getPersistentID, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, getAuth, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, isConnected, arginfo_void, ZEND_ACC_PUBLIC)
+     /* TODO: document getMode() and wait() in README? */
      PHP_ME(Redis, getMode, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, wait, NULL, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, pubsub, NULL, ZEND_ACC_PUBLIC)
 
      /* aliases */
-     PHP_MALIAS(Redis, open, connect, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, popen, pconnect, NULL, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, open, connect, arginfo_connect, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, popen, pconnect, arginfo_pconnect, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, lLen, lSize, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, sGetMembers, sMembers, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, mget, getMultiple, NULL, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, mget, getMultiple, arginfo_mget, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, expire, setTimeout, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, zunionstore, zUnion, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, zinterstore, zInter, NULL, ZEND_ACC_PUBLIC)
@@ -486,9 +547,9 @@ static zend_function_entry redis_functions[] = {
      PHP_MALIAS(Redis, zRemRangeByScore, zDeleteRangeByScore, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, zRemRangeByRank, zDeleteRangeByRank, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, zSize, zCard, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, substr, getRange, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, rename, renameKey, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, del, delete, NULL, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, substr, getRange, arginfo_key_start_end, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, rename, renameKey, arginfo_key_newkey, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, del, delete, arginfo_del, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, keys, getKeys, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, lrem, lRemove, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, ltrim, listTrim, NULL, ZEND_ACC_PUBLIC)
@@ -499,10 +560,10 @@ static zend_function_entry redis_functions[] = {
      PHP_MALIAS(Redis, sismember, sContains, NULL, ZEND_ACC_PUBLIC)
      PHP_MALIAS(Redis, zReverseRange, zRevRange, NULL, ZEND_ACC_PUBLIC)
 
-     PHP_MALIAS(Redis, sendEcho, echo, NULL, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, sendEcho, echo, arginfo_echo, ZEND_ACC_PUBLIC)
 
-     PHP_MALIAS(Redis, evaluate, eval, NULL, ZEND_ACC_PUBLIC)
-     PHP_MALIAS(Redis, evaluateSha, evalsha, NULL, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, evaluate, eval, arginfo_eval, ZEND_ACC_PUBLIC)
+     PHP_MALIAS(Redis, evaluateSha, evalsha, arginfo_evalsha, ZEND_ACC_PUBLIC)
      PHP_FE_END
 };
 
@@ -1317,11 +1378,13 @@ PHP_METHOD(Redis, getRange)
 }
 /* }}} */
 
+/* {{{ proto string Redis::setRange(string key, long start, string value) */
 PHP_METHOD(Redis, setRange)
 {
     REDIS_PROCESS_KW_CMD("SETRANGE", redis_key_long_str_cmd,
         redis_long_response);
 }
+/* }}} */
 
 /* {{{ proto long Redis::getbit(string key, long idx) */
 PHP_METHOD(Redis, getBit)
@@ -1330,10 +1393,12 @@ PHP_METHOD(Redis, getBit)
 }
 /* }}} */
 
+/* {{{ proto long Redis::setbit(string key, long idx, bool|int value) */
 PHP_METHOD(Redis, setBit)
 {
     REDIS_PROCESS_CMD(setbit, redis_long_response);
 }
+/* }}} */
 
 /* {{{ proto long Redis::strlen(string key) */
 PHP_METHOD(Redis, strlen)

--- a/redis.c
+++ b/redis.c
@@ -125,6 +125,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_del, 0, 0, 1)
     ZEND_ARG_INFO(0, key)
 #if PHP_VERSION_ID >= 50600
     ZEND_ARG_VARIADIC_INFO(0, other_keys)
+#else
+    ZEND_ARG_INFO(0, ...)
 #endif
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Reopen #1163 against develop branch

This is incomplete, writing arginfo for everything in a single PR
would be difficult for reviewers.
This focuses on string operations and some common commands for
redis 1.0.

The macro's arguments are:
ZEND_BEGIN_ARG_INFO_EX(name, _unused, return_reference, required_num_args)

For #1055 (Still a lot of work)

This is based on what was written in README, not 100% sure if it matches
the code.