### PR TITLE
FEATURE: Add tcp_keepalive option to redis sock

### DIFF
--- a/common.h
+++ b/common.h
@@ -478,7 +478,8 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_READ_TIMEOUT       3
 #define REDIS_OPT_SCAN               4
 #define REDIS_OPT_FAILOVER           5
-#define REDIS_OPT_COMPRESSION        6
+#define REDIS_OPT_TCP_KEEPALIVE      6
+#define REDIS_OPT_COMPRESSION        7
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -674,6 +675,7 @@ typedef struct {
     int            scan;
 
     int            readonly;
+    int            tcp_keepalive;
 } RedisSock;
 /* }}} */
 

--- a/library.c
+++ b/library.c
@@ -1402,6 +1402,7 @@ redis_sock_create(char *host, int host_len, unsigned short port,
     redis_sock->scan = REDIS_SCAN_NORETRY;
 
     redis_sock->readonly = 0;
+    redis_sock->tcp_keepalive = 0;
 
     return redis_sock;
 }
@@ -1470,10 +1471,12 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
         return -1;
     }
 
-    /* Attempt to set TCP_NODELAY if we're not using a unix socket. */
+    /* Attempt to set TCP_NODELAY/TCP_KEEPALIVE if we're not using a unix socket. */
     sock = (php_netstream_data_t*)redis_sock->stream->abstract;
     if (!usocket) {
         err = setsockopt(sock->socket, IPPROTO_TCP, TCP_NODELAY, (char *) &tcp_flag, sizeof(int));
+        PHPREDIS_NOTUSED(err);
+        err = setsockopt(sock->socket, SOL_SOCKET, SO_KEEPALIVE, (const void *) &redis_sock->tcp_keepalive, sizeof(int));
         PHPREDIS_NOTUSED(err);
     }
 

--- a/redis.c
+++ b/redis.c
@@ -676,6 +676,7 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) 
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SERIALIZER"), REDIS_OPT_SERIALIZER TSRMLS_CC);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_PREFIX"), REDIS_OPT_PREFIX TSRMLS_CC);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_READ_TIMEOUT"), REDIS_OPT_READ_TIMEOUT TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_TCP_KEEPALIVE"), REDIS_OPT_TCP_KEEPALIVE TSRMLS_CC);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION TSRMLS_CC);
 
     /* serializer */


### PR DESCRIPTION
Here is our access model `Redis -> LVS -> Redis`, we use `LVS` as load balance for the Redis server.

We occur the `read error on connection` when the `LVS` kick off the connection without `fin`, so it makes sense to keepalive？and phpredis would be reconnected.
