### PR TITLE
Add failover when connecting to a redis cluster

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -952,6 +952,14 @@ PHP_REDIS_API int cluster_map_keyspace(redisCluster *c TSRMLS_DC) {
             continue;
         }
 
+        // Attempt to read data from the socket to ensure the current seed is available
+        if (redis_sock_write(redis_sock, RESP_CLUSTER_SLOTS_CMD,
+                        sizeof(RESP_CLUSTER_SLOTS_CMD)-1 TSRMLS_CC) < 0 ||
+                        php_stream_getc(redis_sock->stream) == EOF)
+        {
+            continue;
+        }
+
         // Parse out cluster nodes.  Flag mapped if we are valid
         slots = cluster_get_slots(seed TSRMLS_CC);
         if (slots) {

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -237,6 +237,7 @@ typedef struct redisCluster {
     int                redir_host_len;
     unsigned short     redir_slot;
     unsigned short     redir_port;
+    zend_bool          experimental_failover_enabled;
 
 #if (PHP_MAJOR_VERSION >= 7)
     /* Zend object handler */

--- a/library.h
+++ b/library.h
@@ -105,7 +105,7 @@ redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv TSRMLS_DC)
 * Variant Read methods, mostly to implement eval
 */
 
-PHP_REDIS_API int redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type, long *reply_info TSRMLS_DC);
+PHP_REDIS_API int redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type, long *reply_info TSRMLS_DC, zend_bool experimental_failover_enabled);
 PHP_REDIS_API int redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret TSRMLS_DC);
 PHP_REDIS_API int redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_strings, zval *z_ret TSRMLS_DC);
 PHP_REDIS_API int redis_read_variant_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -539,6 +539,8 @@ PHP_METHOD(RedisCluster, __construct) {
             0 TSRMLS_CC);
     }
 
+    context->experimental_failover_enabled = 1;
+
     /* If we've been passed only one argument, the user is attempting to connect
      * to a named cluster, stored in php.ini, otherwise we'll need manual seeds */
     if (ZEND_NUM_ARGS() > 1) {


### PR DESCRIPTION
Fixes #1400 
When connecting to a redis cluster in which one of the masters defined in the cluster seeds is not available the entire setup routine fails.  
The referenced issue already shows where the problem occurs and as a solution I added a flag to the RedisCluster called "experimental_failover_enabled".  
With this flag enabled `redis_read_reply_type` will not throw an exception if php_stream_getc(redis_sock->stream) returns EOF.  

I wanted to remove this exception entirely but I noticed that in the included test suite a huge chunk of tests suddenly failed. As such I have automatically set this argument to false everywhere this function is called except in `cluster_get_slots`.  

To test this I setup a local docker redis cluster based on https://github.com/Grokzen/docker-redis-cluster and just let our codebase connect with the local docker container. I used the included redis version 4.0.0 and added one more slave and master to the docker setup.  

I set `redis.clusters.seeds` to point to all masters, killed the first master listed in the ini string and made sure that the cluster was still working. Then I ran a simple test: connect -> set -> get  

The code on the develop branch fails approx. 1/4th of the time.  
With my fix the code never fails.

