### PR TITLE
the element of z_seeds may be a reference on php7

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -198,11 +198,11 @@ _**Description**_: Connects to a Redis instance.
 
 ##### *Parameters*
 
-*host*: string. can be a host, or the path to a unix domain socket
-*port*: int, optional
-*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
-*reserved*: should be NULL if retry_interval is specified
-*retry_interval*: int, value in milliseconds (optional)
+*host*: string. can be a host, or the path to a unix domain socket  
+*port*: int, optional  
+*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
+*reserved*: should be NULL if retry_interval is specified  
+*retry_interval*: int, value in milliseconds (optional)  
 *read_timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
 
 ##### *Return value*
@@ -235,11 +235,11 @@ persistent equivalents.
 
 ##### *Parameters*
 
-*host*: string. can be a host, or the path to a unix domain socket
-*port*: int, optional
-*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
-*persistent_id*: string. identity for the requested persistent connection
-*retry_interval*: int, value in milliseconds (optional)
+*host*: string. can be a host, or the path to a unix domain socket  
+*port*: int, optional  
+*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
+*persistent_id*: string. identity for the requested persistent connection  
+*retry_interval*: int, value in milliseconds (optional)  
 *read_timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
 
 ##### *Return value*
@@ -293,7 +293,7 @@ _**Description**_: Disconnects from the Redis instance, except when `pconnect` i
 _**Description**_: Set client option.
 
 ##### *Parameters*
-*parameter name*
+*parameter name*  
 *parameter value*
 
 ##### *Return value*
@@ -410,12 +410,12 @@ $redis->bgSave();
 _**Description**_: Get or Set the Redis server configuration parameters.
 
 ##### *Parameters*
-*operation* (string) either `GET` or `SET`
-*key* string for `SET`, glob-pattern for `GET`. See http://redis.io/commands/config-get for examples.
+*operation* (string) either `GET` or `SET`  
+*key* string for `SET`, glob-pattern for `GET`. See http://redis.io/commands/config-get for examples.  
 *value* optional string (only for `SET`)
 
 ##### *Return value*
-*Associative array* for `GET`, key -> value
+*Associative array* for `GET`, key -> value  
 *bool* for `SET`
 
 ##### *Examples*
@@ -583,7 +583,7 @@ _**Description**_: Return the current server time.
 (none)
 
 ##### *Return value*
-If successfull, the time will come back as an associative array with element zero being
+If successful, the time will come back as an associative array with element zero being
 the unix timestamp, and element one being microseconds.
 
 ##### *Examples*
@@ -596,7 +596,7 @@ $redis->time();
 _**Description**_: Access the Redis slowLog
 
 ##### *Parameters*
-*Operation* (string): This can be either `GET`, `LEN`, or `RESET`
+*Operation* (string): This can be either `GET`, `LEN`, or `RESET`  
 *Length* (integer), optional: If executing a `SLOWLOG GET` command, you can pass an optional length.
 #####
 
@@ -690,8 +690,8 @@ $redis->get('key');
 _**Description**_: Set the string value in argument as value of the key.  If you're using Redis >= 2.6.12, you can pass extended options as explained below
 
 ##### *Parameters*
-*Key*
-*Value*
+*Key*  
+*Value*  
 *Timeout or Options Array* (optional). If you pass an integer, phpredis will redirect to SETEX, and will try to use Redis >= 2.6.12 extended options if you pass an array with valid values
 
 ##### *Return value*
@@ -793,7 +793,7 @@ $redis->exists('NonExistingKey'); /* FALSE */
 _**Description**_: Increment the number stored at key by one. If the second argument is filled, it will be used as the integer value of the increment.
 
 ##### *Parameters*
-*key*
+*key*  
 *value*: value that will be added to key (only for incrBy)
 
 ##### *Return value*
@@ -815,7 +815,7 @@ $redis->incrBy('key1', 10); /* 14 */
 _**Description**_: Increment the key with floating point precision.
 
 ##### *Parameters*
-*key*
+*key*  
 *value*: (float) value that will be added to the key
 
 ##### *Return value*
@@ -836,8 +836,8 @@ $redis->incrByFloat('key1', 2.5); /* 4 */
 _**Description**_: Decrement the number stored at key by one. If the second argument is filled, it will be used as the integer value of the decrement.
 
 ##### *Parameters*
-*key*
-*value*: value that will be substracted to key (only for decrBy)
+*key*  
+*value*: value that will be subtracted to key (only for decrBy)
 
 ##### *Return value*
 *INT* the new value
@@ -854,7 +854,7 @@ $redis->decrBy('key1', 10); /* -13 */
 
 ### mGet, getMultiple
 -----
-_**Description**_: Get the values of all the specified keys. If one or more keys dont exist, the array will contain `FALSE` at the position of the key.
+_**Description**_: Get the values of all the specified keys. If one or more keys don't exist, the array will contain `FALSE` at the position of the key.
 
 ##### *Parameters*
 *Array*: Array containing the list of the keys
@@ -1075,12 +1075,12 @@ _**Description**_: Returns the type of data pointed by a given key.
 
 ##### *Return value*
 
-Depending on the type of the data pointed by the key, this method will return the following value:
-string: Redis::REDIS_STRING
-set: Redis::REDIS_SET
-list: Redis::REDIS_LIST
-zset: Redis::REDIS_ZSET
-hash: Redis::REDIS_HASH
+Depending on the type of the data pointed by the key, this method will return the following value:  
+string: Redis::REDIS_STRING  
+set: Redis::REDIS_SET  
+list: Redis::REDIS_LIST  
+zset: Redis::REDIS_ZSET  
+hash: Redis::REDIS_HASH  
 other: Redis::REDIS_NOT_FOUND
 
 ##### *Example*
@@ -1113,8 +1113,8 @@ _**Description**_: Return a substring of a larger string
 *Note*: substr also supported but deprecated in redis.
 
 ##### *Parameters*
-*key*
-*start*
+*key*  
+*start*  
 *end*
 
 ##### *Return value*
@@ -1167,7 +1167,7 @@ $redis->strlen('key'); /* 5 */
 _**Description**_: Return a single bit out of a larger string
 
 ##### *Parameters*
-*key*
+*key*  
 *offset*
 
 ##### *Return value*
@@ -1185,8 +1185,8 @@ $redis->getBit('key', 1); /* 1 */
 _**Description**_: Changes a single bit of a string.
 
 ##### *Parameters*
-*key*
-*offset*
+*key*  
+*offset*  
 *value*: bool or int (1 or 0)
 
 ##### *Return value*
@@ -1205,9 +1205,9 @@ $redis->get('key'); /* chr(0x2f) = "/" = b("0010 1111") */
 _**Description**_: Bitwise operation on multiple keys.
 
 ##### *Parameters*
-*operation*: either "AND", "OR", "NOT", "XOR"
-*ret_key*: return key
-*key1*
+*operation*: either "AND", "OR", "NOT", "XOR"  
+*ret_key*: return key  
+*key1*  
 *key2...*
 
 ##### *Return value*
@@ -1332,8 +1332,8 @@ $val = $redis->dump('foo'); // $val will be the Redis encoded key value
 -----
 _**Description**_: Restore a key from the result of a DUMP operation.
 ##### *Parameters*
-*key* string.  The key name
-*ttl* integer.  How long the key should live (if zero, no expire will be set on the key)
+*key* string.  The key name  
+*ttl* integer.  How long the key should live (if zero, no expire will be set on the key)  
 *value* string (binary).  The Redis encoded key value (from DUMP)
 ##### *Examples*
 ~~~
@@ -1391,8 +1391,8 @@ $redis->migrate('backup', 6379, ['key1', 'key2', 'key3'], 0, 3600);
 -----
 _**Description**_: Adds a value to the hash stored at key.
 ##### *Parameters*
-*key*
-*hashKey*
+*key*  
+*hashKey*  
 *value*
 
 ##### *Return value*
@@ -1426,11 +1426,11 @@ $redis->hSetNx('h', 'key1', 'world'); /* FALSE, 'key1' => 'hello' in the hash at
 -----
 _**Description**_: Gets a value from the hash stored at key. If the hash table doesn't exist, or the key doesn't exist, `FALSE` is returned.
 ##### *Parameters*
-*key*
+*key*  
 *hashKey*
 
 ##### *Return value*
-*STRING* The value, if the command executed successfully
+*STRING* The value, if the command executed successfully  
 *BOOL* `FALSE` in case of failure
 
 
@@ -1454,9 +1454,9 @@ $redis->hLen('h'); /* returns 2 */
 -----
 _**Description**_: Removes a value from the hash stored at key. If the hash table doesn't exist, or the key doesn't exist, `FALSE` is returned.
 ##### *Parameters*
-*key*
-*hashKey1*
-*hashKey2*
+*key*  
+*hashKey1*  
+*hashKey2*  
 ...
 
 ##### *Return value*
@@ -1572,7 +1572,7 @@ The order is random and corresponds to redis' own internal representation of the
 -----
 _**Description**_: Verify if the specified member exists in a key.
 ##### *Parameters*
-*key*
+*key*  
 *memberKey*
 ##### *Return value*
 *BOOL*: If the member exists in the hash table, return `TRUE`, otherwise return `FALSE`.
@@ -1587,8 +1587,8 @@ $redis->hExists('h', 'NonExistingKey'); /* FALSE */
 -----
 _**Description**_: Increments the value of a member from a hash by a given amount.
 ##### *Parameters*
-*key*
-*member*
+*key*  
+*member*  
 *value*: (integer) value that will be added to the member's value
 ##### *Return value*
 *LONG* the new value
@@ -1603,8 +1603,8 @@ $redis->hIncrBy('h', 'x', 1); /* h[x] ← 2 + 1. Returns 3 */
 -----
 _**Description**_: Increments the value of a hash member by the provided float value
 ##### *Parameters*
-*key*
-*member*
+*key*  
+*member*  
 *value*: (float) value that will be added to the member's value
 ##### *Return value*
 *FLOAT* the new value
@@ -1620,7 +1620,7 @@ $redis->hIncrByFloat('h', 'x', -3.0); /* returns 0.0: h[x] = 0.0 now */
 -----
 _**Description**_: Fills in a whole hash. Non-string values are converted to string, using the standard `(string)` cast. NULL values are stored as empty strings.
 ##### *Parameters*
-*key*
+*key*  
 *members*: key → value array
 ##### *Return value*
 *BOOL*
@@ -1635,7 +1635,7 @@ $redis->hIncrBy('user:1', 'salary', 100); // Joe earns 100 more now.
 -----
 _**Description**_: Retrieve the values associated to the specified fields in the hash.
 ##### *Parameters*
-*key*
+*key*  
 *memberKeys* Array
 ##### *Return value*
 *Array* An array of elements, the values of the specified fields in the hash, with the hash keys as array keys.
@@ -1651,10 +1651,10 @@ $redis->hMGet('h', array('field1', 'field2')); /* returns array('field1' => 'val
 -----
 _**Description**_:  Scan a HASH value for members, with an optional pattern and count
 ##### *Parameters*
-*key*: String
-*iterator*: Long (reference)
-*pattern*: Optional pattern to match against
-*count*: How many keys to return in a go (only a sugestion to Redis)
+*key*: String  
+*iterator*: Long (reference)  
+*pattern*: Optional pattern to match against  
+*count*: How many keys to return in a go (only a suggestion to Redis)
 ##### *Return value*
 *Array* An array of members that match our pattern
 
@@ -1674,7 +1674,7 @@ while($arr_keys = $redis->hScan('hash', $it)) {
 -----
 _**Description**_: Get the string length of the value associated with field in the hash stored at key.
 ##### *Parameters*
-*key*: String
+*key*: String  
 *field*: String
 ##### *Return value*
 *LONG* the string length of the value associated with field, or zero when field is not present in the hash or key does not exist at all.
@@ -1704,14 +1704,14 @@ _**Description**_: Is a blocking lPop(rPop) primitive. If at least one of the li
 If all the list identified by the keys passed in arguments are empty, blPop will block during the specified timeout until an element is pushed to one of those lists. This element will be popped.
 
 ##### *Parameters*
-*ARRAY* Array containing the keys of the lists
-*INTEGER* Timeout
-Or
-*STRING* Key1
-*STRING* Key2
-*STRING* Key3
-...
-*STRING* Keyn
+*ARRAY* Array containing the keys of the lists  
+*INTEGER* Timeout  
+Or  
+*STRING* Key1  
+*STRING* Key2  
+*STRING* Key3  
+...  
+*STRING* Keyn  
 *INTEGER* Timeout
 
 ##### *Return value*
@@ -1750,8 +1750,8 @@ $redis->lPush('key1', 'A');
 _**Description**_: A blocking version of `rPopLPush`, with an integral timeout in the third parameter.
 
 ##### *Parameters*
-*Key*: srckey
-*Key*: dstkey
+*Key*: srckey  
+*Key*: dstkey  
 *Long*: timeout
 
 ##### *Return value*
@@ -1761,17 +1761,17 @@ _**Description**_: A blocking version of `rPopLPush`, with an integral timeout i
 -----
 _**Description**_: Return the specified element of the list stored at the specified key.
 
-0 the first element, 1 the second ...
+0 the first element, 1 the second ...  
 -1 the last element, -2 the penultimate ...
 
 Return `FALSE` in case of a bad index or a key that doesn't point to a list.
 
 ##### *Parameters*
-*key*
+*key*  
 *index*
 
 ##### *Return value*
-*String* the element at this index
+*String* the element at this index  
 *Bool* `FALSE` if the key identifies a non-string data type, or no value corresponds to this index in the list `Key`.
 
 ##### *Example*
@@ -1792,9 +1792,9 @@ The parameter options specify the position of the insert (before or after).
 If the list didn't exists, or the pivot didn't exists, the value is not inserted.
 
 ##### *Parameters*
-*key*
-*position*  Redis::BEFORE | Redis::AFTER
-*pivot*
+*key*  
+*position*  Redis::BEFORE | Redis::AFTER  
+*pivot*  
 *value*
 
 ##### *Return value*
@@ -1826,7 +1826,7 @@ _**Description**_: Return and remove the first element of the list.
 *key*
 
 ##### *Return value*
-*STRING* if command executed successfully
+*STRING* if command executed successfully  
 *BOOL* `FALSE` in case of failure (empty list)
 
 ##### *Example*
@@ -1842,7 +1842,7 @@ $redis->lPop('key1'); /* key1 => [ 'B', 'C' ] */
 _**Description**_: Adds the string value to the head (left) of the list. Creates the list if the key didn't exist. If the key exists and is not a list, `FALSE` is returned.
 
 ##### *Parameters*
-*key*
+*key*  
 *value* String, value to push in key
 
 ##### *Return value*
@@ -1862,7 +1862,7 @@ $redis->lPush('key1', 'A'); // returns 3
 _**Description**_: Adds the string value to the head (left) of the list if the list exists.
 
 ##### *Parameters*
-*key*
+*key*  
 *value* String, value to push in key
 
 ##### *Return value*
@@ -1880,13 +1880,13 @@ $redis->lPushx('key1', 'C'); // returns 3
 
 ### lRange, lGetRange
 -----
-_**Description**_: Returns the specified elements of the list stored at the specified key in the range [start, end]. start and stop are interpretated as indices:
-0 the first element, 1 the second ...
+_**Description**_: Returns the specified elements of the list stored at the specified key in the range [start, end]. start and stop are interpreted as indices:  
+0 the first element, 1 the second ...  
 -1 the last element, -2 the penultimate ...
 
 ##### *Parameters*
-*key*
-*start*
+*key*  
+*start*  
 *end*
 
 ##### *Return value*
@@ -1902,17 +1902,17 @@ $redis->lRange('key1', 0, -1); /* array('A', 'B', 'C') */
 
 ### lRem, lRemove
 -----
-_**Description**_: Removes the first `count` occurences of the value element from the list. If count is zero, all the matching elements are removed. If count is negative, elements are removed from tail to head.
+_**Description**_: Removes the first `count` occurrences of the value element from the list. If count is zero, all the matching elements are removed. If count is negative, elements are removed from tail to head.
 
 **Note**: The argument order is not the same as in the Redis documentation. This difference is kept for compatibility reasons.
 
 ##### *Parameters*
-*key*
-*value*
+*key*  
+*value*  
 *count*
 
 ##### *Return value*
-*LONG* the number of elements to remove
+*LONG* the number of elements to remove  
 *BOOL* `FALSE` if the value identified by key is not a list.
 
 ##### *Example*
@@ -1933,12 +1933,12 @@ $redis->lRange('key1', 0, -1); /* array('C', 'B', 'A') */
 _**Description**_: Set the list at index with the new value.
 
 ##### *Parameters*
-*key*
-*index*
+*key*  
+*index*  
 *value*
 
 ##### *Return value*
-*BOOL* `TRUE` if the new value is setted. `FALSE` if the index is out of range, or data type identified by key is not a list.
+*BOOL* `TRUE` if the new value was set. `FALSE` if the index is out of range, or data type identified by key is not a list.
 
 ##### *Example*
 ~~~
@@ -1955,12 +1955,12 @@ $redis->lGet('key1', 0); /* 'X' */
 _**Description**_: Trims an existing list so that it will contain only a specified range of elements.
 
 ##### *Parameters*
-*key*
-*start*
+*key*  
+*start*  
 *stop*
 
 ##### *Return value*
-*Array*
+*Array*  
 *Bool* return `FALSE` if the key identify a non-list value.
 
 ##### *Example*
@@ -1981,7 +1981,7 @@ _**Description**_: Returns and removes the last element of the list.
 *key*
 
 ##### *Return value*
-*STRING* if command executed successfully
+*STRING* if command executed successfully  
 *BOOL* `FALSE` in case of failure (empty list)
 
 ##### *Example*
@@ -1997,7 +1997,7 @@ $redis->rPop('key1'); /* key1 => [ 'A', 'B' ] */
 _**Description**_: Pops a value from the tail of a list, and pushes it to the front of another list. Also return this value. (redis >= 1.1)
 
 ##### *Parameters*
-*Key*: srckey
+*Key*: srckey  
 *Key*: dstkey
 
 ##### *Return value*
@@ -2040,7 +2040,7 @@ array(3) {
 _**Description**_: Adds the string value to the tail (right) of the list. Creates the list if the key didn't exist. If the key exists and is not a list, `FALSE` is returned.
 
 ##### *Parameters*
-*key*
+*key*  
 *value* String, value to push in key
 
 ##### *Return value*
@@ -2060,7 +2060,7 @@ $redis->rPush('key1', 'C'); // returns 3
 _**Description**_: Adds the string value to the tail (right) of the list if the ist exists. `FALSE` in case of Failure.
 
 ##### *Parameters*
-*key*
+*key*  
 *value* String, value to push in key
 
 ##### *Return value*
@@ -2086,7 +2086,7 @@ If the list didn't exist or is empty, the command returns 0. If the data type id
 *Key*
 
 ##### *Return value*
-*LONG* The size of the list identified by Key exists.
+*LONG* The size of the list identified by Key exists.  
 *BOOL* `FALSE` if the data type identified by Key is not list
 
 ##### *Example*
@@ -2122,7 +2122,7 @@ $redis->lSize('key1');/* 2 */
 -----
 _**Description**_: Adds a value to the set value stored at key. If this value is already in the set, `FALSE` is returned.
 ##### *Parameters*
-*key*
+*key*  
 *value*
 
 ##### *Return value*
@@ -2233,7 +2233,7 @@ key1, key2, keyN: keys identifying the different sets on which we will apply the
 
 ##### *Return value*
 
-Array, contain the result of the intersection between those keys. If the intersection beteen the different sets is empty, the return value will be empty array.
+Array, contain the result of the intersection between those keys. If the intersection between the different sets is empty, the return value will be empty array.
 
 ##### *Examples*
 ~~~
@@ -2307,7 +2307,7 @@ array(2) {
 -----
 _**Description**_: Checks if `value` is a member of the set stored at the key `key`.
 ##### *Parameters*
-*key*
+*key*  
 *value*
 
 ##### *Return value*
@@ -2359,8 +2359,8 @@ The order is random and corresponds to redis' own internal representation of the
 -----
 _**Description**_: Moves the specified member from the set at srcKey to the set at dstKey.
 ##### *Parameters*
-*srcKey*
-*dstKey*
+*srcKey*  
+*dstKey*  
 *member*
 ##### *Return value*
 *BOOL* If the operation is successful, return `TRUE`. If the srcKey and/or dstKey didn't exist, and/or the member didn't exist in srcKey, `FALSE` is returned.
@@ -2380,13 +2380,13 @@ $redis->sMove('key1', 'key2', 'member13'); /* 'key1' =>  {'member11', 'member12'
 -----
 _**Description**_: Removes and returns a random element from the set value at Key.
 ##### *Parameters*
-*key*
+*key*  
 *count*: Integer, optional
 ##### *Return value (without count argument)*
-*String* "popped" value
+*String* "popped" value  
 *Bool* `FALSE` if set identified by key is empty or doesn't exist.
 ##### *Return value (with count argument)*
-*Array*: Member(s) returned or an empty array if the set doesn't exist
+*Array*: Member(s) returned or an empty array if the set doesn't exist  
 *Bool*: `FALSE` on error if the key is not a set
 ##### *Example*
 ~~~
@@ -2405,7 +2405,7 @@ $redis->sPop('key2', 3); /* Will return all members but in no particular order *
 -----
 _**Description**_: Returns a random element from the set value at Key, without removing it.
 ##### *Parameters*
-*key*
+*key*  
 *count* (Integer, optional)
 ##### *Return value*
 If no count is provided, a random *String* value from the set will be returned.  If a count
@@ -2434,7 +2434,7 @@ $redis->sRandMember('not-a-set', 100); // Will return FALSE
 -----
 _**Description**_: Removes the specified member from the set value stored at key.
 ##### *Parameters*
-*key*
+*key*  
 *member*
 ##### *Return value*
 *LONG* The number of elements removed from the set.
@@ -2529,9 +2529,9 @@ array(4) {
 _**Description**_: Scan a set for members
 
 ##### *Parameters*
-*Key*: The set to search
-*iterator*: LONG (reference) to the iterator as we go
-*pattern*: String, optional pattern to match against
+*Key*: The set to search  
+*iterator*: LONG (reference) to the iterator as we go  
+*pattern*: String, optional pattern to match against  
 *count*: How many members to return at a time (Redis might return a different amount)
 
 ##### *Return value*
@@ -2569,7 +2569,7 @@ while(($arr_mems = $redis->sScan('set', $it, "*pattern*"))!==FALSE) {
 * [zInter](#zinter) - Intersect multiple sorted sets and store the resulting sorted set in a new key
 * [zRange](#zrange) - Return a range of members in a sorted set, by index
 * [zRangeByScore, zRevRangeByScore](#zrangebyscore-zrevrangebyscore) - Return a range of members in a sorted set, by score
-* [zRangeByLex](#zrangebylex) - Return a lexigraphical range from members that share the same score
+* [zRangeByLex](#zrangebylex) - Return a lexicographical range from members that share the same score
 * [zRank, zRevRank](#zrank-zrevrank) - Determine the index of a member in a sorted set
 * [zRem, zDelete](#zrem-zdelete) - Remove one or more members from a sorted set
 * [zRemRangeByRank, zDeleteRangeByRank](#zremrangebyrank-zdeleterangebyrank) - Remove all members in a sorted set within the given indexes
@@ -2585,7 +2585,7 @@ _**Description**_: Add one or more members to a sorted set or update its score i
 
 ##### *Parameters*
 *key*
-*score* : double
+*score*: double  
 *value*: string
 
 ##### *Return value*
@@ -2622,8 +2622,8 @@ $redis->zSize('key'); /* 3 */
 _**Description**_: Returns the *number* of elements of the sorted set stored at the specified key which have scores in the range [start,end]. Adding a parenthesis before `start` or `end` excludes it from the range. +inf and -inf are also valid limits.
 
 ##### *Parameters*
-*key*
-*start*: string
+*key*  
+*start*: string  
 *end*: string
 
 ##### *Return value*
@@ -2642,8 +2642,8 @@ $redis->zCount('key', 0, 3); /* 2, corresponding to array('val0', 'val2') */
 _**Description**_: Increments the score of a member from a sorted set by a given amount.
 
 ##### *Parameters*
-*key*
-*value*: (double) value that will be added to the member's score
+*key*  
+*value*: (double) value that will be added to the member's score  
 *member*
 
 ##### *Return value*
@@ -2661,13 +2661,13 @@ $redis->zIncrBy('key', 1, 'member1'); /* 3.5 */
 -----
 _**Description**_: Creates an intersection of sorted sets given in second argument. The result of the union will be stored in the sorted set defined by the first argument.
 
-The third optionnel argument defines `weights` to apply to the sorted sets in input. In this case, the `weights` will be multiplied by the score of each element in the sorted set before applying the aggregation.
+The third optional argument defines `weights` to apply to the sorted sets in input. In this case, the `weights` will be multiplied by the score of each element in the sorted set before applying the aggregation.
 The forth argument defines the `AGGREGATE` option which specify how the results of the union are aggregated.
 
 ##### *Parameters*
-*keyOutput*
-*arrayZSetKeys*
-*arrayWeights*
+*keyOutput*  
+*arrayZSetKeys*  
+*arrayWeights*  
 *aggregateFunction* Either "SUM", "MIN", or "MAX": defines the behaviour to use on duplicate entries during the zInter.
 
 ##### *Return value*
@@ -2703,14 +2703,14 @@ $redis->zInter('ko4', array('k1', 'k2'), array(1, 5), 'max'); /* 2, 'ko4' => arr
 -----
 _**Description**_: Returns a range of elements from the ordered set stored at the specified key, with values in the range [start, end].
 
-Start and stop are interpreted as zero-based indices:
-0 the first element, 1 the second ...
--1 the last element, -2 the penultimate ...
+Start and stop are interpreted as zero-based indices:  
+`0` the first element, `1` the second ...  
+`-1` the last element, `-2` the penultimate ...  
 
 ##### *Parameters*
 *key*
-*start*: long
-*end*: long
+*start*: long  
+*end*: long  
 *withscores*: bool = false
 
 ##### *Return value*
@@ -2732,9 +2732,9 @@ $redis->zRange('key1', 0, -1, true); /* array('val0' => 0, 'val2' => 2, 'val10' 
 _**Description**_: Returns the elements of the sorted set stored at the specified key which have scores in the range [start,end]. Adding a parenthesis before `start` or `end` excludes it from the range. +inf and -inf are also valid limits. zRevRangeByScore returns the same items in reverse order, when the `start` and `end` parameters are swapped.
 
 ##### *Parameters*
-*key*
-*start*: string
-*end*: string
+*key*  
+*start*: string  
+*end*: string  
 *options*: array
 
 Two options are available: `withscores => TRUE`, and `limit => array($offset, $count)`
@@ -2755,13 +2755,13 @@ $redis->zRangeByScore('key', 0, 3, array('withscores' => TRUE, 'limit' => array(
 
 ### zRangeByLex
 -----
-_**Description**_:  Returns a lexigraphical range of members in a sorted set, assuming the members have the same score.  The min and max values are required to start with '(' (exclusive), '[' (inclusive), or be exactly the values '-' (negative inf) or '+' (positive inf).  The command must be called with either three *or* five arguments or will return FALSE.
+_**Description**_:  Returns a lexicographical range of members in a sorted set, assuming the members have the same score.  The min and max values are required to start with '(' (exclusive), '[' (inclusive), or be exactly the values '-' (negative inf) or '+' (positive inf).  The command must be called with either three *or* five arguments or will return FALSE.
 
 ##### *Parameters*
-*key*: The ZSET you wish to run against
-*min*: The minimum alphanumeric value you wish to get
-*max*: The maximum alphanumeric value you wish to get
-*offset*:  Optional argument if you wish to start somewhere other than the first element.
+*key*: The ZSET you wish to run against  
+*min*: The minimum alphanumeric value you wish to get  
+*max*: The maximum alphanumeric value you wish to get  
+*offset*:  Optional argument if you wish to start somewhere other than the first element.  
 *limit*: Optional argument if you wish to limit the number of elements returned.
 
 ##### *Return value*
@@ -2782,7 +2782,7 @@ $redis->zRangeByLex('key','-','[c',1,2) /* Array('b','c') */
 _**Description**_: Returns the rank of a given member in the specified sorted set, starting at 0 for the item with the smallest score. zRevRank starts at 0 for the item with the *largest* score.
 
 ##### *Parameters*
-*key*
+*key*  
 *member*
 
 ##### *Return value*
@@ -2804,7 +2804,7 @@ $redis->zRevRank('key', 'two'); /* 0 */
 _**Description**_: Deletes a specified member from the ordered set.
 
 ##### *Parameters*
-*key*
+*key*  
 *member*
 
 ##### *Return value*
@@ -2824,8 +2824,8 @@ $redis->zRange('key', 0, -1); /* array('val0', 'val10') */
 _**Description**_: Deletes the elements of the sorted set stored at the specified key which have rank in the range [start,end].
 
 ##### *Parameters*
-*key*
-*start*: LONG
+*key*  
+*start*: LONG  
 *end*: LONG
 
 ##### *Return value*
@@ -2845,8 +2845,8 @@ $redis->zRange('key', 0, -1, array('withscores' => TRUE)); /* array('three' => 3
 _**Description**_: Deletes the elements of the sorted set stored at the specified key which have scores in the range [start,end].
 
 ##### *Parameters*
-*key*
-*start*: double or "+inf" or "-inf" string
+*key*  
+*start*: double or "+inf" or "-inf" string  
 *end*: double or "+inf" or "-inf" string
 
 ##### *Return value*
@@ -2862,14 +2862,14 @@ $redis->zRemRangeByScore('key', 0, 3); /* 2 */
 
 ### zRevRange
 -----
-_**Description**_: Returns the elements of the sorted set stored at the specified key in the range [start, end] in reverse order. start and stop are interpretated as zero-based indices:
-0 the first element, 1 the second ...
--1 the last element, -2 the penultimate ...
+_**Description**_: Returns the elements of the sorted set stored at the specified key in the range [start, end] in reverse order. start and stop are interpreted as zero-based indices:  
+`0` the first element, `1` the second ...  
+`-1` the last element, `-2` the penultimate ...
 
 ##### *Parameters*
-*key*
-*start*: long
-*end*: long
+*key*  
+*start*: long  
+*end*: long  
 *withscores*: bool = false
 
 ##### *Return value*
@@ -2891,7 +2891,7 @@ $redis->zRevRange('key', 0, -1, true); /* array('val10' => 10, 'val2' => 2, 'val
 _**Description**_: Returns the score of a given member in the specified sorted set.
 
 ##### *Parameters*
-*key*
+*key*  
 *member*
 
 ##### *Return value*
@@ -2907,13 +2907,13 @@ $redis->zScore('key', 'val2'); /* 2.5 */
 -----
 _**Description**_: Creates an union of sorted sets given in second argument. The result of the union will be stored in the sorted set defined by the first argument.
 
-The third optionnel argument defines `weights` to apply to the sorted sets in input. In this case, the `weights` will be multiplied by the score of each element in the sorted set before applying the aggregation.
+The third optional argument defines `weights` to apply to the sorted sets in input. In this case, the `weights` will be multiplied by the score of each element in the sorted set before applying the aggregation.
 The forth argument defines the `AGGREGATE` option which specify how the results of the union are aggregated.
 
 ##### *Parameters*
-*keyOutput*
-*arrayZSetKeys*
-*arrayWeights*
+*keyOutput*  
+*arrayZSetKeys*  
+*arrayWeights*  
 *aggregateFunction* Either "SUM", "MIN", or "MAX": defines the behaviour to use on duplicate entries during the zUnion.
 
 ##### *Return value*
@@ -2946,9 +2946,9 @@ $redis->zUnion('ko3', array('k1', 'k2'), array(5, 1)); /* 4, 'ko3' => array('val
 _**Description**_: Scan a sorted set for members, with optional pattern and count
 
 ##### *Parameters*
-*key*: String, the set to scan
-*iterator*: Long (reference), initialized to NULL
-*pattern*: String (optional), the pattern to match
+*key*: String, the set to scan  
+*iterator*: Long (reference), initialized to NULL  
+*pattern*: String (optional), the pattern to match  
 *count*: How many keys to return per iteration (Redis might return a different number)
 
 ##### *Return value*
@@ -2972,15 +2972,15 @@ while($arr_matches = $redis->zScan('zset', $it, '*pattern*')) {
 
 ##### *Prototype*  
 ~~~
-$redis->geoAdd($key, $longitude, $latitude, $member [, $longitude, $lattitude, $member, ...]);
+$redis->geoAdd($key, $longitude, $latitude, $member [, $longitude, $latitude, $member, ...]);
 ~~~
 
-_**Description**_:  Add one or more geospacial items to the specified key.  This function must be called with at least one _longitude, latitude, member_ triplet.   
+_**Description**_:  Add one or more geospatial items to the specified key.  This function must be called with at least one _longitude, latitude, member_ triplet.
 
-##### *Return value*  
-*Integer*:  The number of elements added to the geospacial key.
+##### *Return value*
+*Integer*:  The number of elements added to the geospatial key.
 
-##### *Example*  
+##### *Example*
 ~~~
 $redis->del("myplaces");
 
@@ -2995,12 +2995,12 @@ $result = $redis->geoAdd(
 ### geoHash
 -----
 
-##### *Prototype*  
+##### *Prototype*
 ~~~
 $redis->geoHash($key, $member [, $member, $member, ...]);
 ~~~
 
-_**Description**_:  Retreive Geohash strings for one or more elements of a geospacial index.  
+_**Description**_:  Retrieve Geohash strings for one or more elements of a geospatial index.  
 
 ##### *Return value*  
 *Array*:  One or more Redis Geohash encoded strings.  
@@ -3030,7 +3030,7 @@ array(2) {
 $redis->geoPos($key, $member [, $member, $member, ...]);
 ~~~
 
-_**Description**_:  Return longitude, lattitude positions for each requested member.
+_**Description**_:  Return longitude, latitude positions for each requested member.
 
 ##### *Return value*  
 *Array*:  One or more longitude/latitude positions
@@ -3071,7 +3071,7 @@ $redis->geoDist($key, $member1, $member2 [, $unit]);
 ~~~
 
 
-_**Description**_:  Return the distance between two members in a geospacial set.  If units are passed it must be one of the following values:
+_**Description**_:  Return the distance between two members in a geospatial set.  If units are passed it must be one of the following values:
 
 * 'm' => Meters
 * 'km' => Kilometers
@@ -3121,7 +3121,7 @@ bool(false)
 $redis->geoRadius($key, $longitude, $latitude, $radius, $unit [, Array $options]);
 ~~~
 
-_**Description**_:  Return members of a set with geospacial information that are within the radius specified by the caller. 
+_**Description**_:  Return members of a set with geospatial information that are within the radius specified by the caller. 
 
 ##### *Options Array*
 The georadius command can be called with various options that control how Redis returns results.  The following table describes the options phpredis supports.  All options are case insensitive.  
@@ -3135,7 +3135,7 @@ The georadius command can be called with various options that control how Redis 
 |       | ASC         | Sort results in ascending order
 |       | DESC        | Sort results in descending order
 
- *Note*:  It doesn't make sense to pass both `ASC` and `DESC` options but if both are passed the last one passed will win!  
+ *Note*:  It doesn't make sense to pass both `ASC` and `DESC` options but if both are passed the last one passed will be used.  
  *Note*:  PhpRedis does not currently support the `STORE` or `STOREDIST` options but will be added to future versions.
 
 ##### *Return value*
@@ -3220,7 +3220,7 @@ array(1) {
 $redis->geoRadiusByMember($key, $member, $radius, $units [, Array $options]);
 ~~~
 
-_**Description**_: This method is identical to [geoRadius](#georadius) except that instead of passing a longitude and latitude as the "source" you pass an existing member in the geospacial set.
+_**Description**_: This method is identical to [geoRadius](#georadius) except that instead of passing a longitude and latitude as the "source" you pass an existing member in the geospatial set.
 
 ##### *Options Array*
 See [geoRadius](#georadius) command for options array.
@@ -3286,8 +3286,8 @@ function pSubscribe($redis, $pattern, $chan, $msg) {
 _**Description**_: Publish messages to channels. Warning: this function will probably change in the future.
 
 ##### *Parameters*
-*channel*: a channel to publish to
-*messsage*: string
+*channel*: a channel to publish to  
+*message*: string
 
 ##### *Example*
 ~~~
@@ -3299,8 +3299,8 @@ $redis->publish('chan-1', 'hello, world!'); // send message.
 _**Description**_: Subscribe to channels. Warning: this function will probably change in the future.
 
 ##### *Parameters*
-*channels*: an array of channels to subscribe to
-*callback*: either a string or an array($instance, 'method_name'). The callback function receives 3 parameters: the redis instance, the channel name, and the message.
+*channels*: an array of channels to subscribe to  
+*callback*: either a string or an array($instance, 'method_name'). The callback function receives 3 parameters: the redis instance, the channel name, and the message.  
 *return value*:  Mixed.  Any non-null return value in the callback will be returned to the caller.
 ##### *Example*
 ~~~
@@ -3328,12 +3328,12 @@ $redis->subscribe(array('chan-1', 'chan-2', 'chan-3'), 'f'); // subscribe to 3 c
 _**Description**_: A command allowing you to get information on the Redis pub/sub system.
 
 ##### *Parameters*
-*keyword*: String, which can be: "channels", "numsub", or "numpat"
+*keyword*: String, which can be: "channels", "numsub", or "numpat"  
 *argument*:  Optional, variant.  For the "channels" subcommand, you can pass a string pattern.  For "numsub" an array of channel names.
 
 ##### *Return value*
-*CHANNELS*: Returns an array where the members are the matching channels.
-*NUMSUB*:  Returns a key/value array where the keys are channel names and values are their counts.
+*CHANNELS*: Returns an array where the members are the matching channels.  
+*NUMSUB*:  Returns a key/value array where the keys are channel names and values are their counts.  
 *NUMPAT*:  Integer return containing the number active pattern subscriptions
 
 ##### *Example*
@@ -3446,8 +3446,8 @@ $ret = FALSE if x has been modified between the call to WATCH and the call to EX
 _**Description**_: Evaluate a LUA script serverside
 
 ##### *Parameters*
-*script* string.
-*args* array, optional.
+*script* string.  
+*args* array, optional.  
 *num_keys* int, optional.
 
 ##### *Return value*
@@ -3475,8 +3475,8 @@ In order to run this command Redis will have to have already loaded the script,
 either by running it or via the SCRIPT LOAD command.
 
 ##### *Parameters*
-*script_sha* string.  The sha1 encoded hash of the script you want to run.
-*args* array, optional.  Arguments to pass to the LUA script.
+*script_sha* string.  The sha1 encoded hash of the script you want to run.  
+*args* array, optional.  Arguments to pass to the LUA script.  
 *num_keys* int, optional.  The number of arguments that should go into the KEYS array, vs. the ARGV array when Redis spins the script
 
 ##### *Return value*
@@ -3645,7 +3645,7 @@ None
 
 ### getHost
 -----
-_**Description**_:  Retreive our host or unix socket that we're connected to
+_**Description**_:  Retrieve our host or unix socket that we're connected to
 
 ##### *Parameters*
 None

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -894,6 +894,7 @@ cluster_init_seeds(redisCluster *cluster, HashTable *ht_seeds) {
     for (i = 0; i < count; i++) {
         z_seed = z_seeds[i];
 
+        ZVAL_DEREF(z_seed);
         /* Has to be a string */
         if (z_seed == NULL || Z_TYPE_P(z_seed) != IS_STRING)
             continue;


### PR DESCRIPTION
yesterday i used RedisCluster connect my redis cluser, code like this:
$hosts = [
"10.1.15.22:7100",
"10.1.15.22:7101",
];
array_walk($hosts, function(&$val) {
$val = trim($val);
});
$rc = new RedisCluster(null, $hosts, null, null, true);

this code runs normally on php5.x but error on php7.x, error info is:
PHP Fatal error: Uncaught RedisClusterException: Couldn't map cluster keyspace using any provided seed in /opt/php/test.php:14
Stack trace:
#0 /opt/php/test.php(14): RedisCluster->__construct(NULL, Array, NULL, NULL, true)
#1 {main}
thrown in /opt/php/test.php on line 14

tracing the source code of phpredis, i found the element of ht_seeds is a referent in function cluster_init_seeds on php7.x environment.

i fixed this problem and re-compiled the redis extension, and the code runs normally on php7