### PR TITLE
Remove useless ZEND_ACC_[C|D]TOR.

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -237,8 +237,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_kscan, 0, 0, 2)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry redis_functions[] = {
-     PHP_ME(Redis, __construct, arginfo_void, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
-     PHP_ME(Redis, __destruct, arginfo_void, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, __construct, arginfo_void, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, __destruct, arginfo_void, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _prefix, arginfo_key, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _serialize, arginfo_value, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _unserialize, arginfo_value, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -107,7 +107,7 @@ ZEND_END_ARG_INFO()
 
 /* Function table */
 zend_function_entry redis_cluster_functions[] = {
-    PHP_ME(RedisCluster, __construct, arginfo_ctor, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, __construct, arginfo_ctor, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, _masters, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, _prefix, arginfo_key, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, _redir, arginfo_void, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
Hi, when I make it in PHP74, I get a compile error.

#ref: https://github.com/php/php-src/commit/8939c4d96b8382abe84f35e69f4f6ebd6f0f749d#r30609734

The flag was automatically determined, there was no need to set it explicitly.
This change is compatible with all PHP versions, and it fixes compilation error in PHP74.