### PR TITLE
Session locking: Fix regenerate ID bug (PHP5, proxy handler)

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -619,11 +619,14 @@ PS_CREATE_SID_FUNC(redis)
 #endif
         }
 
+        int resp_len;
 #if (PHP_MAJOR_VERSION < 7)
-        pool->lock_status->session_key = sid;
+        char *full_session_key = redis_session_key(rpm, sid, strlen(sid), &resp_len);
 #else
-        pool->lock_status->session_key = estrdup(ZSTR_VAL(sid));
+        char *full_session_key = redis_session_key(rpm, ZSTR_VAL(sid), ZSTR_LEN(sid), &resp_len);
 #endif
+        pool->lock_status->session_key = full_session_key;
+
         if (lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) == SUCCESS) {
             return sid;
         }

--- a/redis_session.c
+++ b/redis_session.c
@@ -601,7 +601,7 @@ PS_CREATE_SID_FUNC(redis)
         char* sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        zend_string sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        zend_string* sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.c
+++ b/redis_session.c
@@ -738,12 +738,10 @@ PS_WRITE_FUNC(redis)
     session = redis_session_key(rpm, key, strlen(key), &session_len);
 
     /* We need to check for PHP5 if the session key changes (a bug with session_regenerate_id() is causing a missing PS_CREATE_SID call)*/
-    char *session_key_nt = estrndup(session, session_len);
-
-    int session_key_changed = strcmp(pool->lock_status->session_key, session_key_nt) != 0;
+    int session_key_changed = strlen(pool->lock_status->session_key) != session_len || strncmp(pool->lock_status->session_key, session, session_len) != 0;
     if (session_key_changed) {
         efree(pool->lock_status->session_key);
-        pool->lock_status->session_key = session_key_nt;
+        pool->lock_status->session_key = estrndup(session, session_len);
     }
 
     if (session_key_changed && lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) != SUCCESS) {

--- a/redis_session.c
+++ b/redis_session.c
@@ -636,10 +636,8 @@ PS_CREATE_SID_FUNC(redis)
         sid = NULL;
     }
 
-    if (sid == NULL) {
-        php_error_docref(NULL TSRMLS_CC, E_NOTICE,
-            "Acquiring session lock failed while creating session_id");
-    }
+    php_error_docref(NULL TSRMLS_CC, E_NOTICE,
+        "Acquiring session lock failed while creating session_id");
 
     return NULL;
 }

--- a/redis_session.c
+++ b/redis_session.c
@@ -733,25 +733,24 @@ PS_WRITE_FUNC(redis)
         return FAILURE;
     }
 
-    /* We need to check for PHP5 if the session key changes (a bug with session_regenerate_id() is causing a missing PS_CREATE_SID call)*/
-    #if (PHP_MAJOR_VERSION < 7)
-        session = redis_session_key(rpm, key, strlen(key), &session_len);
-        char *session_key_nt = estrndup(session, session_len);
-
-        int session_key_changed = strcmp(pool->lock_status->session_key, session_key_nt) != 0;
-        if (session_key_changed) {
-            efree(pool->lock_status->session_key);
-            pool->lock_status->session_key = session_key_nt;
-        }
-
-        if (session_key_changed && lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) != SUCCESS) {
-            efree(session);
-            return FAILURE;
-        }
-    #endif
-
     /* send SET command */
 #if (PHP_MAJOR_VERSION < 7)
+    session = redis_session_key(rpm, key, strlen(key), &session_len);
+
+    /* We need to check for PHP5 if the session key changes (a bug with session_regenerate_id() is causing a missing PS_CREATE_SID call)*/
+    char *session_key_nt = estrndup(session, session_len);
+
+    int session_key_changed = strcmp(pool->lock_status->session_key, session_key_nt) != 0;
+    if (session_key_changed) {
+        efree(pool->lock_status->session_key);
+        pool->lock_status->session_key = session_key_nt;
+    }
+
+    if (session_key_changed && lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) != SUCCESS) {
+        efree(session);
+        return FAILURE;
+    }
+
     cmd_len = REDIS_SPPRINTF(&cmd, "SETEX", "sds", session, session_len,
                              INI_INT("session.gc_maxlifetime"), val, vallen);
 #else

--- a/redis_session.c
+++ b/redis_session.c
@@ -622,7 +622,7 @@ PS_CREATE_SID_FUNC(redis)
 #if (PHP_MAJOR_VERSION < 7)
         pool->lock_status->session_key = sid;
 #else
-        pool->lock_status->session_key = estrdup($TR_VAL(sid));
+        pool->lock_status->session_key = estrdup(ZSTR_VAL(sid));
 #endif
         if (lock_acquire(redis_sock, pool->lock_status TSRMLS_CC) == SUCCESS) {
             return sid;

--- a/redis_session.c
+++ b/redis_session.c
@@ -585,17 +585,16 @@ redis_session_key(redis_pool_member *rpm, const char *key, int key_len, int *ses
  */
 PS_CREATE_SID_FUNC(redis)
 {
-    char *sid;
     int retries = 3;
 
     redis_pool *pool = PS_GET_MOD_DATA();
 
     while (retries-- > 0) {
 #if (PHP_MAJOR_VERSION < 7)
-        sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
+        char *sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        zend_string *sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.c
+++ b/redis_session.c
@@ -586,15 +586,20 @@ redis_session_key(redis_pool_member *rpm, const char *key, int key_len, int *ses
 PS_CREATE_SID_FUNC(redis)
 {
     int retries = 3;
+#if (PHP_MAJOR_VERSION < 7)
+    char *sid;
+#else
+    zend_string *sid;
+#endif
 
     redis_pool *pool = PS_GET_MOD_DATA();
 
     while (retries-- > 0) {
 #if (PHP_MAJOR_VERSION < 7)
-        char *sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
+        sid = php_session_create_id((void **) &pool, newlen TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, sid TSRMLS_CC);
 #else
-        zend_string *sid = php_session_create_id((void **) &pool TSRMLS_CC);
+        sid = php_session_create_id((void **) &pool TSRMLS_CC);
         redis_pool_member *rpm = redis_pool_get_sock(pool, ZSTR_VAL(sid) TSRMLS_CC);
 #endif
         RedisSock *redis_sock = rpm?rpm->redis_sock:NULL;

--- a/redis_session.h
+++ b/redis_session.h
@@ -9,6 +9,7 @@ PS_READ_FUNC(redis);
 PS_WRITE_FUNC(redis);
 PS_DESTROY_FUNC(redis);
 PS_GC_FUNC(redis);
+PS_CREATE_SID_FUNC(redis);
 
 PS_OPEN_FUNC(rediscluster);
 PS_CLOSE_FUNC(rediscluster);

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5274,7 +5274,8 @@ class Redis_Test extends TestSuite
         $end = microtime(true);
         $elapsedTime = $end - $start;
 
-        $this->assertTrue($elapsedTime > 2.5 && $elapsedTime < 3.5);
+        $this->assertTrue($elapsedTime > 2.5);
+        $this->assertTrue($elapsedTime < 3.5);
         $this->assertTrue($sessionSuccessful);
     }
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5292,40 +5292,44 @@ class Redis_Test extends TestSuite
     public  function testSession_regenerateSessionId_noLock_noDestroy() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $writeSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+        $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
 
         $newSessionId = $this->regenerateSessionId($sessionId);
-	
+
+        $this->assertTrue($newSessionId !== $sessionId);
         $this->assertEquals('bar', $this->getSessionData($newSessionId));
     }
 
     public  function testSession_regenerateSessionId_noLock_withDestroy() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $writeSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+        $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
 
         $newSessionId = $this->regenerateSessionId($sessionId, false, true);
-	
+
+        $this->assertTrue($newSessionId !== $sessionId);
         $this->assertEquals('bar', $this->getSessionData($newSessionId));
     }
 
     public  function testSession_regenerateSessionId_withLock_noDestroy() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $writeSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+        $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
 
         $newSessionId = $this->regenerateSessionId($sessionId, true);
-	
+
+        $this->assertTrue($newSessionId !== $sessionId);
         $this->assertEquals('bar', $this->getSessionData($newSessionId));
     }
 
     public  function testSession_regenerateSessionId_withLock_withDestroy() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $writeSuccessful = $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
+        $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
 
         $newSessionId = $this->regenerateSessionId($sessionId, true, true);
 
+        $this->assertTrue($newSessionId !== $sessionId);
         $this->assertEquals('bar', $this->getSessionData($newSessionId));
     }
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5334,6 +5334,10 @@ class Redis_Test extends TestSuite
     }
 
     public  function testSession_regenerateSessionId_noLock_noDestroy_withProxy() {
+        if (!interface_exists('SessionHandlerInterface')) {
+            $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+        }
+
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
@@ -5345,6 +5349,10 @@ class Redis_Test extends TestSuite
     }
 
     public  function testSession_regenerateSessionId_noLock_withDestroy_withProxy() {
+        if (!interface_exists('SessionHandlerInterface')) {
+            $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+        }
+
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
@@ -5356,6 +5364,10 @@ class Redis_Test extends TestSuite
     }
 
     public  function testSession_regenerateSessionId_withLock_noDestroy_withProxy() {
+        if (!interface_exists('SessionHandlerInterface')) {
+            $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+        }
+
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');
@@ -5367,6 +5379,10 @@ class Redis_Test extends TestSuite
     }
 
     public  function testSession_regenerateSessionId_withLock_withDestroy_withProxy() {
+        if (!interface_exists('SessionHandlerInterface')) {
+            $this->markTestSkipped('session handler interface not available in PHP < 5.4');
+        }
+
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 0, false, 300, true, null, -1, 1, 'bar');

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5462,8 +5462,6 @@ class Redis_Test extends TestSuite
 
         $command = 'php --no-php-ini --define extension=igbinary.so --define extension=' . __DIR__ . '/../modules/redis.so ' . __DIR__ . '/regenerateSessionId.php ' . escapeshellarg($this->getHost()) . ' ' . implode(' ', $args);
 
-        $command .= ' 2>&1';
-
         exec($command, $output);
 
         return $output[0];

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -18,46 +18,48 @@ if ($locking) {
     ini_set('redis.session.locking_enabled', true);
 }
 
-class TestHandler implements SessionHandlerInterface
-{
-    /**
-     * @var SessionHandler
-     */
-    private $handler;
-
-    public function __construct()
+if (interface_exists('SessionHandlerInterface')) {
+    class TestHandler implements SessionHandlerInterface
     {
-        $this->handler = new SessionHandler();
-    }
+        /**
+         * @var SessionHandler
+         */
+        private $handler;
 
-    public function close()
-    {
-        return $this->handler->close();
-    }
+        public function __construct()
+        {
+            $this->handler = new SessionHandler();
+        }
 
-    public function destroy($session_id)
-    {
-        return $this->handler->destroy($session_id);
-    }
+        public function close()
+        {
+            return $this->handler->close();
+        }
 
-    public function gc($maxlifetime)
-    {
-        return $this->handler->gc($maxlifetime);
-    }
+        public function destroy($session_id)
+        {
+            return $this->handler->destroy($session_id);
+        }
 
-    public function open($save_path, $name)
-    {
-        return $this->handler->open($save_path, $name);
-    }
+        public function gc($maxlifetime)
+        {
+            return $this->handler->gc($maxlifetime);
+        }
 
-    public function read($session_id)
-    {
-        return $this->handler->read($session_id);
-    }
+        public function open($save_path, $name)
+        {
+            return $this->handler->open($save_path, $name);
+        }
 
-    public function write($session_id, $session_data)
-    {
-        return $this->handler->write($session_id, $session_data);
+        public function read($session_id)
+        {
+            return $this->handler->read($session_id);
+        }
+
+        public function write($session_id, $session_data)
+        {
+            return $this->handler->write($session_id, $session_data);
+        }
     }
 }
 

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -5,6 +5,7 @@ $redisHost = $argv[1];
 $sessionId = $argv[2];
 $locking = !!$argv[3];
 $destroyPrevious = !!$argv[4];
+$sessionProxy = !!$argv[5];
 
 if (empty($redisHost)) {
     $redisHost = 'localhost';
@@ -17,6 +18,54 @@ if ($locking) {
     ini_set('redis.session.locking_enabled', true);
 }
 
+class TestHandler implements SessionHandlerInterface
+{
+    /**
+     * @var SessionHandler
+     */
+    private $handler;
+
+    public function __construct()
+    {
+        $this->handler = new SessionHandler();
+    }
+
+    public function close()
+    {
+        return $this->handler->close();
+    }
+
+    public function destroy($session_id)
+    {
+        return $this->handler->destroy($session_id);
+    }
+
+    public function gc($maxlifetime)
+    {
+        return $this->handler->gc($maxlifetime);
+    }
+
+    public function open($save_path, $name)
+    {
+        return $this->handler->open($save_path, $name);
+    }
+
+    public function read($session_id)
+    {
+        return $this->handler->read($session_id);
+    }
+
+    public function write($session_id, $session_data)
+    {
+        return $this->handler->write($session_id, $session_data);
+    }
+}
+
+if ($sessionProxy) {
+    $handler = new TestHandler();
+    session_set_save_handler($handler);
+}
+
 session_id($sessionId);
 if (!session_start()) {
     $result = "FAILED: session_start()";
@@ -27,5 +76,6 @@ elseif (!session_regenerate_id($destroyPrevious)) {
 else {
     $result = session_id();
 }
+session_write_close();
 echo $result;
 

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -1,0 +1,31 @@
+<?php
+error_reporting(E_ERROR | E_WARNING);
+
+$redisHost = $argv[1];
+$sessionId = $argv[2];
+$locking = !!$argv[3];
+$destroyPrevious = !!$argv[4];
+
+if (empty($redisHost)) {
+    $redisHost = 'localhost';
+}
+
+ini_set('session.save_handler', 'redis');
+ini_set('session.save_path', 'tcp://' . $redisHost . ':6379');
+
+if ($locking) {
+    ini_set('redis.session.locking_enabled', true);
+}
+
+session_id($sessionId);
+if (!session_start()) {
+    $result = "FAILED: session_start()";
+}
+elseif (!session_regenerate_id($destroyPrevious)) {
+    $result = "FAILED: session_regenerate_id()";
+}
+else {
+    $result = session_id();
+}
+echo $result;
+


### PR DESCRIPTION
This PR is based on PR #1289 and fixes the issue described [here](https://github.com/phpredis/phpredis/issues/1267#issuecomment-365632260).
@asharpe Thanks for the great work!