### PR TITLE
Add support for Zstd compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,12 @@ matrix:
       env: CC=clang
 addons:
   apt:
-    packages: clang
+    packages:
+    - clang
+    - libzstd1-dev
 before_install:
   - phpize
-  - CFGARGS="--enable-redis-lzf"
+  - CFGARGS="--enable-redis-lzf --enable-redis-zstd"
   - pecl install igbinary && CFGARGS="$CFGARGS --enable-redis-igbinary"
   - pecl install msgpack && CFGARGS="$CFGARGS --enable-redis-msgpack"
   - ./configure $CFGARGS

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@ and PhpRedis adhears to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add optional support for Zstd compression, using `--enable-redis-ztsd`.
+  This requires libzstd version >= 1.3.0 [PR #1382](https://github.com/phpredis/phpredis/pull/1582)
+  ([Remi Collet](https://github.com/remicollet))
+
 ### Fixed
 
 - RedisCluster segfaults after second connection with cache_slots enabled [f52cd237](https://github.com/phpredis/phpredis/pull/1592/commits/f52cd237)

--- a/common.h
+++ b/common.h
@@ -79,6 +79,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_TCP_KEEPALIVE      6
 #define REDIS_OPT_COMPRESSION        7
 #define REDIS_OPT_REPLY_LITERAL      8
+#define REDIS_OPT_COMPRESSION_LEVEL  9
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -96,6 +97,7 @@ typedef enum {
 /* compression */
 #define REDIS_COMPRESSION_NONE 0
 #define REDIS_COMPRESSION_LZF  1
+#define REDIS_COMPRESSION_ZSTD 2
 
 /* SCAN options */
 #define REDIS_SCAN_NORETRY 0
@@ -258,6 +260,7 @@ typedef struct {
 
     redis_serializer  serializer;
     int               compression;
+    int               compression_level;
     long              dbNumber;
 
     zend_string       *prefix;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3888,6 +3888,8 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->serializer);
         case REDIS_OPT_COMPRESSION:
             RETURN_LONG(redis_sock->compression);
+        case REDIS_OPT_COMPRESSION_LEVEL:
+            RETURN_LONG(redis_sock->compression_level);
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 RETURN_STRINGL(ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
@@ -3951,11 +3953,18 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
 #ifdef HAVE_REDIS_LZF
                 || val_long == REDIS_COMPRESSION_LZF
 #endif
+#ifdef HAVE_REDIS_ZSTD
+                || val_long == REDIS_COMPRESSION_ZSTD
+#endif
             ) {
                 redis_sock->compression = val_long;
                 RETURN_TRUE;
             }
             break;
+        case REDIS_OPT_COMPRESSION_LEVEL:
+            val_long = zval_get_long(val);
+            redis_sock->compression_level = val_long;
+            RETURN_TRUE;
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 zend_string_release(redis_sock->prefix);

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4485,13 +4485,25 @@ class Redis_Test extends TestSuite
         if (!defined('Redis::COMPRESSION_LZF')) {
             $this->markTestSkipped();
         }
-        $this->checkCompression(Redis::COMPRESSION_LZF);
+        $this->checkCompression(Redis::COMPRESSION_LZF, 0);
     }
 
-    private function checkCompression($mode)
+    public function testCompressionZSTD()
+    {
+        if (!defined('Redis::COMPRESSION_ZSTD')) {
+            $this->markTestSkipped();
+        }
+        $this->checkCompression(Redis::COMPRESSION_ZSTD, 0);
+        $this->checkCompression(Redis::COMPRESSION_ZSTD, 9);
+    }
+
+    private function checkCompression($mode, $level)
     {
         $this->assertTrue($this->redis->setOption(Redis::OPT_COMPRESSION, $mode) === TRUE);  // set ok
         $this->assertTrue($this->redis->getOption(Redis::OPT_COMPRESSION) === $mode);    // get ok
+
+        $this->assertTrue($this->redis->setOption(Redis::OPT_COMPRESSION_LEVEL, $level) === TRUE);
+        $this->assertTrue($this->redis->getOption(Redis::OPT_COMPRESSION_LEVEL) === $level);
 
         $val = 'xxxxxxxxxx';
         $this->redis->set('key', $val);


### PR DESCRIPTION
**Zstd** is "usually" faster and give better results than **lzf**

From some benchmark (for quite a big file, ie "php" itself)

```
Compress functions:
gzdeflate           zlib: 5103144 => 1823040 (64% saved) in 0,216
bzcompress           bz2: 5103144 => 1747961 (65% saved) in 0,320
lz4_compress         lz4: 5103144 => 2638214 (48% saved) in 0,011
lzf_compress         lzf: 5103144 => 2614515 (48% saved) in 0,021
snappy_compress   snappy: 5103144 => 2671118 (47% saved) in 0,015
zstd_compress      zstd1: 5103144 => 2023044 (60% saved) in 0,017
zstd_compress      zstd3: 5103144 => 1856634 (63% saved) in 0,027
zstd_compress      zstd9: 5103144 => 1724733 (66% saved) in 0,154
zstd_compress     zstd22: 5103144 => 1569291 (69% saved) in 1,401
```
