### PR TITLE
Allow session locking to work with session_regenerate_id (see #1267)

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -601,7 +601,7 @@ PS_CREATE_SID_FUNC(redis)
         char* sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        zend_string sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        zend_string* sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.c
+++ b/redis_session.c
@@ -636,10 +636,8 @@ PS_CREATE_SID_FUNC(redis)
         sid = NULL;
     }
 
-    if (sid == NULL) {
-        php_error_docref(NULL TSRMLS_CC, E_NOTICE,
-            "Acquiring session lock failed while creating session_id");
-    }
+    php_error_docref(NULL TSRMLS_CC, E_NOTICE,
+        "Acquiring session lock failed while creating session_id");
 
     return NULL;
 }

--- a/redis_session.c
+++ b/redis_session.c
@@ -622,7 +622,7 @@ PS_CREATE_SID_FUNC(redis)
 #if (PHP_MAJOR_VERSION < 7)
         pool->lock_status->session_key = sid;
 #else
-        pool->lock_status->session_key = estrdup($TR_VAL(sid));
+        pool->lock_status->session_key = estrdup(ZSTR_VAL(sid));
 #endif
         if (lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) == SUCCESS) {
             return sid;

--- a/redis_session.c
+++ b/redis_session.c
@@ -585,17 +585,16 @@ redis_session_key(redis_pool_member *rpm, const char *key, int key_len, int *ses
  */
 PS_CREATE_SID_FUNC(redis)
 {
-    char *sid;
     int retries = 3;
 
     redis_pool *pool = PS_GET_MOD_DATA();
 
     while (retries-- > 0) {
 #if (PHP_MAJOR_VERSION < 7)
-        sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
+        char *sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        zend_string *sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.c
+++ b/redis_session.c
@@ -586,15 +586,20 @@ redis_session_key(redis_pool_member *rpm, const char *key, int key_len, int *ses
 PS_CREATE_SID_FUNC(redis)
 {
     int retries = 3;
+#if (PHP_MAJOR_VERSION < 7)
+    char *sid;
+#else
+    zend_string *sid;
+#endif
 
     redis_pool *pool = PS_GET_MOD_DATA();
 
     while (retries-- > 0) {
 #if (PHP_MAJOR_VERSION < 7)
-        char *sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
+        sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        zend_string *sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.h
+++ b/redis_session.h
@@ -9,6 +9,7 @@ PS_READ_FUNC(redis);
 PS_WRITE_FUNC(redis);
 PS_DESTROY_FUNC(redis);
 PS_GC_FUNC(redis);
+PS_CREATE_SID_FUNC(redis);
 
 PS_OPEN_FUNC(rediscluster);
 PS_CLOSE_FUNC(rediscluster);

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5274,7 +5274,8 @@ class Redis_Test extends TestSuite
         $end = microtime(true);
         $elapsedTime = $end - $start;
 
-        $this->assertTrue($elapsedTime > 2.5 && $elapsedTime < 3.5);
+        $this->assertTrue($elapsedTime > 2.5);
+        $this->assertTrue($elapsedTime < 3.5);
         $this->assertTrue($sessionSuccessful);
     }
 

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -1,0 +1,31 @@
+<?php
+error_reporting(E_ERROR | E_WARNING);
+
+$redisHost = $argv[1];
+$sessionId = $argv[2];
+$locking = !!$argv[3];
+$destroyPrevious = !!$argv[4];
+
+if (empty($redisHost)) {
+    $redisHost = 'localhost';
+}
+
+ini_set('session.save_handler', 'redis');
+ini_set('session.save_path', 'tcp://' . $redisHost . ':6379');
+
+if ($locking) {
+    ini_set('redis.session.locking_enabled', true);
+}
+
+session_id($sessionId);
+if (!session_start()) {
+    $result = "FAILED: session_start()";
+}
+elseif (!session_regenerate_id($destroyPrevious)) {
+    $result = "FAILED: session_regenerate_id()";
+}
+else {
+    $result = session_id();
+}
+echo $result;
+


### PR DESCRIPTION
Thanks for the session locking functionality!

I work with software that uses `session_regenerate_id(true)` during login and I was unable to login with the code as it was.  After noticing that the memcache extension doesn't suffer from this issue I cobbled this together.

I've only compiled this on php 5.3, 5.4 and 5.6