### PR TITLE
 build warnings

### DIFF
--- a/library.c
+++ b/library.c
@@ -2113,10 +2113,13 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
 PHP_REDIS_API int
 redis_pack(RedisSock *redis_sock, zval *z, char **val, strlen_t *val_len TSRMLS_DC)
 {
-    char *buf, *data;
+    char *buf;
     int valfree;
     strlen_t len;
+#ifdef HAVE_REDIS_LZF
+    char *data;
     uint32_t res;
+#endif
 
     valfree = redis_serialize(redis_sock, z, &buf, &len TSRMLS_CC);
     switch (redis_sock->compression) {
@@ -2142,9 +2145,11 @@ redis_pack(RedisSock *redis_sock, zval *z, char **val, strlen_t *val_len TSRMLS_
 PHP_REDIS_API int
 redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TSRMLS_DC)
 {
+#ifdef HAVE_REDIS_LZF
     char *data;
     int i;
     uint32_t res;
+#endif
 
     switch (redis_sock->compression) {
         case REDIS_COMPRESSION_LZF:


### PR DESCRIPTION
This commit fix 2  [-Wunused-variable] when LZF is not available

Still one warning which seems a good catch from GCC

```
In file included from /usr/include/php/Zend/zend.h:33:0,
                 from /usr/include/php/main/php.h:35,
                 from /work/GIT/phpredis/common.h:1,
                 from /work/GIT/phpredis/library.c:5:
/work/GIT/phpredis/library.c: In function 'redis_read_xclaim_response':
/usr/include/php/Zend/zend_alloc.h:163:26: warning: 'id' may be used uninitialized in this function [-Wmaybe-uninitialized]
 #define efree(ptr)       _efree((ptr) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
                          ^~~~~~
/work/GIT/phpredis/library.c:1409:11: note: 'id' was declared here
     char *id;
           ^~
```

From library.c

`          if ((li != 2 || (id = redis_sock_read(redis_sock, &idlen TSRMLS_CC)) == NULL) ||`

So, if `li == 2` id is not set.