### PR TITLE
Update STREAM API to handle STATUS -> BULK reply change

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -3592,7 +3592,7 @@ PHP_METHOD(Redis, xack) {
 }
 
 PHP_METHOD(Redis, xadd) {
-    REDIS_PROCESS_CMD(xadd, redis_single_line_reply);
+    REDIS_PROCESS_CMD(xadd, redis_read_variant_reply);
 }
 
 PHP_METHOD(Redis, xclaim) {

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2983,7 +2983,7 @@ PHP_METHOD(RedisCluster, xack) {
 
 /* {{{ proto string RedisCluster::xadd(string key, string id, array field_values) }}} */
 PHP_METHOD(RedisCluster, xadd) {
-    CLUSTER_PROCESS_CMD(xadd, cluster_single_line_resp, 0);
+    CLUSTER_PROCESS_CMD(xadd, cluster_bulk_raw_resp, 0);
 }
 
 /* {{{ proto array RedisCluster::xclaim(string key, string group, string consumer,


### PR DESCRIPTION
Right before Redis 5.0 was released, the api was changed to send
message ids as BULK instead of STATUS replies.