### PR TITLE
Use zend_string macros to make it compile against PHP 7.3-dev

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -231,7 +231,7 @@ PS_OPEN_FUNC(redis)
             if (url->query != NULL) {
                 array_init(&params);
 
-                sapi_module.treat_data(PARSE_STRING, estrdup(url->query), &params TSRMLS_CC);
+                sapi_module.treat_data(PARSE_STRING, estrdup(ZSTR_VAL(url->query)), &params TSRMLS_CC);
 
                 if ((param = zend_hash_str_find(Z_ARRVAL(params), "weight", sizeof("weight") - 1)) != NULL) {
                     weight = zval_get_long(param);
@@ -276,9 +276,9 @@ PS_OPEN_FUNC(redis)
 
             RedisSock *redis_sock;
             if(url->host) {
-                redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+                redis_sock = redis_sock_create(ZSTR_VAL(url->host), ZSTR_LEN(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
             } else { /* unix */
-                redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+                redis_sock = redis_sock_create(ZSTR_VAL(url->path), ZSTR_LEN(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
             }
             redis_pool_add(pool, redis_sock, weight, database, prefix, auth TSRMLS_CC);
 

--- a/redis_session.c
+++ b/redis_session.c
@@ -231,7 +231,11 @@ PS_OPEN_FUNC(redis)
             if (url->query != NULL) {
                 array_init(&params);
 
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
+                sapi_module.treat_data(PARSE_STRING, estrdup(url->query), &params TSRMLS_CC);
+#else
                 sapi_module.treat_data(PARSE_STRING, estrdup(ZSTR_VAL(url->query)), &params TSRMLS_CC);
+#endif
 
                 if ((param = zend_hash_str_find(Z_ARRVAL(params), "weight", sizeof("weight") - 1)) != NULL) {
                     weight = zval_get_long(param);
@@ -276,9 +280,17 @@ PS_OPEN_FUNC(redis)
 
             RedisSock *redis_sock;
             if(url->host) {
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
+                redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#else
                 redis_sock = redis_sock_create(ZSTR_VAL(url->host), ZSTR_LEN(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#endif
             } else { /* unix */
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
+                redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#else
                 redis_sock = redis_sock_create(ZSTR_VAL(url->path), ZSTR_LEN(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#endif
             }
             redis_pool_add(pool, redis_sock, weight, database, prefix, auth TSRMLS_CC);
 

--- a/redis_session.c
+++ b/redis_session.c
@@ -4,8 +4,7 @@
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
   | Copyright (c) 1997-2009 The PHP Group                                |
-  +-------------------------
----------------------------------------------+
+  +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
@@ -41,15 +40,6 @@
 #include "php_variables.h"
 #include "SAPI.h"
 #include "ext/standard/url.h"
-
-/* These macros are defined in PHP 7.3 */
-#ifndef ZSTR_VAL
-#define ZSTR_VAL(zstr) zstr
-#endif
-
-#ifndef ZSTR_LEN
-#define ZSTR_LEN(zstr) zstr
-#endif
 
 ps_module ps_mod_redis = {
     PS_MOD(redis)

--- a/redis_session.c
+++ b/redis_session.c
@@ -231,10 +231,10 @@ PS_OPEN_FUNC(redis)
             if (url->query != NULL) {
                 array_init(&params);
 
-#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
-                sapi_module.treat_data(PARSE_STRING, estrdup(url->query), &params TSRMLS_CC);
-#else
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION > 2)
                 sapi_module.treat_data(PARSE_STRING, estrdup(ZSTR_VAL(url->query)), &params TSRMLS_CC);
+#else
+                sapi_module.treat_data(PARSE_STRING, estrdup(url->query), &params TSRMLS_CC);
 #endif
 
                 if ((param = zend_hash_str_find(Z_ARRVAL(params), "weight", sizeof("weight") - 1)) != NULL) {
@@ -280,16 +280,16 @@ PS_OPEN_FUNC(redis)
 
             RedisSock *redis_sock;
             if(url->host) {
-#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
-                redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
-#else
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION > 2)
                 redis_sock = redis_sock_create(ZSTR_VAL(url->host), ZSTR_LEN(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#else
+                redis_sock = redis_sock_create(url->host, strlen(url->host), url->port, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
 #endif
             } else { /* unix */
-#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION < 3)
-                redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
-#else
+#if (PHP_MAJOR_VERSION == 7) && (PHP_MINOR_VERSION > 2)
                 redis_sock = redis_sock_create(ZSTR_VAL(url->path), ZSTR_LEN(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
+#else
+                redis_sock = redis_sock_create(url->path, strlen(url->path), 0, timeout, read_timeout, persistent, persistent_id, retry_interval, 0);
 #endif
             }
             redis_pool_add(pool, redis_sock, weight, database, prefix, auth TSRMLS_CC);

--- a/redis_session.c
+++ b/redis_session.c
@@ -4,7 +4,8 @@
   | PHP Version 5                                                        |
   +----------------------------------------------------------------------+
   | Copyright (c) 1997-2009 The PHP Group                                |
-  +----------------------------------------------------------------------+
+  +-------------------------
+---------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |
   | available through the world-wide-web at the following url:           |
@@ -40,6 +41,15 @@
 #include "php_variables.h"
 #include "SAPI.h"
 #include "ext/standard/url.h"
+
+/* These macros are defined in PHP 7.3 */
+#ifndef ZSTR_VAL
+#define ZSTR_VAL(zstr) zstr
+#endif
+
+#ifndef ZSTR_LEN
+#define ZSTR_LEN(zstr) zstr
+#endif
 
 ps_module ps_mod_redis = {
     PS_MOD(redis)


### PR DESCRIPTION
The default branch was showing warnings when compiling with PHP 7.3-dev and the session handler was no working. Adding ZSTR_VAL() and ZSTR_LEN() macros in 3 lines fixed the problems.