### PR TITLE
Remove HAVE_SPL

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -772,9 +772,7 @@ PHP_MINIT_FUNCTION(redis)
                                                               module_number);
 
     /* Base Exception class */
-#if HAVE_SPL
     exception_ce = zend_hash_str_find_ptr(CG(class_table), "RuntimeException", sizeof("RuntimeException") - 1);
-#endif
     if (exception_ce == NULL) {
         exception_ce = zend_exception_get_default(TSRMLS_C);
     }


### PR DESCRIPTION
The HAVE_SPL symbol is defined in PHP to indicate the presence of the spl extension. Since PHP 5.3 the spl extension is always availabe and since PHP-7.4 the HAVE_SPL symbol has also been removed.