### PR TITLE
Issue #1245

### DIFF
--- a/common.h
+++ b/common.h
@@ -1060,15 +1060,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_pubsub, 0, 0, 1)
 #endif
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_script, 0, 0, 1)
-    ZEND_ARG_INFO(0, cmd)
-#if PHP_VERSION_ID >= 50600
-    ZEND_ARG_VARIADIC_INFO(0, args)
-#else
-    ZEND_ARG_INFO(0, ...)
-#endif
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_slowlog, 0, 0, 1)
     ZEND_ARG_INFO(0, arg)
     ZEND_ARG_INFO(0, option)

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -30,6 +30,8 @@ typedef enum geoSortType {
 
 /* Construct a raw command */
 int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_DC);
+/* Construct a script command */
+smart_string *redis_build_script_cmd(smart_string *cmd, int argc, zval *z_args);
 
 /* Redis command generics.  Many commands share common prototypes meaning that
  * we can write one function to handle all of them.  For example, there are


### PR DESCRIPTION
Move building `script` command logic to `redis_build_script_cmd`
and use it in Redis and RedisCluster objects.
Fix memory leak in `cluster_raw_cmd` when `cluster_cmd_get_slot` fails.