### PR TITLE
Fixed invalid stream id error in example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3330,7 +3330,7 @@ _**Description**_:  Add a message to a stream
 
 ##### *Example*
 ~~~php
-$obj_redis->xAdd('mystream', "\*", ['field' => 'value']);
+$obj_redis->xAdd('mystream', "*", ['field' => 'value']);
 ~~~
 
 ### xClaim


### PR DESCRIPTION
Else: `ERR Invalid stream ID specified as stream command argument`

Example:

```
        var_dump($this->redis->xAdd('test_key', '\*', ['message' => 'id'])); // bool(false)
        var_dump($this->redis->getLastError()); // string(58) "ERR Invalid stream ID specified as stream command argument"
```