### PR TITLE
the element of z_seeds may be a reference on php7

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -894,6 +894,7 @@ cluster_init_seeds(redisCluster *cluster, HashTable *ht_seeds) {
     for (i = 0; i < count; i++) {
         z_seed = z_seeds[i];
 
+        ZVAL_DEREF(z_seed);
         /* Has to be a string */
         if (z_seed == NULL || Z_TYPE_P(z_seed) != IS_STRING)
             continue;


### PR DESCRIPTION
yesterday i used RedisCluster connect my redis cluser, code like this:
$hosts = [
"10.1.15.22:7100",
"10.1.15.22:7101",
];
array_walk($hosts, function(&$val) {
$val = trim($val);
});
$rc = new RedisCluster(null, $hosts, null, null, true);

this code runs normally on php5.x but error on php7.x, error info is:
PHP Fatal error: Uncaught RedisClusterException: Couldn't map cluster keyspace using any provided seed in /opt/php/test.php:14
Stack trace:
#0 /opt/php/test.php(14): RedisCluster->__construct(NULL, Array, NULL, NULL, true)
#1 {main}
thrown in /opt/php/test.php on line 14

tracing the source code of phpredis, i found the element of ht_seeds is a referent in function cluster_init_seeds on php7.x environment.

i fixed this problem and re-compiled the redis extension, and the code runs normally on php7