### PR TITLE
There are two big package managers on OS X

### DIFF
--- a/INSTALL.markdown
+++ b/INSTALL.markdown
@@ -85,6 +85,11 @@ You can install it using Homebrew:
 - [Get homebrew-php](https://github.com/Homebrew/homebrew-php)
 - `brew install php55-redis` (or php53-redis, php54-redis)
 
+You can install it using MacPorts:
+
+- [Get macports-php](https://www.macports.org/)
+- `sudo port install php56-redis` (or php53-redis, php54-redis, php55-redis, php70-redis, php71-redis, php72-redis)
+
 # Building on Windows
 
 See [instructions from @char101](https://github.com/phpredis/phpredis/issues/213#issuecomment-11361242) on how to build phpredis on Windows.


### PR DESCRIPTION
Except for Homebrew (Linux like a clone), there's also package manager MacPorts (FreeBSD like a clone) which is having the package for php-redis