### PR TITLE
Fix: Warning: time() expects exactly 0 parameters, 1 given ... (php 7.3)

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -452,7 +452,7 @@ class Redis_Test extends TestSuite
     public function testExpireAt() {
         $this->redis->del('key');
         $this->redis->set('key', 'value');
-        $now = time(NULL);
+        $now = time();
         $this->redis->expireAt('key', $now + 1);
         $this->assertEquals('value', $this->redis->get('key'));
         sleep(2);


### PR DESCRIPTION
When running test suite with PHP 7.3.0alpha1

```
...
testExpireAt                                                   
Warning: time() expects exactly 0 parameters, 1 given in /dev/shm/BUILD/php73-php-pecl-redis4-4.1.0~RC1/NTS/tests/RedisTest.php on line 455
[FAILED]
testSetEx                                                      [PASSED]
...
```