### PR TITLE
Reset the socket after a timeout to make sure no wrong data is received

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1456,6 +1456,11 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char
             "The Redis Cluster is down (CLUSTERDOWN)", 0 TSRMLS_CC);
         return -1;
     } else if (timedout) {
+        // Make sure the socket is reconnected, it such that it is in a clean state
+        if (c->cmd_sock->stream) {
+            redis_sock_disconnect(c->cmd_sock, 1 TSRMLS_CC);
+        }
+
         zend_throw_exception(redis_cluster_exception_ce,
             "Timed out attempting to find data in the correct node!", 0 TSRMLS_CC);
     }

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1456,9 +1456,7 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char
         return -1;
     } else if (timedout) {
         // Make sure the socket is reconnected, it such that it is in a clean state
-        if (c->cmd_sock->stream) {
-            redis_sock_disconnect(c->cmd_sock, 1 TSRMLS_CC);
-        }
+        redis_sock_disconnect(c->cmd_sock, 1 TSRMLS_CC);
 
         zend_throw_exception(redis_cluster_exception_ce,
             "Timed out attempting to find data in the correct node!", 0 TSRMLS_CC);

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1203,7 +1203,7 @@ static int cluster_sock_write(redisCluster *c, const char *cmd, size_t sz,
         if (CLUSTER_SEND_PAYLOAD(redis_sock, cmd, sz)) return 0;
     } else if (failover == REDIS_FAILOVER_ERROR) {
         /* Try the master, then fall back to any slaves we may have */
-        redis_sock_server_open(redis_sock);
+        redis_sock_server_open(redis_sock TSRMLS_CC);
         if (CLUSTER_SEND_PAYLOAD(redis_sock, cmd, sz) ||
            !cluster_dist_write(c, cmd, sz, 1 TSRMLS_CC)) return 0;
     } else {
@@ -1225,7 +1225,7 @@ static int cluster_sock_write(redisCluster *c, const char *cmd, size_t sz,
         if (seed_node == NULL || seed_node->sock == redis_sock || seed_node->slave) continue;
 
         /* Connect to this node if we haven't already */
-        redis_sock_server_open(seed_node->sock);
+        redis_sock_server_open(seed_node->sock TSRMLS_CC);
 
         /* Attempt to write our request to this node */
         if (CLUSTER_SEND_PAYLOAD(seed_node->sock, cmd, sz)) {

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -51,14 +51,6 @@
     ZSTR_LEN(SLOT_SOCK(c,c->redir_slot)->host) != c->redir_host_len || \
     memcmp(ZSTR_VAL(SLOT_SOCK(c,c->redir_slot)->host),c->redir_host,c->redir_host_len))
 
-/* Lazy connect logic */
-#define CLUSTER_LAZY_CONNECT(s) \
-    if(s->lazy_connect) { \
-        if(!redis_sock_server_open(s TSRMLS_CC)) { \
-            s->lazy_connect = 0; \
-        } \
-    }
-
 /* Clear out our "last error" */
 #define CLUSTER_CLEAR_ERROR(c) do { \
     if (c->err) { \

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -62,7 +62,7 @@
 
 /* Protected sending of data down the wire to a RedisSock->stream */
 #define CLUSTER_SEND_PAYLOAD(sock, buf, len) \
-    (sock && sock->stream && !redis_check_eof(sock, 1 TSRMLS_CC) && \
+    (sock && !redis_sock_server_open(sock TSRMLS_CC) && sock->stream && !redis_check_eof(sock, 1 TSRMLS_CC) && \
      php_stream_write(sock->stream, buf, len)==len)
 
 /* Macro to read our reply type character */

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -54,8 +54,9 @@
 /* Lazy connect logic */
 #define CLUSTER_LAZY_CONNECT(s) \
     if(s->lazy_connect) { \
-        s->lazy_connect = 0; \
-        redis_sock_server_open(s TSRMLS_CC); \
+        if(!redis_sock_server_open(s TSRMLS_CC)) { \
+            s->lazy_connect = 0; \
+        } \
     }
 
 /* Clear out our "last error" */

--- a/common.h
+++ b/common.h
@@ -678,8 +678,6 @@ typedef struct {
 
     zend_string    *err;
 
-    zend_bool      lazy_connect;
-
     int            scan;
 
     int            readonly;

--- a/library.c
+++ b/library.c
@@ -1858,6 +1858,7 @@ redis_sock_disconnect(RedisSock *redis_sock, int force TSRMLS_DC)
     redis_sock->mode = ATOMIC;
     redis_sock->status = REDIS_SOCK_STATUS_DISCONNECTED;
     redis_sock->watching = 0;
+    redis_sock->lazy_connect = 1; // Make sure we can reconnect this socket
 
     return SUCCESS;
 }

--- a/library.c
+++ b/library.c
@@ -1687,7 +1687,6 @@ redis_sock_create(char *host, int host_len, unsigned short port,
     redis_sock->dbNumber = 0;
     redis_sock->retry_interval = retry_interval * 1000;
     redis_sock->persistent = persistent;
-    redis_sock->lazy_connect = lazy_connect;
     redis_sock->persistent_id = NULL;
 
     if (persistent && persistent_id != NULL) {
@@ -1858,7 +1857,6 @@ redis_sock_disconnect(RedisSock *redis_sock, int force TSRMLS_DC)
     redis_sock->mode = ATOMIC;
     redis_sock->status = REDIS_SOCK_STATUS_DISCONNECTED;
     redis_sock->watching = 0;
-    redis_sock->lazy_connect = 1; // Make sure we can reconnect this socket
 
     return SUCCESS;
 }

--- a/redis.c
+++ b/redis.c
@@ -647,11 +647,8 @@ redis_sock_get(zval *id TSRMLS_DC, int no_throw)
         return NULL;
     }
 
-    if (redis_sock->lazy_connect) {
-        redis_sock->lazy_connect = 0;
-        if (redis_sock_server_open(redis_sock TSRMLS_CC) < 0) {
-            return NULL;
-        }
+    if (redis_sock_server_open(redis_sock TSRMLS_CC) < 0) {
+        return NULL;
     }
 
     return redis_sock;


### PR DESCRIPTION
Fixes #1222 
Fixes #1418 

I did the following stuff on a timeout:

- Force disconnect the current socket, so even a persistent connection is cleared (so no chance for illegal data to be returned the next time).
- Change the lazy_connect logic to reset this correctly. Without this change, the loop in `cluster_send_command` will run very quickly without really retrying to connect.

I'm not really sure if this last change is correct in all cases, but it seems to work for me.