### PR TITLE
32bit xclaim fix

### DIFF
--- a/common.h
+++ b/common.h
@@ -461,8 +461,10 @@ typedef size_t strlen_t;
 
 #ifdef PHP_WIN32
 #define PHP_REDIS_API __declspec(dllexport)
+#define phpredis_atoi64(p) _atoi64((p))
 #else
 #define PHP_REDIS_API
+#define phpredis_atoi64(p) atoll((p))
 #endif
 
 /* reply types */

--- a/library.c
+++ b/library.c
@@ -699,6 +699,15 @@ int redis_cmd_append_sstr_long(smart_string *str, long append) {
 }
 
 /*
+ * Append a 64-bit integer to our command
+ */
+int redis_cmd_append_sstr_i64(smart_string *str, int64_t append) {
+    char nbuf[64];
+    int len = snprintf(nbuf, sizeof(nbuf), "%lld", append);
+    return redis_cmd_append_sstr(str, nbuf, len);
+}
+
+/*
  * Append a double to a smart string command
  */
 int
@@ -1080,11 +1089,8 @@ PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS,
     }
 
     if(response[0] == ':') {
-#ifdef PHP_WIN32
-        __int64 ret = _atoi64(response + 1);
-#else
-        long long ret = atoll(response + 1);
-#endif
+        int64_t ret = phpredis_atoi64(response + 1);
+
         if (IS_ATOMIC(redis_sock)) {
             if(ret > LONG_MAX) { /* overflow */
                 RETVAL_STRINGL(response + 1, response_len - 1);

--- a/library.h
+++ b/library.h
@@ -18,6 +18,7 @@ int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyw
 int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);
 int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
+int redis_cmd_append_sstr_i64(smart_string *str, int64_t append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
 int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock TSRMLS_DC);
 int redis_cmd_append_sstr_key(smart_string *str, char *key, strlen_t len, RedisSock *redis_sock, short *slot);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3568,7 +3568,7 @@ static int64_t get_xclaim_i64_arg(const char *key, zval *zv TSRMLS_DC) {
     /* No negative values are allowed for XCLAIM and INT64_MAX should indicate a
      * positive overflow.  Note that if the user actually passed us INT64_MAX
      * (as a string or otherwise) it is an invalid value here anyway. */
-    if (retval < 0 || (retval == INT64_MAX)) {
+    if (retval < 0 || retval == INT64_MAX) {
         /* Inform the user that they have passed incorrect data */
         php_error_docref(NULL TSRMLS_CC, E_WARNING,
             "Invalid value passed to XCLAIM option '%s' will be ignored", key);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3563,16 +3563,12 @@ static int zval_get_i64(zval *zv, int64_t *retval) {
  * not a valid number or negative, we'll inform the user of the problem and
  * that the argument is being ignored. */
 static int64_t get_xclaim_i64_arg(const char *key, zval *zv TSRMLS_DC) {
-    int64_t retval;
+    int64_t retval = -1;
 
-    /* Try to extract an i64 from the zval */
+    /* Extract an i64, and if we can't let the user know there is an issue. */
     if (zval_get_i64(zv, &retval) == FAILURE || retval < 0) {
-        /* Inform the user that they have passed an invalid value */
         php_error_docref(NULL TSRMLS_CC, E_WARNING,
             "Invalid XCLAIM option '%s' will be ignored", key);
-
-        /* We treat a value of -1 as unset */
-        return -1;
     }
 
     /* Success */

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3560,15 +3560,15 @@ static int64_t get_xclaim_i64_arg(const char *key, zval *zv TSRMLS_DC) {
     } else if (Z_TYPE_P(zv) == IS_DOUBLE) {
         retval = (int64_t)Z_DVAL_P(zv);
     } else if (Z_TYPE_P(zv) == IS_STRING &&
-               string_all_digits(Z_STRVAL_P(zv), Z_STRLEN_P(zv) == SUCCESS))
+               string_all_digits(Z_STRVAL_P(zv), Z_STRLEN_P(zv)) == SUCCESS)
     {
         retval = phpredis_atoi64(Z_STRVAL_P(zv));
     }
 
-    /* No negative values are allowed for XCLAIM and LONG_MAX should indicate a
-     * positive overflow.  Note that if the user actually passed us LONG_MAX
+    /* No negative values are allowed for XCLAIM and INT64_MAX should indicate a
+     * positive overflow.  Note that if the user actually passed us INT64_MAX
      * (as a string or otherwise) it is an invalid value here anyway. */
-    if (retval < 0 || (retval == LONG_MAX)) {
+    if (retval < 0 || (retval == INT64_MAX)) {
         /* Inform the user that they have passed incorrect data */
         php_error_docref(NULL TSRMLS_CC, E_WARNING,
             "Invalid value passed to XCLAIM option '%s' will be ignored", key);


### PR DESCRIPTION
This should fix the XCLAIM issue on 32-bit PHP installs.

I'm not 100% sure we can rely on INT64_MAX being defined in Windows but it seems like we can since PHP defines it in `win32/php_stdint.h` only under certain conditions.  We'll want to verify that this is correct before officially releasing 4.2.0.

I tried to protect the user from passing us invalid data while allowing them to pass us the option in pretty much any possible way (float, long, or string).