### PR TITLE
Change mkdeb.sh to enable/dissable module correctly

### DIFF
--- a/debian.control
+++ b/debian.control
@@ -1,16 +1,16 @@
 Package: phpredis
-Version: 2.2.7
-Section: web 
+Version: 3.0.0
+Section: web
 Priority: optional
 Architecture: all
 Essential: no
-Depends: 
-Pre-Depends: 
-Recommends: php5
-Suggests: 
-Installed-Size: 
+Depends:
+Pre-Depends:
+Recommends: php7.0
+Suggests:
+Installed-Size:
 Maintainer: Nicolas Favre-Felix [n.favre-felix@owlient.eu]
-Conflicts: 
-Replaces: 
+Conflicts:
+Replaces:
 Provides: phpredis
-Description: Redis C extension for PHP5.
+Description: Redis C extension for PHP7.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,116 @@
+phpredis 3.0.0
+
+  This version of phpredis supports cluster and is intended for php versions
+  7.0.0 and higher.  To compile cluster-enabled phpredis for older versions
+  of php, please use the 2.2.8 pecl package.
+
+  A huge thanks goes out to Sean DuBois for doing all the work required to get
+  phpredis working in php 7.0!
+
+  -- Improvements ---
+
+  * PHP 7 Support (Sean DuBois) [3159bd2, 567dc2f, daa4d9f, f2711e3, 9cb9d07,
+    9d51c89, 9ff8f49, 33bb629, cbdf65a, f30b7fd, c687a51, 6b3e773, 2bf8241,
+    771bd3d, 9221ca4, 4e00df6, e2407ca, 97fcfe6, 77e6200]
+  * Redis Cluster support
+  * Allow SINTERSTORE to take a single array argument again
+  * IPv6 support
+
+  --- Fixes ---
+
+  * config.w32 fix (Jan-E) [495d308, c9e0b682]
+  * Exception handling improvement (Jan-E) [314a2c3c]
+  * Unit test fix for max int value (Jan-E) [659ea2aa]
+  * unsigned long -> zend_ulong fix (Jan-E) [4d66e3d4]
+  * Visual Stuio 14 fixes (Jan-E) [ea98401c]
+  * Segfault fix when looking up our socket (ephemeralsnow) [0126481a]
+  * Allow '-' and '+' in ZRANGEBYLEX (Patrick Pokatilo) [8bfa2188]
+  * Documentation fixes (Ares) [54b9a0ec]
+  * php7 related memory leak fix (Stuart Carnie) [b75bf3b4]
+  * Potential segfault fix in cluster session (Sergei Lomakov) [661fb5b1]
+  * php7 related serialization leak fix (Adam Harvey) [c40fc1d8]
+
+phpredis 2.2.7
+
+  -- Improvements ---
+
+  * Implemented PFADD, PFMERGE, and PFCOUNT command handling
+  * Implemented ZRANGEBYLEX command (holding off on ZREVRANGEBYLEX
+    as that won't be out until 3.0)
+  * Implemented getMode() so clients can detect whether we're in
+    ATOMIC/MULTI/PIPELINE mode.
+  * Implemented rawCommand() so clients can send arbitrary things to
+    the redis server
+  * Implemented DEBUG OBJECT (@michael-grunder, @isage)
+  * Added/abide by connect timeout for RedisArray
+  * Select to the last selected DB when phpredis reconnects
+
+  -- Fixes ---
+
+  * Fix a possible invalid free in _serialize
+  * Added SAVE and BGSAVE to "distributable" commands for RedisArray
+  * @welting -- Fixed invalid "argc" calculation re HLL commands
+  * Allow clients to break out of the subscribe loop and return context.
+  * Fixes a memory leak in SCAN when OPT_SCAN_RETRY id.
+  * @remicollet -- Fix possible segfault when igbinary is enabled.
+  * Add a couple of cases where we throw on an error (LOADING/NOAUTH/MASTERDOWN)
+  * Fix several issues with serialization NARY
+  * @itcom -- Fix missing TSRMLS_CC and a TSRMLS_DC/TSRMLS_CC typo
+
+phpredis 2.2.5
+
+  This is a minor release with several bug fixes as well as additions to support
+  new commands that have been introduced to Redis since our last release.
+
+  A special thanks to everyone who helps the project by commenting on issues and
+  submitting pull requests!  :)
+
+  [NEW] Support for the BITPOS command
+  [NEW] Connection timeout option for RedisArray (@MikeToString)
+  [NEW] A _serialize method, to complement our existing _unserialize method
+  [NEW] Support for the PUBSUB command
+  [NEW] Support for SCAN, SSCAN, HSCAN, and ZSCAN
+  [NEW] Support for the WAIT command
+
+  [FIX] Handle the COPY and REPLACE arguments for the MIGRATE command
+
+  [DOC] Fix syntax error in documentation for the SET command (@mithunsatheesh)
+  [DOC] Homebrew documentation instructions (@mathias)
+
+phpredis 2.2.4
+
+   **
+   ** Features / Improvements
+   **
+
+   * Randomized reconnect delay for RedisArray @mobli
+     This feature adds an optional parameter when constructing a RedisArray object
+     such that a random delay will be introduced if reconnections are made,
+     mitigating any &apos;thundering herd&apos; type problems.
+
+   * Lazy connections to RedisArray servers @mobli
+     By default, RedisArray will attempt to connect to each server you pass in
+     the ring on construction.  This feature lets you specify that you would
+     rather have RedisArray only attempt a connection when it needs to get data
+     from a particular node (throughput/performance improvement).
+
+   * Allow LONG and STRING keys in MGET/MSET
+   * Extended SET options for Redis &gt;= 2.6.12
+   * Persistent connections and UNIX SOCKET support for RedisArray
+   * Allow aggregates for ZUNION/ZINTER without weights @mheijkoop
+   * Support for SLOWLOG command
+   * Reworked MGET algorithm to run in linear time regardless of key count.
+   * Reworked ZINTERSTORE/ZUNIONSTORE algorithm to run in linear time
+
+   **
+   ** Bug fixes
+   **
+
+   * C99 Compliance (or rather lack thereof) fix @mobli
+   * Added ZEND_ACC_CTOR and ZEND_ACC_DTOR @euskadi31
+   * Stop throwing and clearing an exception on connect failure @matmoi
+   * Fix a false positive unit test failure having to do with TTL returns
+
 php5-redis (2.2.2-1) unstable; urgency=low
 
   * Non-maintainer upload.

--- a/debian/control
+++ b/debian/control
@@ -1,16 +1,17 @@
-Source: php5-redis
+Package: php7.0-redis
+Version: 3.0.0
 Section: web
 Priority: optional
-Maintainer: Nicolas Favre-Felix <n.favre-felix@owlient.eu>
-Build-Depends: debhelper (>= 7), php5-dev
-Standards-Version: 3.8.0
-Homepage: https://github.com/nicolasff/phpredis
-
-Package: php5-redis
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${php5:Depends}
-Recommends: php5
-Provides: php5-redis
+Architecture: all
+Essential: no
+Depends: php7.0-dev
+Build-Depends:
+Pre-Depends: php7.0-dev
+Recommends: php7.0
+Suggests:
+Installed-Size:
+Maintainer: Nicolas Favre-Felix [n.favre-felix@owlient.eu]
 Conflicts: phpredis
 Replaces: phpredis
-Description: Redis C extension for PHP5.
+Provides: php7.0-redis
+Description: Redis C extension for PHP7.

--- a/debian/postinst
+++ b/debian/postinst
@@ -19,10 +19,11 @@ set -e
 
 case "$1" in
     configure)
-	    cat > /etc/php5/conf.d/redis.ini <<EOF
+	    cat > /etc/php/7.0/mods-available/redis.ini <<EOF
 ; uncomment the next line to enable the module
 extension=redis.so
 EOF
+      phpenmod -v 7.0 redis
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/postrm
+++ b/debian/postrm
@@ -20,8 +20,9 @@ set -e
 
 case "$1" in
     purge)
-	if [ -e /etc/php5/conf.d/redis.ini ]; then
-		rm -f /etc/php5/conf.d/redis.ini
+	if [ -e /etc/php/7.0/mods-available/redis.ini ]; then
+    phpdismod -v 7.0 redis
+		rm -f /etc/php/7.0/mods-available/redis.ini
 	fi
     ;;
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # Sample debian/rules that uses debhelper.
-# This file is public domain software, originally written by Joey Hess. 
+# This file is public domain software, originally written by Joey Hess.
 #
 # This version is for packages that are architecture dependent.
 
@@ -9,7 +9,7 @@
 
 DEB_SRCDIR=$(shell pwd)
 INSTALL_DIR=$(DEB_SRCDIR)/debian/$(shell dh_listpackages)
-EXTENSION_DIR=`php-config5 --extension-dir`
+EXTENSION_DIR=`php-config --extension-dir | cut -c 2-`
 CFLAGS = -O3
 
 
@@ -18,7 +18,7 @@ build-stamp:
 	dh_testdir
 
 	# Add here commands to compile the package.
-	
+
 	# Because phpize --clean removes all testfiles
 	# in tests/*.php the svn-buildpackage will fail
 	# when tests/TestRedis.php was removed.
@@ -26,7 +26,7 @@ build-stamp:
 	cd $(DEB_SRCDIR) && mv tests/TestRedis.php tests/TestRedis.php.bak && \
 		phpize --clean && mv tests/TestRedis.php.bak tests/TestRedis.php && \
 	        phpize && \
-		./configure --with-php-config=/usr/bin/php-config5
+		./configure --with-php-config=/usr/bin/php-config
 	$(MAKE) -C $(DEB_SRCDIR)
 
 	touch build-stamp
@@ -67,7 +67,7 @@ binary-arch: build install
 	dh_installexamples
 #	dh_install
 #	dh_installmenu
-#	dh_installdebconf	
+#	dh_installdebconf
 #	dh_installlogrotate
 #	dh_installemacsen
 #	dh_installcatalogs
@@ -91,7 +91,7 @@ binary-arch: build install
 	dh_installdeb
 	dh_shlibdeps
 	cd $(DEB_SRCDIR) && \
-	       echo "php5:Depends=phpapi-`php-config5 --phpapi`, php5-common" >> debian/phpredis.substvars
+	       echo "php5:Depends=phpapi-`php-config --phpapi`, php7.0-common" >> debian/phpredis.substvars
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb

--- a/mkdeb.sh
+++ b/mkdeb.sh
@@ -4,18 +4,14 @@ phpize
 make clean all
 DIR=`php-config --extension-dir | cut -c 2-`
 
-rm -rf debian
+mkdir -p deb
+mkdir -p deb/DEBIAN
+mkdir -p deb/$DIR
 
-mkdir -p debian
-mkdir -p debian/DEBIAN
-mkdir -p debian/$DIR
+cp debian/* deb/DEBIAN/
 
-cp debian.control debian/DEBIAN/control
+cp modules/redis.so deb/$DIR
 
-UBUNTU=`uname -v | grep -ci ubuntu`
-mkdir -p debian/etc/php/7.0/conf.d/
-echo "extension=redis.so" >> debian/etc/php/7.0/conf.d/redis.ini
+dpkg -b deb phpredis-`git rev-parse --abbrev-ref HEAD`_`uname -m`.deb
 
-cp modules/redis.so debian/$DIR
-dpkg -b debian phpredis-`git describe --abbrev=0 --tags`_`uname -m`.deb
-rm -rf debian/
+rm -rf deb


### PR DESCRIPTION
Currently mkdeb.sh creates a package that not correctly enables extension for php7.0-fpm and cli

+ changelog updated