### PR TITLE
MOD: Support reply literal string instead of bool when redis reply simple string

### DIFF
--- a/common.h
+++ b/common.h
@@ -438,6 +438,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_READ_TIMEOUT       3
 #define REDIS_OPT_SCAN               4
 #define REDIS_OPT_FAILOVER           5
+#define REDIS_OPT_REPLY_LITERAL      6
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -624,6 +625,7 @@ typedef struct {
     int            scan;
 
     int            readonly;
+    int            reply_literal;
 } RedisSock;
 /* }}} */
 

--- a/library.c
+++ b/library.c
@@ -1396,6 +1396,7 @@ redis_sock_create(char *host, int host_len, unsigned short port,
     redis_sock->scan = REDIS_SCAN_NORETRY;
 
     redis_sock->readonly = 0;
+    redis_sock->reply_literal = 0;
 
     return redis_sock;
 }
@@ -2058,8 +2059,12 @@ redis_read_variant_line(RedisSock *redis_sock, REDIS_REPLY_TYPE reply_type,
 		/* Set our response to FALSE */
 		ZVAL_FALSE(z_ret);
 	} else {
-		/* Set our response to TRUE */
-		ZVAL_TRUE(z_ret);
+		if (!redis_sock->reply_literal) {
+		    /* Set our response to TRUE */
+		    ZVAL_TRUE(z_ret);
+		} else {
+		    ZVAL_STRINGL(z_ret, inbuf, line_size);
+		}
 	}
 
     return 0;

--- a/redis.c
+++ b/redis.c
@@ -596,6 +596,7 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) 
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SERIALIZER"), REDIS_OPT_SERIALIZER TSRMLS_CC);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_PREFIX"), REDIS_OPT_PREFIX TSRMLS_CC);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_READ_TIMEOUT"), REDIS_OPT_READ_TIMEOUT TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_REPLY_LITERAL"), REDIS_OPT_REPLY_LITERAL TSRMLS_CC);
 
     /* serializer */
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE TSRMLS_CC);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2975,6 +2975,8 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->scan);
         case REDIS_OPT_FAILOVER:
             RETURN_LONG(c->failover);
+        case REDIS_OPT_REPLY_LITERAL:
+            RETURN_LONG(redis_sock->reply_literal);
         default:
             RETURN_FALSE;
     }
@@ -3048,6 +3050,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 RETURN_TRUE;
             }
             break;
+        case REDIS_OPT_REPLY_LITERAL:
+            redis_sock->reply_literal = atol(val_str);
+            RETURN_TRUE;
         EMPTY_SWITCH_DEFAULT_CASE()
     }
     RETURN_FALSE;

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -583,5 +583,9 @@ class Redis_Cluster_Test extends Redis_Test {
         session_write_close();
         $this->assertTrue($this->redis->exists('PHPREDIS_CLUSTER_SESSION:' . session_id()));
     }
+
+    public function testReplyLiterString() {
+        $this->assertTrue($this->redis->rawCommand("mykey", "ping"));
+    }
 }
 ?>

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5033,5 +5033,11 @@ class Redis_Test extends TestSuite
             $this->assertEquals($this->redis->ping(), "+PONG");
         }
     }
+    public function testReplyLiterString() {
+        $this->redis->setOption(Redis::OPT_REPLY_LITERAL, 1);
+        $this->assertEquals($this->redis->rawCommand("ping"), "PONG");
+        $this->redis->setOption(Redis::OPT_REPLY_LITERAL, 0);
+        $this->assertTrue($this->redis->rawCommand("ping"));
+    }
 }
 ?>


### PR DESCRIPTION
The Redis simple string was converted to true in `redis_read_variant_line`, but sometimes we need to get the string. 

for example, we use phpredis  to connect the Disque, execute the `ADDJOB` by rawCommand, and it should retrieve the `job id`(simple string like "+D-b628d44e-i7UHxyLPj2aPT3BPD3VPz4P2-05a1") but got TRUE.

We should retrieve the simple string instead of TRUE, while it may mean to user