### PR TITLE
Add reconnect API.

### DIFF
--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -94,6 +94,7 @@ ZEND_END_ARG_INFO();
 zend_function_entry redis_cluster_functions[] = {
     PHP_ME(RedisCluster, __construct, NULL, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, close, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, reconnect, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, get, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, set, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, mget, NULL, ZEND_ACC_PUBLIC)
@@ -538,6 +539,22 @@ PHP_METHOD(RedisCluster, __construct) {
 PHP_METHOD(RedisCluster, close) {
     cluster_disconnect(GET_CONTEXT() TSRMLS_CC);
     RETURN_TRUE;
+}
+/* {{{ proto bool RedisCLuster::reconnect() */
+PHP_METHOD(RedisCluster, reconnect) {
+   redisCluster *context = GET_CONTEXT();
+   redisClusterNode *node;
+
+   // cluster disconnect
+   ZEND_HASH_FOREACH_PTR(context->nodes, node) {
+     if (node == NULL) continue;
+     redis_sock_disconnect(node->sock TSRMLS_CC);
+     node->sock->persistent_id = NULL;
+     php_stream_close(node->sock->stream);
+     node->sock->stream = NULL;
+     redis_sock_connect(node->sock);
+   } ZEND_HASH_FOREACH_END();
+   RETURN_TRUE;
 }
 
 /* {{{ proto string RedisCluster::get(string key) */

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -552,7 +552,7 @@ PHP_METHOD(RedisCluster, reconnect) {
      node->sock->persistent_id = NULL;
      php_stream_close(node->sock->stream);
      node->sock->stream = NULL;
-     redis_sock_connect(node->sock);
+     redis_sock_connect(node->sock TSRMLS_CC);
    } ZEND_HASH_FOREACH_END();
    RETURN_TRUE;
 }

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -123,6 +123,7 @@ void init_rediscluster(TSRMLS_D);
 /* RedisCluster method implementation */
 PHP_METHOD(RedisCluster, __construct);
 PHP_METHOD(RedisCluster, close);
+PHP_METHOD(RedisCluster, reconnect);
 PHP_METHOD(RedisCluster, get);
 PHP_METHOD(RedisCluster, set);
 PHP_METHOD(RedisCluster, mget);


### PR DESCRIPTION

# Add reconnect api to phpredis.

## problem
When we encounter network problem(temporary loss of connection, setting corruption, etc...), redis-cluster's persistent connection try to connect using the same connection. 
But if connection entered an invalid state, we couldn't restore valid connection even after call close() and new().

## Solution
Explicit socket and stream close.

## Result 
Invalid Persistent Connection return to valid state after I called reconnect api.

