### PR TITLE
throw exception when write in a read only slave

### DIFF
--- a/library.c
+++ b/library.c
@@ -138,7 +138,8 @@ redis_error_throw(RedisSock *redis_sock TSRMLS_DC)
     if (redis_sock != NULL && redis_sock->err != NULL &&
         memcmp(redis_sock->err, "ERR", sizeof("ERR") - 1) != 0 &&
         memcmp(redis_sock->err, "NOSCRIPT", sizeof("NOSCRIPT") - 1) != 0 &&
-        memcmp(redis_sock->err, "WRONGTYPE", sizeof("WRONGTYPE") - 1) != 0
+        memcmp(redis_sock->err, "WRONGTYPE", sizeof("WRONGTYPE") - 1) != 0 &&
+        memcmp(redis_sock->err, "READONLY", sizeof("READONLY") - 1) != 0
     ) {
         zend_throw_exception(redis_exception_ce, redis_sock->err, 0 TSRMLS_CC);
     }


### PR DESCRIPTION
throw exception when write in a read only slave.

when write in a read only slave , phpredis will only return false.
when php lpop on a list , php will get false as same as the return when list is empty.
this will make something unexpect .