### PR TITLE
cleanup TSRMLS_* usage

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -62,12 +62,12 @@
 
 /* Protected sending of data down the wire to a RedisSock->stream */
 #define CLUSTER_SEND_PAYLOAD(sock, buf, len) \
-    (sock && !cluster_sock_open(sock TSRMLS_CC) && sock->stream && !redis_check_eof(sock, 1 TSRMLS_CC) && \
+    (sock && !cluster_sock_open(sock) && sock->stream && !redis_check_eof(sock, 1 ) && \
      php_stream_write(sock->stream, buf, len)==len)
 
 /* Macro to read our reply type character */
 #define CLUSTER_VALIDATE_REPLY_TYPE(sock, type) \
-    (redis_check_eof(sock, 1 TSRMLS_CC) == 0 && \
+    (redis_check_eof(sock, 1) == 0 && \
      (php_stream_getc(sock->stream) == type))
 
 /* Reset our last single line reply buffer and length */
@@ -141,7 +141,7 @@ typedef enum CLUSTER_REDIR_TYPE {
 } CLUSTER_REDIR_TYPE;
 
 /* MULTI BULK response callback typedef */
-typedef int  (*mbulk_cb)(RedisSock*,zval*,long long, void* TSRMLS_DC);
+typedef int  (*mbulk_cb)(RedisSock*,zval*,long long, void*);
 
 /* A list of covered slot ranges */
 typedef struct redisSlotRange {
@@ -340,9 +340,9 @@ typedef struct clusterReply {
 } clusterReply;
 
 /* Direct variant response handler */
-clusterReply *cluster_read_resp(redisCluster *c, int status_strings TSRMLS_DC);
+clusterReply *cluster_read_resp(redisCluster *c, int status_strings);
 clusterReply *cluster_read_sock_resp(RedisSock *redis_sock,
-    REDIS_REPLY_TYPE type, char *line_reply, size_t reply_len TSRMLS_DC);
+    REDIS_REPLY_TYPE type, char *line_reply, size_t reply_len);
 void cluster_free_reply(clusterReply *reply, int free_data);
 
 /* Cluster distribution helpers for WATCH */
@@ -351,7 +351,7 @@ void cluster_dist_free(HashTable *ht);
 int cluster_dist_add_key(redisCluster *c, HashTable *ht, char *key,
     size_t key_len, clusterKeyVal **kv);
 void cluster_dist_add_val(redisCluster *c, clusterKeyVal *kv, zval *val
-    TSRMLS_DC);
+   );
 
 /* Aggregation for multi commands like MGET, MSET, and MSETNX */
 void cluster_multi_init(clusterMultiCmd *mc, char *kw, int kw_len);
@@ -367,25 +367,25 @@ unsigned short cluster_hash_key(const char *key, int len);
 long long mstime(void);
 
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
-    int cmd_len TSRMLS_DC);
+    int cmd_len);
 
-PHP_REDIS_API void cluster_disconnect(redisCluster *c, int force TSRMLS_DC);
+PHP_REDIS_API void cluster_disconnect(redisCluster *c, int force);
 
-PHP_REDIS_API int cluster_send_exec(redisCluster *c, short slot TSRMLS_DC);
-PHP_REDIS_API int cluster_send_discard(redisCluster *c, short slot TSRMLS_DC);
-PHP_REDIS_API int cluster_abort_exec(redisCluster *c TSRMLS_DC);
+PHP_REDIS_API int cluster_send_exec(redisCluster *c, short slot);
+PHP_REDIS_API int cluster_send_discard(redisCluster *c, short slot);
+PHP_REDIS_API int cluster_abort_exec(redisCluster *c);
 PHP_REDIS_API int cluster_reset_multi(redisCluster *c);
 
 PHP_REDIS_API short cluster_find_slot(redisCluster *c, const char *host,
     unsigned short port);
 PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
-    int cmd_len, REDIS_REPLY_TYPE rtype TSRMLS_DC);
+    int cmd_len, REDIS_REPLY_TYPE rtype);
 
 PHP_REDIS_API redisCluster *cluster_create(double timeout, double read_timeout,
     int failover, int persistent);
-PHP_REDIS_API void cluster_free(redisCluster *c, int free_ctx TSRMLS_DC);
+PHP_REDIS_API void cluster_free(redisCluster *c, int free_ctx);
 PHP_REDIS_API int cluster_init_seeds(redisCluster *c, HashTable *ht_seeds);
-PHP_REDIS_API int cluster_map_keyspace(redisCluster *c TSRMLS_DC);
+PHP_REDIS_API int cluster_map_keyspace(redisCluster *c);
 PHP_REDIS_API void cluster_free_node(redisClusterNode *node);
 
 /* Functions for interacting with cached slots maps */
@@ -396,7 +396,7 @@ PHP_REDIS_API void cluster_init_cache(redisCluster *c, redisCachedCluster *rcc);
 /* Functions to facilitate cluster slot caching */
 
 PHP_REDIS_API char **cluster_sock_read_multibulk_reply(RedisSock *redis_sock,
-    int *len TSRMLS_DC);
+    int *len);
 
 /*
  * Redis Cluster response handlers.  Our response handlers generally take the
@@ -492,15 +492,15 @@ PHP_REDIS_API void cluster_xinfo_resp(INTERNAL_FUNCTION_PARAMETERS,
 
 /* MULTI BULK processing callbacks */
 int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx TSRMLS_DC);
+    long long count, void *ctx);
 int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx TSRMLS_DC);
+    long long count, void *ctx);
 int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx TSRMLS_DC);
+    long long count, void *ctx);
 int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx TSRMLS_DC);
+    long long count, void *ctx);
 int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx TSRMLS_DC);
+    long long count, void *ctx);
 
 #endif
 

--- a/common.h
+++ b/common.h
@@ -127,7 +127,7 @@ typedef enum {
 } while (0)
 
 #define SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len) \
-    if(redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) < 0) { \
+    if(redis_sock_write(redis_sock, cmd, cmd_len) < 0) { \
     efree(cmd); \
     RETURN_FALSE; \
 }
@@ -156,7 +156,7 @@ typedef enum {
 
 #define REDIS_PROCESS_RESPONSE_CLOSURE(function, closure_context) \
     if (!IS_PIPELINE(redis_sock)) { \
-        if (redis_response_enqueued(redis_sock TSRMLS_CC) != SUCCESS) { \
+        if (redis_response_enqueued(redis_sock) != SUCCESS) { \
             RETURN_FALSE; \
         } \
     } \
@@ -177,7 +177,7 @@ typedef enum {
  * function is redis_<cmdname>_cmd */
 #define REDIS_PROCESS_CMD(cmdname, resp_func) \
     RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL || \
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL || \
        redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,redis_sock, \
                              &cmd, &cmd_len, NULL, &ctx)==FAILURE) { \
             RETURN_FALSE; \
@@ -193,7 +193,7 @@ typedef enum {
  * and keyword which is passed to us*/
 #define REDIS_PROCESS_KW_CMD(kw, cmdfunc, resp_func) \
     RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL || \
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL || \
        cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, kw, &cmd, \
                &cmd_len, NULL, &ctx)==FAILURE) { \
             RETURN_FALSE; \

--- a/library.c
+++ b/library.c
@@ -58,7 +58,7 @@ extern zend_class_entry *redis_exception_ce;
 extern int le_redis_pconnect;
 
 static ConnectionPool *
-redis_sock_get_connection_pool(RedisSock *redis_sock TSRMLS_DC)
+redis_sock_get_connection_pool(RedisSock *redis_sock)
 {
     zend_string *persistent_id = strpprintf(0, "phpredis_%s:%d", ZSTR_VAL(redis_sock->host), redis_sock->port);
     zend_resource *le = zend_hash_find_ptr(&EG(persistent_list), persistent_id);
@@ -75,21 +75,21 @@ redis_sock_get_connection_pool(RedisSock *redis_sock TSRMLS_DC)
 }
 
 /* Helper to reselect the proper DB number when we reconnect */
-static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
+static int reselect_db(RedisSock *redis_sock) {
     char *cmd, *response;
     int cmd_len, response_len;
 
-    cmd_len = redis_spprintf(redis_sock, NULL TSRMLS_CC, &cmd, "SELECT", "d",
+    cmd_len = redis_spprintf(redis_sock, NULL, &cmd, "SELECT", "d",
                              redis_sock->dbNumber);
 
-    if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) < 0) {
+    if (redis_sock_write(redis_sock, cmd, cmd_len) < 0) {
         efree(cmd);
         return -1;
     }
 
     efree(cmd);
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) == NULL) {
         return -1;
     }
 
@@ -104,22 +104,22 @@ static int reselect_db(RedisSock *redis_sock TSRMLS_DC) {
 
 /* Helper to resend AUTH <password> in the case of a reconnect */
 PHP_REDIS_API int
-redis_sock_auth(RedisSock *redis_sock TSRMLS_DC)
+redis_sock_auth(RedisSock *redis_sock)
 {
     char *cmd, *response;
     int cmd_len, response_len;
 
-    cmd_len = redis_spprintf(redis_sock, NULL TSRMLS_CC, &cmd, "AUTH", "s",
+    cmd_len = redis_spprintf(redis_sock, NULL, &cmd, "AUTH", "s",
                              ZSTR_VAL(redis_sock->auth), ZSTR_LEN(redis_sock->auth));
 
-    if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) < 0) {
+    if (redis_sock_write(redis_sock, cmd, cmd_len) < 0) {
         efree(cmd);
         return -1;
     }
 
     efree(cmd);
 
-    response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
+    response = redis_sock_read(redis_sock, &response_len);
     if (response == NULL) {
         return -1;
     }
@@ -148,7 +148,7 @@ static int redis_sock_errcmp(RedisSock *redis_sock, const char *err, size_t errl
  *    3) LOADING
  */
 static void
-redis_error_throw(RedisSock *redis_sock TSRMLS_DC)
+redis_error_throw(RedisSock *redis_sock)
 {
     /* Short circuit if we have no redis_sock or any error */
     if (redis_sock == NULL || redis_sock->err == NULL)
@@ -168,7 +168,7 @@ redis_error_throw(RedisSock *redis_sock TSRMLS_DC)
 }
 
 PHP_REDIS_API int
-redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC)
+redis_check_eof(RedisSock *redis_sock, int no_throw)
 {
     int count;
     char *errmsg;
@@ -206,26 +206,26 @@ redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC)
         for (count = 0; count < 10; ++count) {
             /* close existing stream before reconnecting */
             if (redis_sock->stream) {
-                redis_sock_disconnect(redis_sock, 1 TSRMLS_CC);
+                redis_sock_disconnect(redis_sock, 1);
             }
             // Wait for a while before trying to reconnect
             if (redis_sock->retry_interval) {
                 // Random factor to avoid having several (or many) concurrent connections trying to reconnect at the same time
-                long retry_interval = (count ? redis_sock->retry_interval : (php_rand(TSRMLS_C) % redis_sock->retry_interval));
+                long retry_interval = (count ? redis_sock->retry_interval : (php_rand() % redis_sock->retry_interval));
                 usleep(retry_interval);
             }
             /* reconnect */
-            if (redis_sock_connect(redis_sock TSRMLS_CC) == 0) {
+            if (redis_sock_connect(redis_sock) == 0) {
                 /* check for EOF again. */
                 errno = 0;
                 if (php_stream_eof(redis_sock->stream) == 0) {
                     /* If we're using a password, attempt a reauthorization */
-                    if (redis_sock->auth && redis_sock_auth(redis_sock TSRMLS_CC) != 0) {
+                    if (redis_sock->auth && redis_sock_auth(redis_sock) != 0) {
                         errmsg = "AUTH failed while reconnecting";
                         break;
                     }
                     /* If we're using a non-zero db, reselect it */
-                    if (redis_sock->dbNumber && reselect_db(redis_sock TSRMLS_CC) != 0) {
+                    if (redis_sock->dbNumber && reselect_db(redis_sock) != 0) {
                         errmsg = "SELECT failed while reconnecting";
                         break;
                     }
@@ -236,7 +236,7 @@ redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC)
         }
     }
     /* close stream and mark socket as failed */
-    redis_sock_disconnect(redis_sock, 1 TSRMLS_CC);
+    redis_sock_disconnect(redis_sock, 1);
     redis_sock->status = REDIS_SOCK_STATUS_FAILED;
     if (!no_throw) {
         REDIS_THROW_EXCEPTION( errmsg, 0);
@@ -254,21 +254,21 @@ redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *p_iter;
 
     /* Our response should have two multibulk replies */
-    if(redis_read_reply_type(redis_sock, &reply_type, &reply_info TSRMLS_CC)<0
+    if(redis_read_reply_type(redis_sock, &reply_type, &reply_info)<0
        || reply_type != TYPE_MULTIBULK || reply_info != 2)
     {
         return -1;
     }
 
     /* The BULK response iterator */
-    if(redis_read_reply_type(redis_sock, &reply_type, &reply_info TSRMLS_CC)<0
+    if(redis_read_reply_type(redis_sock, &reply_type, &reply_info)<0
        || reply_type != TYPE_BULK)
     {
         return -1;
     }
 
     /* Attempt to read the iterator */
-    if(!(p_iter = redis_sock_read_bulk_reply(redis_sock, reply_info TSRMLS_CC))) {
+    if(!(p_iter = redis_sock_read_bulk_reply(redis_sock, reply_info))) {
         return -1;
     }
 
@@ -389,7 +389,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
         sctx->cb.param_count = tab_idx;
 
         // Execute callback
-        if(zend_call_function(&(sctx->cb), &(sctx->cb_cache) TSRMLS_CC)
+        if(zend_call_function(&(sctx->cb), &(sctx->cb_cache))
                               ==FAILURE)
         {
             break;
@@ -448,7 +448,7 @@ redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS,
     size_t len;
 
     ZVAL_NULL(z_tab);
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return NULL;
     }
 
@@ -459,7 +459,7 @@ redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS,
 
     array_init(z_tab);
 
-    redis_mbulk_reply_loop(redis_sock, z_tab, numElems, UNSERIALIZE_ALL TSRMLS_CC);
+    redis_mbulk_reply_loop(redis_sock, z_tab, numElems, UNSERIALIZE_ALL);
 
     return z_tab;
 }
@@ -468,13 +468,13 @@ redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS,
  * redis_sock_read_bulk_reply
  */
 PHP_REDIS_API char *
-redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC)
+redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes)
 {
     int offset = 0, nbytes;
     char *reply;
     size_t got;
 
-    if (-1 == bytes || -1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
+    if (-1 == bytes || -1 == redis_check_eof(redis_sock, 0)) {
         return NULL;
     }
 
@@ -507,13 +507,13 @@ redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC)
  * redis_sock_read
  */
 PHP_REDIS_API char *
-redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC)
+redis_sock_read(RedisSock *redis_sock, int *buf_len)
 {
     char inbuf[4096];
     size_t len;
 
     *buf_len = 0;
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return NULL;
     }
 
@@ -522,12 +522,12 @@ redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC)
             redis_sock_set_err(redis_sock, inbuf+1, len);
 
             /* Filter our ERROR through the few that should actually throw */
-            redis_error_throw(redis_sock TSRMLS_CC);
+            redis_error_throw(redis_sock);
 
             return NULL;
         case '$':
             *buf_len = atoi(inbuf + 1);
-            return redis_sock_read_bulk_reply(redis_sock, *buf_len TSRMLS_CC);
+            return redis_sock_read_bulk_reply(redis_sock, *buf_len);
 
         case '*':
             /* For null multi-bulk replies (like timeouts from brpoplpush): */
@@ -581,7 +581,7 @@ union resparg {
  * L - Alias to 'l'
  */
 PHP_REDIS_API int
-redis_spprintf(RedisSock *redis_sock, short *slot TSRMLS_DC, char **ret, char *kw, char *fmt, ...) {
+redis_spprintf(RedisSock *redis_sock, short *slot, char **ret, char *kw, char *fmt, ...) {
     smart_string cmd = {0};
     va_list ap;
     union resparg arg;
@@ -615,7 +615,7 @@ redis_spprintf(RedisSock *redis_sock, short *slot TSRMLS_DC, char **ret, char *k
                 break;
             case 'v':
                 arg.zv = va_arg(ap, zval*);
-                argfree = redis_pack(redis_sock, arg.zv, &dup, &arglen TSRMLS_CC);
+                argfree = redis_pack(redis_sock, arg.zv, &dup, &arglen);
                 redis_cmd_append_sstr(&cmd, dup, arglen);
                 if (argfree) efree(dup);
                 break;
@@ -727,12 +727,12 @@ redis_cmd_append_sstr_dbl(smart_string *str, double value)
 
 /* Append a zval to a redis command.  The value will be serialized if we are
  * configured to do that */
-int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock TSRMLS_DC) {
+int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock) {
     char *val;
     size_t vallen;
     int valfree, retval;
 
-    valfree = redis_pack(redis_sock, z, &val, &vallen TSRMLS_CC);
+    valfree = redis_pack(redis_sock, z, &val, &vallen);
     retval = redis_cmd_append_sstr(str, val, vallen);
     if (valfree) efree(val);
 
@@ -776,7 +776,7 @@ PHP_REDIS_API void redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, Redi
     int response_len;
     double ret;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) == NULL) {
         if (IS_ATOMIC(redis_sock)) {
             RETURN_FALSE;
         }
@@ -798,7 +798,7 @@ PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
     int response_len;
     long l;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) == NULL) {
         if (IS_ATOMIC(redis_sock)) {
             RETURN_FALSE;
         }
@@ -836,7 +836,7 @@ PHP_REDIS_API void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
     zval z_ret;
 
     /* Read bulk response */
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) == NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -914,7 +914,7 @@ PHP_REDIS_API void redis_client_list_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSo
     zval z_ret;
 
     /* Make sure we can read the bulk response from Redis */
-    if ((resp = redis_sock_read(redis_sock, &resp_len TSRMLS_CC)) == NULL) {
+    if ((resp = redis_sock_read(redis_sock, &resp_len)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1037,7 +1037,7 @@ redis_boolean_response_impl(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int response_len;
     zend_bool ret = 0;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) != NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) != NULL) {
         ret = (*response == '+');
         efree(response);
     }
@@ -1068,7 +1068,7 @@ PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS,
     char *response;
     int response_len;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
+    if ((response = redis_sock_read(redis_sock, &response_len))
                                     == NULL)
     {
         if (IS_ATOMIC(redis_sock)) {
@@ -1108,7 +1108,7 @@ PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS,
  * key => value] when returning data to the caller.  Depending on our decode
  * flag we'll convert the value data types */
 static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
-                                        int decode TSRMLS_DC)
+                                        int decode)
 {
 
     zval z_ret, z_sub;
@@ -1161,13 +1161,13 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
 }
 
 static int
-read_mbulk_header(RedisSock *redis_sock, int *nelem TSRMLS_DC)
+read_mbulk_header(RedisSock *redis_sock, int *nelem)
 {
     char line[4096];
     size_t len;
 
     /* Throws exception on failure */
-    if (redis_sock_gets(redis_sock, line, sizeof(line)-1, &len TSRMLS_CC) < 0)
+    if (redis_sock_gets(redis_sock, line, sizeof(line)-1, &len) < 0)
         return -1;
 
     if (line[0] != '*') {
@@ -1192,7 +1192,7 @@ redis_mbulk_reply_zipped(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int numElems;
     size_t len;
 
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return -1;
     }
 
@@ -1209,10 +1209,10 @@ redis_mbulk_reply_zipped(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     array_init(&z_multi_result); /* pre-allocate array for multi's results. */
 
     /* Grab our key, value, key, value array */
-    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, unserialize TSRMLS_CC);
+    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, unserialize);
 
     /* Zip keys and values */
-    array_zip_values_and_scores(redis_sock, &z_multi_result, decode TSRMLS_CC);
+    array_zip_values_and_scores(redis_sock, &z_multi_result, decode);
 
     if (IS_ATOMIC(redis_sock)) {
         RETVAL_ZVAL(&z_multi_result, 0, 1);
@@ -1226,18 +1226,18 @@ redis_mbulk_reply_zipped(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 /* Consume message ID */
 PHP_REDIS_API int
 redis_sock_read_single_line(RedisSock *redis_sock, char *buffer, size_t buflen,
-                            size_t *linelen, int set_err TSRMLS_DC)
+                            size_t *linelen, int set_err)
 {
     REDIS_REPLY_TYPE type;
     long info;
 
-    if (redis_read_reply_type(redis_sock, &type, &info TSRMLS_CC) < 0 ||
+    if (redis_read_reply_type(redis_sock, &type, &info) < 0 ||
         (type != TYPE_LINE && type != TYPE_ERR))
     {
         return -1;
     }
 
-    if (redis_sock_gets(redis_sock, buffer, buflen, linelen TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, buffer, buflen, linelen) < 0) {
         return -1;
     }
 
@@ -1254,7 +1254,7 @@ redis_sock_read_single_line(RedisSock *redis_sock, char *buffer, size_t buflen,
  * multiple stream callers (e.g. XREAD[GROUP], and X[REV]RANGE handlers). */
 PHP_REDIS_API int
 redis_read_stream_messages(RedisSock *redis_sock, int count, zval *z_ret
-                           TSRMLS_DC)
+                          )
 {
     zval z_message;
     int i, mhdr, fields;
@@ -1265,9 +1265,9 @@ redis_read_stream_messages(RedisSock *redis_sock, int count, zval *z_ret
     for (i = 0; i < count; i++) {
         /* Consume inner multi-bulk header, message ID itself and finaly
          * the multi-bulk header for field and values */
-        if ((read_mbulk_header(redis_sock, &mhdr TSRMLS_CC) < 0 || mhdr != 2) ||
-            ((id = redis_sock_read(redis_sock, &idlen TSRMLS_CC)) == NULL) ||
-            (read_mbulk_header(redis_sock, &fields TSRMLS_CC) < 0 || fields % 2 != 0))
+        if ((read_mbulk_header(redis_sock, &mhdr) < 0 || mhdr != 2) ||
+            ((id = redis_sock_read(redis_sock, &idlen)) == NULL) ||
+            (read_mbulk_header(redis_sock, &fields) < 0 || fields % 2 != 0))
         {
             if (id) efree(id);
             return -1;
@@ -1275,8 +1275,8 @@ redis_read_stream_messages(RedisSock *redis_sock, int count, zval *z_ret
 
         array_init(&z_message);
 
-        redis_mbulk_reply_loop(redis_sock, &z_message, fields, UNSERIALIZE_VALS TSRMLS_CC);
-        array_zip_values_and_scores(redis_sock, &z_message, SCORE_DECODE_NONE TSRMLS_CC);
+        redis_mbulk_reply_loop(redis_sock, &z_message, fields, UNSERIALIZE_VALS);
+        array_zip_values_and_scores(redis_sock, &z_message, SCORE_DECODE_NONE);
         add_assoc_zval_ex(z_ret, id, idlen, &z_message);
         efree(id);
     }
@@ -1293,8 +1293,8 @@ redis_xrange_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     array_init(&z_messages);
 
-    if (read_mbulk_header(redis_sock, &messages TSRMLS_CC) < 0 ||
-        redis_read_stream_messages(redis_sock, messages, &z_messages TSRMLS_CC) < 0)
+    if (read_mbulk_header(redis_sock, &messages) < 0 ||
+        redis_read_stream_messages(redis_sock, messages, &z_messages) < 0)
     {
         zval_dtor(&z_messages);
         if (IS_ATOMIC(redis_sock)) {
@@ -1316,7 +1316,7 @@ redis_xrange_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 PHP_REDIS_API int
 redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_streams
-                                 TSRMLS_DC)
+                                )
 {
     zval z_messages;
     int i, shdr, messages;
@@ -1324,9 +1324,9 @@ redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_strea
     int idlen;
 
     for (i = 0; i < count; i++) {
-        if ((read_mbulk_header(redis_sock, &shdr TSRMLS_CC) < 0 || shdr != 2) ||
-            (id = redis_sock_read(redis_sock, &idlen TSRMLS_CC)) == NULL ||
-            read_mbulk_header(redis_sock, &messages TSRMLS_CC) < 0)
+        if ((read_mbulk_header(redis_sock, &shdr) < 0 || shdr != 2) ||
+            (id = redis_sock_read(redis_sock, &idlen)) == NULL ||
+            read_mbulk_header(redis_sock, &messages) < 0)
         {
             if (id) efree(id);
             return -1;
@@ -1334,7 +1334,7 @@ redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_strea
 
         array_init(&z_messages);
 
-        if (redis_read_stream_messages(redis_sock, messages, &z_messages TSRMLS_CC) < 0)
+        if (redis_read_stream_messages(redis_sock, messages, &z_messages) < 0)
             goto failure;
 
         add_assoc_zval_ex(z_streams, id, idlen, &z_messages);
@@ -1355,12 +1355,12 @@ redis_xread_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zval z_rv;
     int streams;
 
-    if (read_mbulk_header(redis_sock, &streams TSRMLS_CC) < 0)
+    if (read_mbulk_header(redis_sock, &streams) < 0)
         goto failure;
 
     array_init(&z_rv);
 
-    if (redis_read_stream_messages_multi(redis_sock, streams, &z_rv TSRMLS_CC) < 0)
+    if (redis_read_stream_messages_multi(redis_sock, streams, &z_rv) < 0)
         goto cleanup;
 
     if (IS_ATOMIC(redis_sock)) {
@@ -1385,7 +1385,7 @@ failure:
  * Redis and RedisCluster.  Note that XCLAIM is somewhat unique in that its reply type depends
  * on whether or not it was called with the JUSTID option */
 PHP_REDIS_API int
-redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv TSRMLS_DC) {
+redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv) {
     zval z_msg;
     REDIS_REPLY_TYPE type;
     char *id = NULL;
@@ -1394,20 +1394,20 @@ redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv TSRMLS_DC)
 
     for (i = 0; i < count; i++) {
         /* Consume inner reply type */
-        if (redis_read_reply_type(redis_sock, &type, &li TSRMLS_CC) < 0 ||
+        if (redis_read_reply_type(redis_sock, &type, &li) < 0 ||
             (type != TYPE_BULK && type != TYPE_MULTIBULK) ||
             (type == TYPE_BULK && li <= 0)) return -1;
 
         /* TYPE_BULK is the JUSTID variant, otherwise it's standard xclaim response */
         if (type == TYPE_BULK) {
-            if ((id = redis_sock_read_bulk_reply(redis_sock, (size_t)li TSRMLS_CC)) == NULL)
+            if ((id = redis_sock_read_bulk_reply(redis_sock, (size_t)li)) == NULL)
                 return -1;
 
             add_next_index_stringl(rv, id, li);
             efree(id);
         } else {
-            if ((li != 2 || (id = redis_sock_read(redis_sock, &idlen TSRMLS_CC)) == NULL) ||
-                (read_mbulk_header(redis_sock, &fields TSRMLS_CC) < 0 || fields % 2 != 0))
+            if ((li != 2 || (id = redis_sock_read(redis_sock, &idlen)) == NULL) ||
+                (read_mbulk_header(redis_sock, &fields) < 0 || fields % 2 != 0))
             {
                 if (id) efree(id);
                 return -1;
@@ -1415,8 +1415,8 @@ redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv TSRMLS_DC)
 
             array_init(&z_msg);
 
-            redis_mbulk_reply_loop(redis_sock, &z_msg, fields, UNSERIALIZE_VALS TSRMLS_CC);
-            array_zip_values_and_scores(redis_sock, &z_msg, SCORE_DECODE_NONE TSRMLS_CC);
+            redis_mbulk_reply_loop(redis_sock, &z_msg, fields, UNSERIALIZE_VALS);
+            array_zip_values_and_scores(redis_sock, &z_msg, SCORE_DECODE_NONE);
             add_assoc_zval_ex(rv, id, idlen, &z_msg);
             efree(id);
         }
@@ -1433,12 +1433,12 @@ redis_xclaim_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int messages;
 
     /* All XCLAIM responses start multibulk */
-    if (read_mbulk_header(redis_sock, &messages TSRMLS_CC) < 0)
+    if (read_mbulk_header(redis_sock, &messages) < 0)
         goto failure;
 
     array_init(&z_ret);
 
-    if (redis_read_xclaim_response(redis_sock, messages, &z_ret TSRMLS_CC) < 0) {
+    if (redis_read_xclaim_response(redis_sock, messages, &z_ret) < 0) {
         zval_dtor(&z_ret);
         goto failure;
     }
@@ -1469,12 +1469,12 @@ redis_read_xinfo_response(RedisSock *redis_sock, zval *z_ret, int elements)
     long li;
 
     for (i = 0; i < elements; ++i) {
-        if (redis_read_reply_type(redis_sock, &type, &li TSRMLS_CC) < 0) {
+        if (redis_read_reply_type(redis_sock, &type, &li) < 0) {
             goto failure;
         }
         switch (type) {
         case TYPE_BULK:
-            if ((data = redis_sock_read_bulk_reply(redis_sock, li TSRMLS_CC)) == NULL) {
+            if ((data = redis_sock_read_bulk_reply(redis_sock, li)) == NULL) {
                 goto failure;
             } else if (key) {
                 add_assoc_stringl_ex(z_ret, key, len, data, li);
@@ -1527,9 +1527,9 @@ redis_xinfo_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_t
     zval z_ret;
     int elements;
 
-    if (read_mbulk_header(redis_sock, &elements TSRMLS_CC) == SUCCESS) {
+    if (read_mbulk_header(redis_sock, &elements) == SUCCESS) {
         array_init(&z_ret);
-        if (redis_read_xinfo_response(redis_sock, &z_ret, elements TSRMLS_CC) == SUCCESS) {
+        if (redis_read_xinfo_response(redis_sock, &z_ret, elements) == SUCCESS) {
             if (IS_ATOMIC(redis_sock)) {
                 RETVAL_ZVAL(&z_ret, 0, 1);
             } else {
@@ -1585,7 +1585,7 @@ redis_1_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_ta
     int response_len;
     zend_bool ret = 0;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC)) != NULL) {
+    if ((response = redis_sock_read(redis_sock, &response_len)) != NULL) {
         ret = (response[1] == '1');
         efree(response);
     }
@@ -1602,7 +1602,7 @@ PHP_REDIS_API void redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock
     char *response;
     int response_len;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
+    if ((response = redis_sock_read(redis_sock, &response_len))
                                     == NULL)
     {
         if (IS_ATOMIC(redis_sock)) {
@@ -1612,12 +1612,12 @@ PHP_REDIS_API void redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock
         return;
     }
     if (IS_ATOMIC(redis_sock)) {
-        if (!redis_unpack(redis_sock, response, response_len, return_value TSRMLS_CC)) {
+        if (!redis_unpack(redis_sock, response, response_len, return_value)) {
             RETVAL_STRINGL(response, response_len);
         }
     } else {
         zval z_unpacked;
-        if (redis_unpack(redis_sock, response, response_len, &z_unpacked TSRMLS_CC)) {
+        if (redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
             add_next_index_zval(z_tab, &z_unpacked);
         } else {
             add_next_index_stringl(z_tab, response, response_len);
@@ -1633,7 +1633,7 @@ void redis_single_line_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock
     char buffer[4096];
     size_t len;
 
-    if (redis_sock_read_single_line(redis_sock, buffer, sizeof(buffer), &len, 1 TSRMLS_CC) < 0) {
+    if (redis_sock_read_single_line(redis_sock, buffer, sizeof(buffer), &len, 1) < 0) {
         if (IS_ATOMIC(redis_sock)) {
             RETURN_FALSE;
         } else {
@@ -1659,7 +1659,7 @@ redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *response;
     int response_len;
 
-    if ((response = redis_sock_read(redis_sock, &response_len TSRMLS_CC))
+    if ((response = redis_sock_read(redis_sock, &response_len))
                                     == NULL)
     {
         if (IS_ATOMIC(redis_sock)) {
@@ -1684,7 +1684,7 @@ PHP_REDIS_API void redis_debug_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock 
     int is_numeric,  resp_len;
 
     /* Add or return false if we can't read from the socket */
-    if((resp = redis_sock_read(redis_sock, &resp_len TSRMLS_CC))==NULL) {
+    if((resp = redis_sock_read(redis_sock, &resp_len))==NULL) {
         if (IS_ATOMIC(redis_sock)) {
             RETURN_FALSE;
         }
@@ -1789,7 +1789,7 @@ redis_sock_create(char *host, int host_len, unsigned short port,
 /**
  * redis_sock_connect
  */
-PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
+PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
 {
     struct timeval tv, read_tv, *tv_ptr = NULL;
     zend_string *persistent_id = NULL, *estr = NULL;
@@ -1799,7 +1799,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
     ConnectionPool *p = NULL;
 
     if (redis_sock->stream != NULL) {
-        redis_sock_disconnect(redis_sock, 0 TSRMLS_CC);
+        redis_sock_disconnect(redis_sock, 0);
     }
 
     address = ZSTR_VAL(redis_sock->host);
@@ -1827,7 +1827,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
 
     if (redis_sock->persistent) {
         if (INI_INT("redis.pconnect.pooling_enabled")) {
-            p = redis_sock_get_connection_pool(redis_sock TSRMLS_CC);
+            p = redis_sock_get_connection_pool(redis_sock);
             if (zend_llist_count(&p->list) > 0) {
                 redis_sock->stream = *(php_stream **)zend_llist_get_last(&p->list);
                 zend_llist_remove_tail(&p->list);
@@ -1912,14 +1912,14 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
  * redis_sock_server_open
  */
 PHP_REDIS_API int
-redis_sock_server_open(RedisSock *redis_sock TSRMLS_DC)
+redis_sock_server_open(RedisSock *redis_sock)
 {
     if (redis_sock) {
         switch (redis_sock->status) {
         case REDIS_SOCK_STATUS_FAILED:
             return FAILURE;
         case REDIS_SOCK_STATUS_DISCONNECTED:
-            return redis_sock_connect(redis_sock TSRMLS_CC);
+            return redis_sock_connect(redis_sock);
         default:
             return SUCCESS;
         }
@@ -1931,7 +1931,7 @@ redis_sock_server_open(RedisSock *redis_sock TSRMLS_DC)
  * redis_sock_disconnect
  */
 PHP_REDIS_API int
-redis_sock_disconnect(RedisSock *redis_sock, int force TSRMLS_DC)
+redis_sock_disconnect(RedisSock *redis_sock, int force)
 {
     if (redis_sock == NULL) {
         return FAILURE;
@@ -1939,7 +1939,7 @@ redis_sock_disconnect(RedisSock *redis_sock, int force TSRMLS_DC)
         if (redis_sock->persistent) {
             ConnectionPool *p = NULL;
             if (INI_INT("redis.pconnect.pooling_enabled")) {
-                p = redis_sock_get_connection_pool(redis_sock TSRMLS_CC);
+                p = redis_sock_get_connection_pool(redis_sock);
             }
             if (force) {
                 php_stream_pclose(redis_sock->stream);
@@ -1988,7 +1988,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
     int numElems;
     size_t len;
 
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return -1;
     }
 
@@ -2008,7 +2008,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS,
     zval z_multi_result;
     array_init(&z_multi_result); /* pre-allocate array for multi's results. */
 
-    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_ALL TSRMLS_CC);
+    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_ALL);
 
     if (IS_ATOMIC(redis_sock)) {
         RETVAL_ZVAL(&z_multi_result, 0, 1);
@@ -2029,7 +2029,7 @@ redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval 
     int numElems;
     size_t len;
 
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return -1;
     }
 
@@ -2048,7 +2048,7 @@ redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval 
     zval z_multi_result;
     array_init(&z_multi_result); /* pre-allocate array for multi's results. */
 
-    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_NONE TSRMLS_CC);
+    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_NONE);
 
     if (IS_ATOMIC(redis_sock)) {
         RETVAL_ZVAL(&z_multi_result, 0, 1);
@@ -2061,14 +2061,14 @@ redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval 
 
 PHP_REDIS_API void
 redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count,
-                       int unserialize TSRMLS_DC)
+                       int unserialize)
 {
     zval z_unpacked;
     char *line;
     int i, len;
 
     for (i = 0; i < count; ++i) {
-        if ((line = redis_sock_read(redis_sock, &len TSRMLS_CC)) == NULL) {
+        if ((line = redis_sock_read(redis_sock, &len)) == NULL) {
             add_next_index_bool(z_tab, 0);
             continue;
         }
@@ -2082,7 +2082,7 @@ redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count,
             (unserialize == UNSERIALIZE_VALS && i % 2 != 0)
         );
 
-        if (unwrap && redis_unpack(redis_sock, line, len, &z_unpacked TSRMLS_CC)) {
+        if (unwrap && redis_unpack(redis_sock, line, len, &z_unpacked)) {
             add_next_index_zval(z_tab, &z_unpacked);
         } else {
             add_next_index_stringl(z_tab, line, len);
@@ -2102,7 +2102,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 
     zval *z_keys = ctx;
 
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return -1;
     }
 
@@ -2120,10 +2120,10 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 
     for(i = 0; i < numElems; ++i) {
         zend_string *zstr = zval_get_string(&z_keys[i]);
-        response = redis_sock_read(redis_sock, &response_len TSRMLS_CC);
+        response = redis_sock_read(redis_sock, &response_len);
         if(response != NULL) {
             zval z_unpacked;
-            if (redis_unpack(redis_sock, response, response_len, &z_unpacked TSRMLS_CC)) {
+            if (redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
                 add_assoc_zval_ex(&z_multi_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), &z_unpacked);
             } else {
                 add_assoc_stringl_ex(&z_multi_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), response, response_len);
@@ -2149,9 +2149,9 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
  * redis_sock_write
  */
 PHP_REDIS_API int
-redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC)
+redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz)
 {
-    if (redis_check_eof(redis_sock, 0 TSRMLS_CC) == 0 &&
+    if (redis_check_eof(redis_sock, 0) == 0 &&
         php_stream_write(redis_sock->stream, cmd, sz) == sz
     ) {
         return sz;
@@ -2186,13 +2186,13 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
 }
 
 PHP_REDIS_API int
-redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len TSRMLS_DC)
+redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len)
 {
     char *buf;
     int valfree;
     size_t len;
 
-    valfree = redis_serialize(redis_sock, z, &buf, &len TSRMLS_CC);
+    valfree = redis_serialize(redis_sock, z, &buf, &len);
     switch (redis_sock->compression) {
         case REDIS_COMPRESSION_LZF:
 #ifdef HAVE_REDIS_LZF
@@ -2254,7 +2254,7 @@ redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len TSRMLS_DC
 }
 
 PHP_REDIS_API int
-redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TSRMLS_DC)
+redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret)
 {
     switch (redis_sock->compression) {
         case REDIS_COMPRESSION_LZF:
@@ -2273,7 +2273,7 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TS
                         /* errno != E2BIG will brake for loop */
                         efree(data);
                         continue;
-                    } else if (redis_unserialize(redis_sock, data, res, z_ret TSRMLS_CC) == 0) {
+                    } else if (redis_unserialize(redis_sock, data, res, z_ret) == 0) {
                         ZVAL_STRINGL(z_ret, data, res);
                     }
                     efree(data);
@@ -2295,7 +2295,7 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TS
                     if (ZSTD_isError(len)) {
                         efree(data);
                         break;
-                    } else if (redis_unserialize(redis_sock, data, len, z_ret TSRMLS_CC) == 0) {
+                    } else if (redis_unserialize(redis_sock, data, len, z_ret) == 0) {
                         ZVAL_STRINGL(z_ret, data, len);
                     }
                     efree(data);
@@ -2305,12 +2305,12 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TS
 #endif
             break;
     }
-    return redis_unserialize(redis_sock, val, val_len, z_ret TSRMLS_CC);
+    return redis_unserialize(redis_sock, val, val_len, z_ret);
 }
 
 PHP_REDIS_API int
 redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
-                TSRMLS_DC)
+               )
 {
     php_serialize_data_t ht;
 
@@ -2363,7 +2363,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
 
         case REDIS_SERIALIZER_MSGPACK:
 #ifdef HAVE_REDIS_MSGPACK
-            php_msgpack_serialize(&sstr, z TSRMLS_CC);
+            php_msgpack_serialize(&sstr, z);
             *val = estrndup(ZSTR_VAL(sstr.s), ZSTR_LEN(sstr.s));
             *val_len = ZSTR_LEN(sstr.s);
             smart_str_free(&sstr);
@@ -2373,7 +2373,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
             break;
         case REDIS_SERIALIZER_IGBINARY:
 #ifdef HAVE_REDIS_IGBINARY
-            if(igbinary_serialize(&val8, (size_t *)&sz, z TSRMLS_CC) == 0) {
+            if(igbinary_serialize(&val8, (size_t *)&sz, z) == 0) {
                 *val = (char*)val8;
                 *val_len = sz;
                 return 1;
@@ -2397,7 +2397,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
 
 PHP_REDIS_API int
 redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
-                  zval *z_ret TSRMLS_DC)
+                  zval *z_ret)
 {
 
     php_unserialize_data_t var_hash;
@@ -2419,7 +2419,7 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
 
         case REDIS_SERIALIZER_MSGPACK:
 #ifdef HAVE_REDIS_MSGPACK
-            ret = !php_msgpack_unserialize(z_ret, (char *)val, (size_t)val_len TSRMLS_CC);
+            ret = !php_msgpack_unserialize(z_ret, (char *)val, (size_t)val_len);
 #endif
             break;
 
@@ -2449,7 +2449,7 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
                 break;
             }
 
-            ret = !igbinary_unserialize((const uint8_t *)val, (size_t)val_len, z_ret TSRMLS_CC);
+            ret = !igbinary_unserialize((const uint8_t *)val, (size_t)val_len, z_ret);
 #endif
             break;
         case REDIS_SERIALIZER_JSON:
@@ -2494,10 +2494,10 @@ redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len) {
 
 PHP_REDIS_API int
 redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size,
-                size_t *line_size TSRMLS_DC)
+                size_t *line_size)
 {
     // Handle EOF
-    if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
+    if(-1 == redis_check_eof(redis_sock, 0)) {
         return -1;
     }
 
@@ -2512,7 +2512,7 @@ redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size,
             spprintf(&errmsg, 0, "read error on connection to %s:%d", ZSTR_VAL(redis_sock->host), redis_sock->port);
         }
         // Close our socket
-        redis_sock_disconnect(redis_sock, 1 TSRMLS_CC);
+        redis_sock_disconnect(redis_sock, 1);
 
         // Throw a read error exception
         REDIS_THROW_EXCEPTION(errmsg, 0);
@@ -2530,10 +2530,10 @@ redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size,
 
 PHP_REDIS_API int
 redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type,
-                      long *reply_info TSRMLS_DC)
+                      long *reply_info)
 {
     // Make sure we haven't lost the connection, even trying to reconnect
-    if(-1 == redis_check_eof(redis_sock, 0 TSRMLS_CC)) {
+    if(-1 == redis_check_eof(redis_sock, 0)) {
         // Failure
         *reply_type = EOF;
         return -1;
@@ -2571,21 +2571,21 @@ redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type,
  */
 static int
 redis_read_variant_line(RedisSock *redis_sock, REDIS_REPLY_TYPE reply_type,
-                        int as_string, zval *z_ret TSRMLS_DC)
+                        int as_string, zval *z_ret)
 {
     // Buffer to read our single line reply
     char inbuf[4096];
     size_t len;
 
     /* Attempt to read our single line reply */
-    if(redis_sock_gets(redis_sock, inbuf, sizeof(inbuf), &len TSRMLS_CC) < 0) {
+    if(redis_sock_gets(redis_sock, inbuf, sizeof(inbuf), &len) < 0) {
         return -1;
     }
 
     /* Throw exception on SYNC error otherwise just set error string */
     if(reply_type == TYPE_ERR) {
         redis_sock_set_err(redis_sock, inbuf, len);
-        redis_error_throw(redis_sock TSRMLS_CC);
+        redis_error_throw(redis_sock);
         ZVAL_FALSE(z_ret);
     } else if (as_string) {
         ZVAL_STRINGL(z_ret, inbuf, len);
@@ -2598,10 +2598,10 @@ redis_read_variant_line(RedisSock *redis_sock, REDIS_REPLY_TYPE reply_type,
 
 PHP_REDIS_API int
 redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret
-                        TSRMLS_DC)
+                       )
 {
     // Attempt to read the bulk reply
-    char *bulk_resp = redis_sock_read_bulk_reply(redis_sock, size TSRMLS_CC);
+    char *bulk_resp = redis_sock_read_bulk_reply(redis_sock, size);
 
     /* Set our reply to FALSE on failure, and the string on success */
     if(bulk_resp == NULL) {
@@ -2615,7 +2615,7 @@ redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret
 
 PHP_REDIS_API int
 redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_strings,
-                               zval *z_ret TSRMLS_DC)
+                               zval *z_ret)
 {
     long reply_info;
     REDIS_REPLY_TYPE reply_type;
@@ -2625,7 +2625,7 @@ redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_s
     while(elements > 0) {
         // Attempt to read our reply type
         if(redis_read_reply_type(redis_sock, &reply_type, &reply_info
-                                 TSRMLS_CC) < 0)
+                                ) < 0)
         {
             zend_throw_exception_ex(redis_exception_ce, 0,
                 "protocol error, couldn't parse MULTI-BULK response\n");
@@ -2637,7 +2637,7 @@ redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_s
             case TYPE_ERR:
             case TYPE_LINE:
                 redis_read_variant_line(redis_sock, reply_type, status_strings,
-                                        &z_subelem TSRMLS_CC);
+                                        &z_subelem);
                 add_next_index_zval(z_ret, &z_subelem);
                 break;
             case TYPE_INT:
@@ -2646,7 +2646,7 @@ redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_s
                 break;
             case TYPE_BULK:
                 // Init a zval for our bulk response, read and add it
-                redis_read_variant_bulk(redis_sock, reply_info, &z_subelem TSRMLS_CC);
+                redis_read_variant_bulk(redis_sock, reply_info, &z_subelem);
                 add_next_index_zval(z_ret, &z_subelem);
                 break;
             case TYPE_MULTIBULK:
@@ -2654,7 +2654,7 @@ redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_s
                 array_init(&z_subelem);
                 add_next_index_zval(z_ret, &z_subelem);
                 redis_read_multibulk_recursive(redis_sock, reply_info, status_strings,
-                                               &z_subelem TSRMLS_CC);
+                                               &z_subelem);
                 break;
             default:
                 // Stop the compiler from whinging
@@ -2678,7 +2678,7 @@ variant_reply_generic(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zval z_ret;
 
     // Attempt to read our header
-    if(redis_read_reply_type(redis_sock,&reply_type,&reply_info TSRMLS_CC) < 0)
+    if(redis_read_reply_type(redis_sock,&reply_type,&reply_info) < 0)
     {
         return -1;
     }
@@ -2687,13 +2687,13 @@ variant_reply_generic(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     switch(reply_type) {
         case TYPE_ERR:
         case TYPE_LINE:
-            redis_read_variant_line(redis_sock, reply_type, status_strings, &z_ret TSRMLS_CC);
+            redis_read_variant_line(redis_sock, reply_type, status_strings, &z_ret);
             break;
         case TYPE_INT:
             ZVAL_LONG(&z_ret, reply_info);
             break;
         case TYPE_BULK:
-            redis_read_variant_bulk(redis_sock, reply_info, &z_ret TSRMLS_CC);
+            redis_read_variant_bulk(redis_sock, reply_info, &z_ret);
             break;
         case TYPE_MULTIBULK:
             /* Initialize an array for our multi-bulk response */
@@ -2702,7 +2702,7 @@ variant_reply_generic(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             // If we've got more than zero elements, parse our multi bulk
             // response recursively
             if (reply_info > -1) {
-                redis_read_multibulk_recursive(redis_sock, reply_info, status_strings, &z_ret TSRMLS_CC);
+                redis_read_multibulk_recursive(redis_sock, reply_info, status_strings, &z_ret);
             }
             break;
         default:

--- a/library.h
+++ b/library.h
@@ -3,7 +3,7 @@
 
 /* Non cluster command helper */
 #define REDIS_SPPRINTF(ret, kw, fmt, ...) \
-    redis_spprintf(redis_sock, NULL TSRMLS_CC, ret, kw, fmt, ##__VA_ARGS__)
+    redis_spprintf(redis_sock, NULL, ret, kw, fmt, ##__VA_ARGS__)
 
 #define REDIS_CMD_APPEND_SSTR_STATIC(sstr, str) \
     redis_cmd_append_sstr(sstr, str, sizeof(str)-1);
@@ -26,14 +26,14 @@ int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
 int redis_cmd_append_sstr_i64(smart_string *str, int64_t append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
-int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock TSRMLS_DC);
+int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock);
 int redis_cmd_append_sstr_key(smart_string *str, char *key, size_t len, RedisSock *redis_sock, short *slot);
 int redis_cmd_append_sstr_arrkey(smart_string *cmd, zend_string *kstr, ulong idx);
 
-PHP_REDIS_API int redis_spprintf(RedisSock *redis_sock, short *slot TSRMLS_DC, char **ret, char *kw, char *fmt, ...);
+PHP_REDIS_API int redis_spprintf(RedisSock *redis_sock, short *slot, char **ret, char *kw, char *fmt, ...);
 
-PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
-PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len TSRMLS_DC);
+PHP_REDIS_API char * redis_sock_read(RedisSock *redis_sock, int *buf_len);
+PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len);
 PHP_REDIS_API void redis_1_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API void redis_long_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval* z_tab, void *ctx);
 typedef void (*SuccessCallback)(RedisSock *redis_sock);
@@ -49,17 +49,17 @@ PHP_REDIS_API void redis_parse_info_response(char *response, zval *z_ret);
 PHP_REDIS_API void redis_parse_client_list_response(char *response, zval *z_ret);
 PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, double read_timeout, int persistent, char *persistent_id, long retry_interval);
-PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC);
-PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock TSRMLS_DC);
-PHP_REDIS_API int redis_sock_auth(RedisSock *redis_sock TSRMLS_DC);
-PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock, int force TSRMLS_DC);
+PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock);
+PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock);
+PHP_REDIS_API int redis_sock_auth(RedisSock *redis_sock);
+PHP_REDIS_API int redis_sock_disconnect(RedisSock *redis_sock, int force);
 PHP_REDIS_API zval *redis_sock_read_multibulk_reply_zval(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab);
 PHP_REDIS_API int redis_sock_read_single_line(RedisSock *redis_sock, char *buffer,
-    size_t buflen, size_t *linelen, int set_err TSRMLS_DC);
-PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes TSRMLS_DC);
+    size_t buflen, size_t *linelen, int set_err);
+PHP_REDIS_API char *redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes);
 PHP_REDIS_API int redis_sock_read_multibulk_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *_z_tab, void *ctx);
 //PHP_REDIS_API void redis_mbulk_reply_loop(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, int count, int unserialize);
-PHP_REDIS_API void redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count, int unserialize TSRMLS_DC);
+PHP_REDIS_API void redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count, int unserialize);
 
 
 PHP_REDIS_API int redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
@@ -86,39 +86,39 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);
 
-PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz TSRMLS_DC);
-PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw TSRMLS_DC);
-PHP_REDIS_API RedisSock *redis_sock_get(zval *id TSRMLS_DC, int nothrow);
+PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz);
+PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw);
+PHP_REDIS_API RedisSock *redis_sock_get(zval *id, int nothrow);
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len);
 
 PHP_REDIS_API int
-redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len TSRMLS_DC);
+redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len);
 PHP_REDIS_API int
 redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len);
 
 PHP_REDIS_API int
-redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TSRMLS_DC);
+redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret);
 
-PHP_REDIS_API int redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len TSRMLS_DC);
-PHP_REDIS_API int redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret TSRMLS_DC);
+PHP_REDIS_API int redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len);
+PHP_REDIS_API int redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret);
 
 PHP_REDIS_API int
-redis_read_stream_messages(RedisSock *redis_sock, int count, zval *z_ret TSRMLS_DC);
+redis_read_stream_messages(RedisSock *redis_sock, int count, zval *z_ret);
 PHP_REDIS_API int
-redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_ret TSRMLS_DC);
+redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_ret);
 PHP_REDIS_API int
-redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv TSRMLS_DC);
+redis_read_xclaim_response(RedisSock *redis_sock, int count, zval *rv);
 PHP_REDIS_API int
-redis_read_xinfo_response(RedisSock *redis_sock, zval *z_ret, int elements TSRMLS_DC);
+redis_read_xinfo_response(RedisSock *redis_sock, zval *z_ret, int elements);
 
 /*
 * Variant Read methods, mostly to implement eval
 */
 
-PHP_REDIS_API int redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type, long *reply_info TSRMLS_DC);
-PHP_REDIS_API int redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret TSRMLS_DC);
-PHP_REDIS_API int redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_strings, zval *z_ret TSRMLS_DC);
+PHP_REDIS_API int redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type, long *reply_info);
+PHP_REDIS_API int redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret);
+PHP_REDIS_API int redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_strings, zval *z_ret);
 PHP_REDIS_API int redis_read_variant_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_read_variant_reply_strings(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/php_redis.h
+++ b/php_redis.h
@@ -273,11 +273,11 @@ PHP_REDIS_API void generic_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, char *sub
 PHP_REDIS_API void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, 
     char *unsub_cmd);
 
-PHP_REDIS_API int redis_response_enqueued(RedisSock *redis_sock TSRMLS_DC);
+PHP_REDIS_API int redis_response_enqueued(RedisSock *redis_sock);
 
-PHP_REDIS_API int get_flag(zval *object TSRMLS_DC);
+PHP_REDIS_API int get_flag(zval *object);
 
-PHP_REDIS_API void set_flag(zval *object, int new_flag TSRMLS_DC);
+PHP_REDIS_API void set_flag(zval *object, int new_flag);
 
 PHP_REDIS_API int redis_sock_read_multibulk_multi_reply_loop(
     INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, 

--- a/redis.c
+++ b/redis.c
@@ -516,7 +516,7 @@ zend_object_handlers redis_object_handlers;
 
 /* Send a static DISCARD in case we're in MULTI mode. */
 static int
-redis_send_discard(RedisSock *redis_sock TSRMLS_DC)
+redis_send_discard(RedisSock *redis_sock)
 {
     int result = FAILURE;
     char *cmd, *resp;
@@ -526,8 +526,8 @@ redis_send_discard(RedisSock *redis_sock TSRMLS_DC)
     cmd_len = REDIS_SPPRINTF(&cmd, "DISCARD", "");
 
     /* send our DISCARD command */
-    if (redis_sock_write(redis_sock, cmd, cmd_len TSRMLS_CC) >= 0 &&
-       (resp = redis_sock_read(redis_sock,&resp_len TSRMLS_CC)) != NULL)
+    if (redis_sock_write(redis_sock, cmd, cmd_len) >= 0 &&
+       (resp = redis_sock_read(redis_sock,&resp_len)) != NULL)
     {
         /* success if we get OK */
         result = (resp_len == 3 && strncmp(resp,"+OK", 3) == 0) ? SUCCESS:FAILURE;
@@ -568,21 +568,21 @@ free_redis_object(zend_object *object)
 {
     redis_object *redis = (redis_object *)((char *)(object) - XtOffsetOf(redis_object, std));
 
-    zend_object_std_dtor(&redis->std TSRMLS_CC);
+    zend_object_std_dtor(&redis->std);
     if (redis->sock) {
-        redis_sock_disconnect(redis->sock, 0 TSRMLS_CC);
+        redis_sock_disconnect(redis->sock, 0);
         redis_free_socket(redis->sock);
     }
 }
 
 zend_object *
-create_redis_object(zend_class_entry *ce TSRMLS_DC)
+create_redis_object(zend_class_entry *ce)
 {
     redis_object *redis = ecalloc(1, sizeof(redis_object) + zend_object_properties_size(ce));
 
     redis->sock = NULL;
 
-    zend_object_std_init(&redis->std, ce TSRMLS_CC);
+    zend_object_std_init(&redis->std, ce);
     object_properties_init(&redis->std, ce);
 
     memcpy(&redis_object_handlers, zend_get_std_object_handlers(), sizeof(redis_object_handlers));
@@ -594,7 +594,7 @@ create_redis_object(zend_class_entry *ce TSRMLS_DC)
 }
 
 static zend_always_inline RedisSock *
-redis_sock_get_instance(zval *id TSRMLS_DC, int no_throw)
+redis_sock_get_instance(zval *id, int no_throw)
 {
     redis_object *redis;
 
@@ -615,15 +615,15 @@ redis_sock_get_instance(zval *id TSRMLS_DC, int no_throw)
  * redis_sock_get
  */
 PHP_REDIS_API RedisSock *
-redis_sock_get(zval *id TSRMLS_DC, int no_throw)
+redis_sock_get(zval *id, int no_throw)
 {
     RedisSock *redis_sock;
 
-    if ((redis_sock = redis_sock_get_instance(id TSRMLS_CC, no_throw)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(id, no_throw)) == NULL) {
         return NULL;
     }
 
-    if (redis_sock_server_open(redis_sock TSRMLS_CC) < 0) {
+    if (redis_sock_server_open(redis_sock) < 0) {
         if (!no_throw) {
             char *errmsg = NULL;
             if (redis_sock->port < 0) {
@@ -650,9 +650,9 @@ PHP_REDIS_API RedisSock *redis_sock_get_connected(INTERNAL_FUNCTION_PARAMETERS) 
 
     // If we can't grab our object, or get a socket, or we're not connected,
     // return NULL
-    if((zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O",
+    if((zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",
        &object, redis_ce) == FAILURE) ||
-       (redis_sock = redis_sock_get(object TSRMLS_CC, 1)) == NULL ||
+       (redis_sock = redis_sock_get(object, 1)) == NULL ||
        redis_sock->status != REDIS_SOCK_STATUS_CONNECTED)
     {
         return NULL;
@@ -664,48 +664,48 @@ PHP_REDIS_API RedisSock *redis_sock_get_connected(INTERNAL_FUNCTION_PARAMETERS) 
 
 /* Redis and RedisCluster objects share serialization/prefixing settings so
  * this is a generic function to add class constants to either */
-static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) {
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_NOT_FOUND"), REDIS_NOT_FOUND TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_STRING"), REDIS_STRING TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_SET"), REDIS_SET TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_LIST"), REDIS_LIST TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_ZSET"), REDIS_ZSET TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_HASH"), REDIS_HASH TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_STREAM"), REDIS_STREAM TSRMLS_CC);
+static void add_class_constants(zend_class_entry *ce, int is_cluster) {
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_NOT_FOUND"), REDIS_NOT_FOUND);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_STRING"), REDIS_STRING);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_SET"), REDIS_SET);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_LIST"), REDIS_LIST);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_ZSET"), REDIS_ZSET);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_HASH"), REDIS_HASH);
+    zend_declare_class_constant_long(ce, ZEND_STRL("REDIS_STREAM"), REDIS_STREAM);
 
     /* Cluster doesn't support pipelining at this time */
     if(!is_cluster) {
-        zend_declare_class_constant_long(ce, ZEND_STRL("PIPELINE"), PIPELINE TSRMLS_CC);
+        zend_declare_class_constant_long(ce, ZEND_STRL("PIPELINE"), PIPELINE);
     }
 
     /* Add common mode constants */
-    zend_declare_class_constant_long(ce, ZEND_STRL("ATOMIC"), ATOMIC TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("MULTI"), MULTI TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("ATOMIC"), ATOMIC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("MULTI"), MULTI);
 
     /* options */
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SERIALIZER"), REDIS_OPT_SERIALIZER TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_PREFIX"), REDIS_OPT_PREFIX TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_READ_TIMEOUT"), REDIS_OPT_READ_TIMEOUT TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_TCP_KEEPALIVE"), REDIS_OPT_TCP_KEEPALIVE TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SERIALIZER"), REDIS_OPT_SERIALIZER);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_PREFIX"), REDIS_OPT_PREFIX);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_READ_TIMEOUT"), REDIS_OPT_READ_TIMEOUT);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_TCP_KEEPALIVE"), REDIS_OPT_TCP_KEEPALIVE);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_REPLY_LITERAL"), REDIS_OPT_REPLY_LITERAL);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_LEVEL"), REDIS_OPT_COMPRESSION_LEVEL);
 
     /* serializer */
-    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_PHP"), REDIS_SERIALIZER_PHP TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_PHP"), REDIS_SERIALIZER_PHP);
 #ifdef HAVE_REDIS_IGBINARY
-    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY);
 #endif
 #ifdef HAVE_REDIS_MSGPACK
-    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_MSGPACK"), REDIS_SERIALIZER_MSGPACK TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_MSGPACK"), REDIS_SERIALIZER_MSGPACK);
 #endif
-    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_JSON"), REDIS_SERIALIZER_JSON TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_JSON"), REDIS_SERIALIZER_JSON);
 
     /* compression */
-    zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_NONE"), REDIS_COMPRESSION_NONE TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_NONE"), REDIS_COMPRESSION_NONE);
 #ifdef HAVE_REDIS_LZF
-    zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_LZF"), REDIS_COMPRESSION_LZF TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_LZF"), REDIS_COMPRESSION_LZF);
 #endif
 #ifdef HAVE_REDIS_ZSTD
     zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_ZSTD"), REDIS_COMPRESSION_ZSTD);
@@ -719,21 +719,21 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster TSRMLS_DC) 
 #endif
 
     /* scan options*/
-    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SCAN"), REDIS_OPT_SCAN TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("SCAN_RETRY"), REDIS_SCAN_RETRY TSRMLS_CC);
-    zend_declare_class_constant_long(ce, ZEND_STRL("SCAN_NORETRY"), REDIS_SCAN_NORETRY TSRMLS_CC);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SCAN"), REDIS_OPT_SCAN);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SCAN_RETRY"), REDIS_SCAN_RETRY);
+    zend_declare_class_constant_long(ce, ZEND_STRL("SCAN_NORETRY"), REDIS_SCAN_NORETRY);
 
     /* Cluster option to allow for slave failover */
     if (is_cluster) {
-        zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SLAVE_FAILOVER"), REDIS_OPT_FAILOVER TSRMLS_CC);
-        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_NONE"), REDIS_FAILOVER_NONE TSRMLS_CC);
-        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_ERROR"), REDIS_FAILOVER_ERROR TSRMLS_CC);
-        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_DISTRIBUTE"), REDIS_FAILOVER_DISTRIBUTE TSRMLS_CC);
-        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_DISTRIBUTE_SLAVES"), REDIS_FAILOVER_DISTRIBUTE_SLAVES TSRMLS_CC);
+        zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SLAVE_FAILOVER"), REDIS_OPT_FAILOVER);
+        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_NONE"), REDIS_FAILOVER_NONE);
+        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_ERROR"), REDIS_FAILOVER_ERROR);
+        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_DISTRIBUTE"), REDIS_FAILOVER_DISTRIBUTE);
+        zend_declare_class_constant_long(ce, ZEND_STRL("FAILOVER_DISTRIBUTE_SLAVES"), REDIS_FAILOVER_DISTRIBUTE_SLAVES);
     }
 
-    zend_declare_class_constant_stringl(ce, "AFTER", 5, "after", 5 TSRMLS_CC);
-    zend_declare_class_constant_stringl(ce, "BEFORE", 6, "before", 6 TSRMLS_CC);
+    zend_declare_class_constant_stringl(ce, "AFTER", 5, "after", 5);
+    zend_declare_class_constant_stringl(ce, "BEFORE", 6, "before", 6);
 }
 
 static ZEND_RSRC_DTOR_FUNC(redis_connections_pool_dtor)
@@ -768,17 +768,17 @@ PHP_MINIT_FUNCTION(redis)
 
     /* Redis class */
     INIT_CLASS_ENTRY(redis_class_entry, "Redis", redis_functions);
-    redis_ce = zend_register_internal_class(&redis_class_entry TSRMLS_CC);
+    redis_ce = zend_register_internal_class(&redis_class_entry);
     redis_ce->create_object = create_redis_object;
 
     /* RedisArray class */
     INIT_CLASS_ENTRY(redis_array_class_entry, "RedisArray", redis_array_functions);
-    redis_array_ce = zend_register_internal_class(&redis_array_class_entry TSRMLS_CC);
+    redis_array_ce = zend_register_internal_class(&redis_array_class_entry);
     redis_array_ce->create_object = create_redis_array_object;
 
     /* RedisCluster class */
     INIT_CLASS_ENTRY(redis_cluster_class_entry, "RedisCluster", redis_cluster_functions);
-    redis_cluster_ce = zend_register_internal_class(&redis_cluster_class_entry TSRMLS_CC);
+    redis_cluster_ce = zend_register_internal_class(&redis_cluster_class_entry);
     redis_cluster_ce->create_object = create_cluster_context;
 
     /* Register our cluster cache list item */
@@ -789,7 +789,7 @@ PHP_MINIT_FUNCTION(redis)
     /* Base Exception class */
     exception_ce = zend_hash_str_find_ptr(CG(class_table), "RuntimeException", sizeof("RuntimeException") - 1);
     if (exception_ce == NULL) {
-        exception_ce = zend_exception_get_default(TSRMLS_C);
+        exception_ce = zend_exception_get_default();
     }
 
     /* RedisException class */
@@ -805,8 +805,8 @@ PHP_MINIT_FUNCTION(redis)
         &redis_cluster_exception_class_entry, exception_ce);
 
     /* Add shared class constants to Redis and RedisCluster objects */
-    add_class_constants(redis_ce, 0 TSRMLS_CC);
-    add_class_constants(redis_cluster_ce, 1 TSRMLS_CC);
+    add_class_constants(redis_ce, 0);
+    add_class_constants(redis_cluster_ce, 1);
 
 #ifdef PHP_SESSION
     php_session_register_module(&ps_mod_redis);
@@ -898,7 +898,7 @@ PHP_MINFO_FUNCTION(redis)
     Public constructor */
 PHP_METHOD(Redis, __construct)
 {
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         RETURN_FALSE;
     }
 }
@@ -908,13 +908,13 @@ PHP_METHOD(Redis, __construct)
     Public Destructor
  */
 PHP_METHOD(Redis,__destruct) {
-    if(zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         RETURN_FALSE;
     }
 
     // Grab our socket
     RedisSock *redis_sock;
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 1)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 1)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -923,7 +923,7 @@ PHP_METHOD(Redis,__destruct) {
         if (!IS_PIPELINE(redis_sock) && redis_sock->stream) {
             // Discard any multi commands, and free any callbacks that have been
             // queued
-            redis_send_discard(redis_sock TSRMLS_CC);
+            redis_send_discard(redis_sock);
         }
         free_reply_callbacks(redis_sock);
     }
@@ -969,7 +969,7 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
     persistent = 0;
 #endif
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "Os|lds!ld", &object, redis_ce, &host,
                                      &host_len, &port, &timeout, &persistent_id,
                                      &persistent_id_len, &retry_interval,
@@ -1006,14 +1006,14 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
     redis = PHPREDIS_GET_OBJECT(redis_object, object);
     /* if there is a redis sock already we have to remove it */
     if (redis->sock) {
-        redis_sock_disconnect(redis->sock, 0 TSRMLS_CC);
+        redis_sock_disconnect(redis->sock, 0);
         redis_free_socket(redis->sock);
     }
 
     redis->sock = redis_sock_create(host, host_len, port, timeout, read_timeout, persistent,
         persistent_id, retry_interval);
 
-    if (redis_sock_server_open(redis->sock TSRMLS_CC) < 0) {
+    if (redis_sock_server_open(redis->sock) < 0) {
         if (redis->sock->err) {
             REDIS_THROW_EXCEPTION(ZSTR_VAL(redis->sock->err), 0);
         }
@@ -1053,7 +1053,7 @@ PHP_METHOD(Redis, close)
 {
     RedisSock *redis_sock = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
-    if (redis_sock_disconnect(redis_sock, 1 TSRMLS_CC) == SUCCESS) {
+    if (redis_sock_disconnect(redis_sock, 1) == SUCCESS) {
         RETURN_TRUE;
     }
     RETURN_FALSE;
@@ -1195,13 +1195,13 @@ PHP_METHOD(Redis, mget)
     int arg_count;
 
     /* Make sure we have proper arguments */
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oa",
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oa",
                                     &object, redis_ce, &z_args) == FAILURE) {
         RETURN_FALSE;
     }
 
     /* We'll need the socket */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1515,7 +1515,7 @@ PHP_METHOD(Redis, sRandMember)
     RedisSock *redis_sock;
 
     // Grab our socket, validate call
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL ||
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL ||
        redis_srandmember_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
                              &cmd, &cmd_len, NULL, NULL, &have_count) == FAILURE)
     {
@@ -1601,7 +1601,7 @@ PHP_METHOD(Redis, sort) {
     RedisSock *redis_sock;
 
     // Grab socket, handle command construction
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL ||
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL ||
        redis_sort_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &have_store,
                       &cmd, &cmd_len, NULL, NULL) == FAILURE)
     {
@@ -1632,7 +1632,7 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
     smart_string cmd = {0};
 
     /* Parse myriad of sort arguments */
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "Os|s!z!lls", &object, redis_ce, &key,
                                      &keylen, &pattern, &patternlen, &zget,
                                      &offset, &count, &store, &storelen)
@@ -1642,7 +1642,7 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
     }
 
     /* Ensure we're sorting something, and we can get context */
-    if (keylen == 0 || !(redis_sock = redis_sock_get(object TSRMLS_CC, 0)))
+    if (keylen == 0 || !(redis_sock = redis_sock_get(object, 0)))
         RETURN_FALSE;
 
     /* Start calculating argc depending on input arguments */
@@ -1855,14 +1855,14 @@ PHP_METHOD(Redis, info) {
     size_t opt_len;
     int cmd_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "O|s", &object, redis_ce, &opt, &opt_len)
                                      == FAILURE)
     {
         RETURN_FALSE;
     }
 
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1893,12 +1893,12 @@ PHP_METHOD(Redis, select) {
     int cmd_len;
     zend_long dbNumber;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Ol",
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol",
                                      &object, redis_ce, &dbNumber) == FAILURE) {
         RETURN_FALSE;
     }
 
-    if (dbNumber < 0 || (redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if (dbNumber < 0 || (redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1938,14 +1938,14 @@ void generic_mset(INTERNAL_FUNCTION_PARAMETERS, char *kw, ResultCallback fun)
     size_t keylen;
     zend_ulong idx;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oa",
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oa",
                                      &object, redis_ce, &z_array) == FAILURE)
     {
         RETURN_FALSE;
     }
 
     /* Make sure we can get our socket, and we were not passed an empty array */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL ||
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL ||
         zend_hash_num_elements(Z_ARRVAL_P(z_array)) == 0)
     {
         RETURN_FALSE;
@@ -1965,7 +1965,7 @@ void generic_mset(INTERNAL_FUNCTION_PARAMETERS, char *kw, ResultCallback fun)
         }
 
         /* Append our value */
-        redis_cmd_append_sstr_zval(&cmd, zmem, redis_sock TSRMLS_CC);
+        redis_cmd_append_sstr_zval(&cmd, zmem, redis_sock);
     } ZEND_HASH_FOREACH_END();
 
     REDIS_PROCESS_REQUEST(redis_sock, cmd.c, cmd.len);
@@ -2016,7 +2016,7 @@ static void generic_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw,
     RedisSock *redis_sock;
     int withscores = 0;
 
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2319,7 +2319,7 @@ PHP_METHOD(Redis, multi)
     zval *object;
     zend_long multi_value = MULTI;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "O|l", &object, redis_ce, &multi_value)
                                      == FAILURE)
     {
@@ -2328,14 +2328,14 @@ PHP_METHOD(Redis, multi)
 
     /* if the flag is activated, send the command, the reply will be "QUEUED"
      * or -ERR */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
     if (multi_value == PIPELINE) {
         /* Cannot enter pipeline mode in a MULTI block */
         if (IS_MULTI(redis_sock)) {
-            php_error_docref(NULL TSRMLS_CC, E_ERROR, "Can't activate pipeline in multi mode!");
+            php_error_docref(NULL, E_ERROR, "Can't activate pipeline in multi mode!");
             RETURN_FALSE;
         }
 
@@ -2356,7 +2356,7 @@ PHP_METHOD(Redis, multi)
             } else {
                 SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len)
                 efree(cmd);
-                if ((resp = redis_sock_read(redis_sock, &resp_len TSRMLS_CC)) == NULL) {
+                if ((resp = redis_sock_read(redis_sock, &resp_len)) == NULL) {
                     RETURN_FALSE;
                 } else if (strncmp(resp, "+OK", 3) != 0) {
                     efree(resp);
@@ -2367,7 +2367,7 @@ PHP_METHOD(Redis, multi)
             }
         }
     } else {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown mode sent to Redis::multi");
+        php_error_docref(NULL, E_WARNING, "Unknown mode sent to Redis::multi");
         RETURN_FALSE;
     }
 
@@ -2381,12 +2381,12 @@ PHP_METHOD(Redis, discard)
     RedisSock *redis_sock;
     zval *object;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O",
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",
                                      &object, redis_ce) == FAILURE) {
         RETURN_FALSE;
     }
 
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2397,7 +2397,7 @@ PHP_METHOD(Redis, discard)
             redis_sock->pipeline_cmd = NULL;
         }
     } else if (IS_MULTI(redis_sock)) {
-        ret = redis_send_discard(redis_sock TSRMLS_CC);
+        ret = redis_send_discard(redis_sock);
     }
     if (ret == SUCCESS) {
         free_reply_callbacks(redis_sock);
@@ -2416,7 +2416,7 @@ PHP_REDIS_API int redis_sock_read_multibulk_multi_reply(INTERNAL_FUNCTION_PARAME
     int numElems;
     size_t len;
 
-    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+    if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         return - 1;
     }
 
@@ -2444,9 +2444,9 @@ PHP_METHOD(Redis, exec)
     int cmd_len, ret;
     zval *object;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "O", &object, redis_ce) == FAILURE ||
-        (redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL
+        (redis_sock = redis_sock_get(object, 0)) == NULL
     ) {
         RETURN_FALSE;
     }
@@ -2480,7 +2480,7 @@ PHP_METHOD(Redis, exec)
             array_init(return_value);
         } else {
             if (redis_sock_write(redis_sock, ZSTR_VAL(redis_sock->pipeline_cmd),
-                    ZSTR_LEN(redis_sock->pipeline_cmd) TSRMLS_CC) < 0) {
+                    ZSTR_LEN(redis_sock->pipeline_cmd)) < 0) {
                 ZVAL_FALSE(return_value);
             } else {
                 array_init(return_value);
@@ -2496,12 +2496,12 @@ PHP_METHOD(Redis, exec)
 }
 
 PHP_REDIS_API int
-redis_response_enqueued(RedisSock *redis_sock TSRMLS_DC)
+redis_response_enqueued(RedisSock *redis_sock)
 {
     char *resp;
     int resp_len, ret = FAILURE;
 
-    if ((resp = redis_sock_read(redis_sock, &resp_len TSRMLS_CC)) != NULL) {
+    if ((resp = redis_sock_read(redis_sock, &resp_len)) != NULL) {
         if (strncmp(resp, "+QUEUED", 7) == 0) {
             ret = SUCCESS;
         }
@@ -2522,24 +2522,24 @@ redis_sock_read_multibulk_multi_reply_loop(INTERNAL_FUNCTION_PARAMETERS,
     for (fi = redis_sock->head; fi; /* void */) {
         if (fi->fun) {
             fi->fun(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab,
-                fi->ctx TSRMLS_CC);
+                fi->ctx);
             fi = fi->next;
             continue;
         }
         size_t len;
         char inbuf[255];
 
-        if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+        if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         } else if (strncmp(inbuf, "+OK", 3) != 0) {
         }
 
         while ((fi = fi->next) && fi->fun) {
-            if (redis_response_enqueued(redis_sock TSRMLS_CC) == SUCCESS) {
+            if (redis_response_enqueued(redis_sock) == SUCCESS) {
             } else {
             }
         }
 
-        if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len TSRMLS_CC) < 0) {
+        if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
         }
 
         zval z_ret;
@@ -2548,7 +2548,7 @@ redis_sock_read_multibulk_multi_reply_loop(INTERNAL_FUNCTION_PARAMETERS,
 
         int num = atol(inbuf + 1);
 
-        if (num > 0 && redis_read_multibulk_recursive(redis_sock, num, 0, &z_ret TSRMLS_CC) < 0) {
+        if (num > 0 && redis_read_multibulk_recursive(redis_sock, num, 0, &z_ret) < 0) {
         }
 
         if (fi) fi = fi->next;
@@ -2562,16 +2562,16 @@ PHP_METHOD(Redis, pipeline)
     RedisSock *redis_sock;
     zval *object;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "O", &object, redis_ce) == FAILURE ||
-        (redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL
+        (redis_sock = redis_sock_get(object, 0)) == NULL
     ) {
         RETURN_FALSE;
     }
 
     /* User cannot enter MULTI mode if already in a pipeline */
     if (IS_MULTI(redis_sock)) {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "Can't activate pipeline in multi mode!");
+        php_error_docref(NULL, E_ERROR, "Can't activate pipeline in multi mode!");
         RETURN_FALSE;
     }
 
@@ -2632,11 +2632,11 @@ PHP_REDIS_API void generic_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS,
     int i;
     zval z_tab, *z_channel;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oa",
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oa",
                                      &object, redis_ce, &array) == FAILURE) {
         RETURN_FALSE;
     }
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2717,13 +2717,13 @@ PHP_METHOD(Redis, slaveof)
     zend_long port = 6379;
     int cmd_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "O|sl", &object, redis_ce, &host,
                                      &host_len, &port) == FAILURE)
     {
         RETURN_FALSE;
     }
-    if (port < 0 || (redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if (port < 0 || (redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2749,7 +2749,7 @@ PHP_METHOD(Redis, object)
     char *cmd; int cmd_len;
     REDIS_REPLY_TYPE rtype;
 
-    if ((redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL) {
        RETURN_FALSE;
     }
 
@@ -2782,7 +2782,7 @@ PHP_METHOD(Redis, getOption)
 {
     RedisSock *redis_sock;
 
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2795,7 +2795,7 @@ PHP_METHOD(Redis, setOption)
 {
     RedisSock *redis_sock;
 
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2813,7 +2813,7 @@ PHP_METHOD(Redis, config)
     enum {CFG_GET, CFG_SET} mode;
     int cmd_len;
 
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                      "Oss|s", &object, redis_ce, &op, &op_len,
                                      &key, &key_len, &val, &val_len) == FAILURE)
     {
@@ -2829,7 +2829,7 @@ PHP_METHOD(Redis, config)
         RETURN_FALSE;
     }
 
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2869,7 +2869,7 @@ PHP_METHOD(Redis, slowlog) {
     enum {SLOWLOG_GET, SLOWLOG_LEN, SLOWLOG_RESET} mode;
 
     // Make sure we can get parameters
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                     "Os|l", &object, redis_ce, &arg, &arg_len,
                                     &option) == FAILURE)
     {
@@ -2889,7 +2889,7 @@ PHP_METHOD(Redis, slowlog) {
     }
 
     /* Make sure we can grab our redis socket */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2922,7 +2922,7 @@ PHP_METHOD(Redis, wait) {
     int cmd_len;
 
     /* Make sure arguments are valid */
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "Oll",
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oll",
                                     &object, redis_ce, &num_slaves, &timeout)
                                     ==FAILURE)
     {
@@ -2935,7 +2935,7 @@ PHP_METHOD(Redis, wait) {
     }
 
     /* Grab our socket */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -2954,7 +2954,7 @@ PHP_METHOD(Redis, wait) {
 /* Construct a PUBSUB command */
 PHP_REDIS_API int
 redis_build_pubsub_cmd(RedisSock *redis_sock, char **ret, PUBSUB_TYPE type,
-                       zval *arg TSRMLS_DC)
+                       zval *arg)
 {
     HashTable *ht_chan;
     zval *z_ele;
@@ -3009,7 +3009,7 @@ PHP_METHOD(Redis, pubsub) {
     zval *arg = NULL;
 
     // Parse arguments
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                     "Os|z", &object, redis_ce, &keyword,
                                     &kw_len, &arg)==FAILURE)
     {
@@ -3039,12 +3039,12 @@ PHP_METHOD(Redis, pubsub) {
     }
 
     /* Grab our socket context object */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
     /* Construct our "PUBSUB" command */
-    cmd_len = redis_build_pubsub_cmd(redis_sock, &cmd, type, arg TSRMLS_CC);
+    cmd_len = redis_build_pubsub_cmd(redis_sock, &cmd, type, arg);
 
     REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
 
@@ -3092,7 +3092,7 @@ PHP_METHOD(Redis, script) {
     int argc = ZEND_NUM_ARGS();
 
     /* Attempt to grab our socket */
-    if (argc < 1 || (redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL) {
+    if (argc < 1 || (redis_sock = redis_sock_get(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3151,7 +3151,7 @@ PHP_METHOD(Redis, migrate) {
 PHP_METHOD(Redis, _prefix) {
     RedisSock *redis_sock;
 
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3163,7 +3163,7 @@ PHP_METHOD(Redis, _serialize) {
     RedisSock *redis_sock;
 
     // Grab socket
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3175,7 +3175,7 @@ PHP_METHOD(Redis, _unserialize) {
     RedisSock *redis_sock;
 
     // Grab socket
-    if ((redis_sock = redis_sock_get_instance(getThis() TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3189,14 +3189,14 @@ PHP_METHOD(Redis, getLastError) {
     RedisSock *redis_sock;
 
     // Grab our object
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O",
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",
                                     &object, redis_ce) == FAILURE)
     {
         RETURN_FALSE;
     }
 
     // Grab socket
-    if ((redis_sock = redis_sock_get_instance(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3213,13 +3213,13 @@ PHP_METHOD(Redis, clearLastError) {
     RedisSock *redis_sock;
 
     // Grab our object
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O",
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O",
                                     &object, redis_ce) == FAILURE)
     {
         RETURN_FALSE;
     }
     // Grab socket
-    if ((redis_sock = redis_sock_get_instance(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3240,12 +3240,12 @@ PHP_METHOD(Redis, getMode) {
     RedisSock *redis_sock;
 
     /* Grab our object */
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(), "O", &object, redis_ce) == FAILURE) {
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &object, redis_ce) == FAILURE) {
         RETURN_FALSE;
     }
 
     /* Grab socket */
-    if ((redis_sock = redis_sock_get_instance(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get_instance(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3378,7 +3378,7 @@ PHP_METHOD(Redis, client) {
     int cmd_len;
 
     // Parse our method parameters
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                     "Os|s", &object, redis_ce, &opt, &opt_len,
                                     &arg, &arg_len) == FAILURE)
     {
@@ -3386,7 +3386,7 @@ PHP_METHOD(Redis, client) {
     }
 
     /* Grab our socket */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -3425,18 +3425,18 @@ PHP_METHOD(Redis, rawcommand) {
 
     /* Sanity check on arguments */
     if (argc < 1) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Must pass at least one command keyword");
         RETURN_FALSE;
     }
     z_args = emalloc(argc * sizeof(zval));
     if (zend_get_parameters_array(ht, argc, z_args) == FAILURE) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Internal PHP error parsing arguments");
         efree(z_args);
         RETURN_FALSE;
-    } else if (redis_build_raw_cmd(z_args, argc, &cmd, &cmd_len TSRMLS_CC) < 0 ||
-               (redis_sock = redis_sock_get(getThis() TSRMLS_CC, 0)) == NULL
+    } else if (redis_build_raw_cmd(z_args, argc, &cmd, &cmd_len) < 0 ||
+               (redis_sock = redis_sock_get(getThis(), 0)) == NULL
     ) {
         if (cmd) efree(cmd);
         efree(z_args);
@@ -3529,7 +3529,7 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
     /* Different prototype depending on if this is a key based scan */
     if(type != TYPE_SCAN) {
         // Requires a key
-        if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+        if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                         "Osz/|s!l", &object, redis_ce, &key,
                                         &key_len, &z_iter, &pattern,
                                         &pattern_len, &count)==FAILURE)
@@ -3538,7 +3538,7 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
         }
     } else {
         // Doesn't require a key
-        if(zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+        if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                         "Oz/|s!l", &object, redis_ce, &z_iter,
                                         &pattern, &pattern_len, &count)
                                         == FAILURE)
@@ -3548,13 +3548,13 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
     }
 
     /* Grab our socket */
-    if ((redis_sock = redis_sock_get(object TSRMLS_CC, 0)) == NULL) {
+    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
         RETURN_FALSE;
     }
 
     /* Calling this in a pipeline makes no sense */
     if (!IS_ATOMIC(redis_sock)) {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR,
+        php_error_docref(NULL, E_ERROR,
             "Can't call SCAN commands in multi or pipeline mode!");
         RETURN_FALSE;
     }

--- a/redis_array.h
+++ b/redis_array.h
@@ -66,9 +66,9 @@ typedef struct RedisArray_ {
     struct RedisArray_ *prev;
 } RedisArray;
 
-zend_object *create_redis_array_object(zend_class_entry *ce TSRMLS_DC);
+zend_object *create_redis_array_object(zend_class_entry *ce);
 void free_redis_array_object(zend_object *object);
 
-PHP_REDIS_API int ra_call_user_function(HashTable *function_table, zval *object, zval *function_name, zval *retval_ptr, uint param_count, zval params[] TSRMLS_DC);
+PHP_REDIS_API int ra_call_user_function(HashTable *function_table, zval *object, zval *function_name, zval *retval_ptr, uint param_count, zval params[]);
 
 #endif

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -33,7 +33,7 @@
 extern zend_class_entry *redis_ce;
 
 static RedisArray *
-ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_string *auth, long retry_interval, zend_bool b_lazy_connect TSRMLS_DC)
+ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_string *auth, long retry_interval, zend_bool b_lazy_connect)
 {
     int i = 0, host_len;
     char *host, *p;
@@ -80,7 +80,7 @@ ra_load_hosts(RedisArray *ra, HashTable *hosts, zend_string *auth, long retry_in
         if (!b_lazy_connect)
         {
             /* connect */
-            if (redis_sock_server_open(redis->sock TSRMLS_CC) < 0 || (auth && redis_sock_auth(redis->sock TSRMLS_CC) < 0)) {
+            if (redis_sock_server_open(redis->sock) < 0 || (auth && redis_sock_auth(redis->sock ) < 0)) {
                 zval_dtor(&z_cons);
                 ra->count = ++i;
                 return NULL;
@@ -162,7 +162,7 @@ ra_find_name(const char *name) {
 }
 
 /* laod array from INI settings */
-RedisArray *ra_load_array(const char *name TSRMLS_DC) {
+RedisArray *ra_load_array(const char *name) {
 
     zval *z_data, z_fun, z_dist;
     zval z_params_hosts;
@@ -197,7 +197,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find hosts */
     array_init(&z_params_hosts);
     if ((iptr = INI_STR("redis.arrays.hosts")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_hosts TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_hosts);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_hosts), name, name_len)) != NULL) {
         hHosts = Z_ARRVAL_P(z_data);
@@ -206,7 +206,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find previous hosts */
     array_init(&z_params_prev);
     if ((iptr = INI_STR("redis.arrays.previous")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_prev TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_prev);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_prev), name, name_len)) != NULL) {
         hPrev = Z_ARRVAL_P(z_data);
@@ -215,7 +215,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find function */
     array_init(&z_params_funs);
     if ((iptr = INI_STR("redis.arrays.functions")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_funs TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_funs);
     }
     ZVAL_NULL(&z_fun);
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_funs), name, name_len)) != NULL) {
@@ -225,7 +225,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find distributor */
     array_init(&z_params_dist);
     if ((iptr = INI_STR("redis.arrays.distributor")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_dist TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_dist);
     }
     ZVAL_NULL(&z_dist);
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_dist), name, name_len)) != NULL) {
@@ -235,7 +235,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find hash algorithm */
     array_init(&z_params_algo);
     if ((iptr = INI_STR("redis.arrays.algorithm")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_algo TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_algo);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_algo), name, name_len)) != NULL) {
         algorithm = zval_get_string(z_data);
@@ -244,7 +244,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find index option */
     array_init(&z_params_index);
     if ((iptr = INI_STR("redis.arrays.index")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_index TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_index);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_index), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_STRING && strncmp(Z_STRVAL_P(z_data), "1", 1) == 0) {
@@ -255,7 +255,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find autorehash option */
     array_init(&z_params_autorehash);
     if ((iptr = INI_STR("redis.arrays.autorehash")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_autorehash TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_autorehash);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_autorehash), name, name_len)) != NULL) {
         if(Z_TYPE_P(z_data) == IS_STRING && strncmp(Z_STRVAL_P(z_data), "1", 1) == 0) {
@@ -266,7 +266,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find retry interval option */
     array_init(&z_params_retry_interval);
     if ((iptr = INI_STR("redis.arrays.retryinterval")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_retry_interval TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_retry_interval);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_retry_interval), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_LONG) {
@@ -279,7 +279,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find pconnect option */
     array_init(&z_params_pconnect);
     if ((iptr = INI_STR("redis.arrays.pconnect")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_pconnect TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_pconnect);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_pconnect), name, name_len)) != NULL) {
         if(Z_TYPE_P(z_data) == IS_STRING && strncmp(Z_STRVAL_P(z_data), "1", 1) == 0) {
@@ -290,7 +290,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find lazy connect option */
     array_init(&z_params_lazy_connect);
     if ((iptr = INI_STR("redis.arrays.lazyconnect")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_lazy_connect TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_lazy_connect);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_lazy_connect), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_STRING && strncmp(Z_STRVAL_P(z_data), "1", 1) == 0) {
@@ -301,7 +301,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find connect timeout option */
     array_init(&z_params_connect_timeout);
     if ((iptr = INI_STR("redis.arrays.connecttimeout")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_connect_timeout TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_connect_timeout);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_connect_timeout), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_DOUBLE) {
@@ -316,7 +316,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find read timeout option */
     array_init(&z_params_read_timeout);
     if ((iptr = INI_STR("redis.arrays.readtimeout")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_read_timeout TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_read_timeout);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_read_timeout), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_DOUBLE) {
@@ -331,7 +331,7 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find consistent option */
     array_init(&z_params_consistent);
     if ((iptr = INI_STR("redis.arrays.consistent")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_consistent TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_consistent);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_consistent), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_data) == IS_STRING && strncmp(Z_STRVAL_P(z_data), "1", 1) == 0) {
@@ -342,14 +342,14 @@ RedisArray *ra_load_array(const char *name TSRMLS_DC) {
     /* find auth option */
     array_init(&z_params_auth);
     if ((iptr = INI_STR("redis.arrays.auth")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_auth TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_auth);
     }
     if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_auth), name, name_len)) != NULL) {
         auth = zval_get_string(z_data);
     }
 
     /* create RedisArray object */
-    ra = ra_make_array(hHosts, &z_fun, &z_dist, hPrev, b_index, b_pconnect, l_retry_interval, b_lazy_connect, d_connect_timeout, read_timeout, consistent, algorithm, auth TSRMLS_CC);
+    ra = ra_make_array(hHosts, &z_fun, &z_dist, hPrev, b_index, b_pconnect, l_retry_interval, b_lazy_connect, d_connect_timeout, read_timeout, consistent, algorithm, auth);
     if (ra) {
         ra->auto_rehash = b_autorehash;
         if(ra->prev) ra->prev->auto_rehash = b_autorehash;
@@ -420,7 +420,7 @@ ra_make_continuum(zend_string **hosts, int nb_hosts)
 }
 
 RedisArray *
-ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, long retry_interval, zend_bool b_lazy_connect, double connect_timeout, double read_timeout, zend_bool consistent, zend_string *algorithm, zend_string *auth TSRMLS_DC)
+ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, long retry_interval, zend_bool b_lazy_connect, double connect_timeout, double read_timeout, zend_bool consistent, zend_string *algorithm, zend_string *auth)
 {
     int i, count;
     RedisArray *ra;
@@ -441,7 +441,7 @@ ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev
     ra->continuum = NULL;
     ra->algorithm = NULL;
 
-    if (ra_load_hosts(ra, hosts, auth, retry_interval, b_lazy_connect TSRMLS_CC) == NULL || !ra->count) {
+    if (ra_load_hosts(ra, hosts, auth, retry_interval, b_lazy_connect) == NULL || !ra->count) {
         for (i = 0; i < ra->count; ++i) {
             zval_dtor(&ra->redis[i]);
             zend_string_release(ra->hosts[i]);
@@ -451,7 +451,7 @@ ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev
         efree(ra);
         return NULL;
     }
-    ra->prev = hosts_prev ? ra_make_array(hosts_prev, z_fun, z_dist, NULL, b_index, b_pconnect, retry_interval, b_lazy_connect, connect_timeout, read_timeout, consistent, algorithm, auth TSRMLS_CC) : NULL;
+    ra->prev = hosts_prev ? ra_make_array(hosts_prev, z_fun, z_dist, NULL, b_index, b_pconnect, retry_interval, b_lazy_connect, connect_timeout, read_timeout, consistent, algorithm, auth) : NULL;
 
     /* init array data structures */
     ra_init_function_table(ra);
@@ -472,21 +472,21 @@ ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev
 
 /* call userland key extraction function */
 zend_string *
-ra_call_extractor(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
+ra_call_extractor(RedisArray *ra, const char *key, int key_len)
 {
     zend_string *out = NULL;
     zval z_ret, z_argv;
 
     /* check that we can call the extractor function */
     if (!zend_is_callable_ex(&ra->z_fun, NULL, 0, NULL, NULL, NULL)) {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "Could not call extractor function");
+        php_error_docref(NULL, E_ERROR, "Could not call extractor function");
         return NULL;
     }
 
     ZVAL_NULL(&z_ret);
     /* call extraction function */
     ZVAL_STRINGL(&z_argv, key, key_len);
-    ra_call_user_function(EG(function_table), NULL, &ra->z_fun, &z_ret, 1, &z_argv TSRMLS_CC);
+    ra_call_user_function(EG(function_table), NULL, &ra->z_fun, &z_ret, 1, &z_argv);
 
     if (Z_TYPE(z_ret) == IS_STRING) {
         out = zval_get_string(&z_ret);
@@ -498,12 +498,12 @@ ra_call_extractor(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
 }
 
 static zend_string *
-ra_extract_key(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
+ra_extract_key(RedisArray *ra, const char *key, int key_len)
 {
     char *start, *end;
 
     if (Z_TYPE(ra->z_fun) != IS_NULL) {
-        return ra_call_extractor(ra, key, key_len TSRMLS_CC);
+        return ra_call_extractor(ra, key, key_len);
     } else if ((start = strchr(key, '{')) == NULL || (end = strchr(start + 1, '}')) == NULL) {
         return zend_string_init(key, key_len, 0);
     }
@@ -513,21 +513,21 @@ ra_extract_key(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
 
 /* call userland key distributor function */
 int
-ra_call_distributor(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
+ra_call_distributor(RedisArray *ra, const char *key, int key_len)
 {
     int ret;
     zval z_ret, z_argv;
 
     /* check that we can call the extractor function */
     if (!zend_is_callable_ex(&ra->z_dist, NULL, 0, NULL, NULL, NULL)) {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "Could not call distributor function");
+        php_error_docref(NULL, E_ERROR, "Could not call distributor function");
         return -1;
     }
 
     ZVAL_NULL(&z_ret);
     /* call extraction function */
     ZVAL_STRINGL(&z_argv, key, key_len);
-    ra_call_user_function(EG(function_table), NULL, &ra->z_dist, &z_ret, 1, &z_argv TSRMLS_CC);
+    ra_call_user_function(EG(function_table), NULL, &ra->z_dist, &z_ret, 1, &z_argv);
 
     ret = (Z_TYPE(z_ret) == IS_LONG) ? Z_LVAL(z_ret) : -1;
 
@@ -537,13 +537,13 @@ ra_call_distributor(RedisArray *ra, const char *key, int key_len TSRMLS_DC)
 }
 
 zval *
-ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_DC)
+ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos)
 {
     int pos;
     zend_string *out;
 
     /* extract relevant part of the key */
-    if ((out = ra_extract_key(ra, key, key_len TSRMLS_CC)) == NULL) {
+    if ((out = ra_extract_key(ra, key, key_len)) == NULL) {
         return NULL;
     }
 
@@ -591,7 +591,7 @@ ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_D
             pos = (int)((ret ^ 0xffffffff) * ra->count / 0xffffffff);
         }
     } else {
-        pos = ra_call_distributor(ra, key, key_len TSRMLS_CC);
+        pos = ra_call_distributor(ra, key, key_len);
         if (pos < 0 || pos >= ra->count) {
             zend_string_release(out);
             return NULL;
@@ -605,7 +605,7 @@ ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_D
 }
 
 zval *
-ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC) {
+ra_find_node_by_name(RedisArray *ra, const char *host, int host_len) {
 
     int i;
     for(i = 0; i < ra->count; ++i) {
@@ -617,7 +617,7 @@ ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC) {
 }
 
 void
-ra_index_multi(zval *z_redis, long multi_value TSRMLS_DC) {
+ra_index_multi(zval *z_redis, long multi_value) {
 
     zval z_fun_multi, z_ret;
     zval z_args[1];
@@ -625,13 +625,13 @@ ra_index_multi(zval *z_redis, long multi_value TSRMLS_DC) {
     /* run MULTI */
     ZVAL_STRINGL(&z_fun_multi, "MULTI", 5);
     ZVAL_LONG(&z_args[0], multi_value);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_multi, &z_ret, 1, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_multi, &z_ret, 1, z_args);
     zval_dtor(&z_fun_multi);
     zval_dtor(&z_ret);
 }
 
 static void
-ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis TSRMLS_DC) {
+ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis) {
 
     int i, argc;
     zval z_fun, z_ret, *z_args;
@@ -655,7 +655,7 @@ ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis TSRMLS_DC) {
     }
 
     /* run cmd */
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, argc, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, argc, z_args);
 
     zval_dtor(&z_args[0]);
     zval_dtor(&z_fun);
@@ -664,12 +664,12 @@ ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis TSRMLS_DC) {
 }
 
 void
-ra_index_del(zval *z_keys, zval *z_redis TSRMLS_DC) {
-    ra_index_change_keys("SREM", z_keys, z_redis TSRMLS_CC);
+ra_index_del(zval *z_keys, zval *z_redis) {
+    ra_index_change_keys("SREM", z_keys, z_redis);
 }
 
 void
-ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC) {
+ra_index_keys(zval *z_pairs, zval *z_redis) {
 
     zval z_keys, *z_val;
     zend_string *zkey;
@@ -693,14 +693,14 @@ ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC) {
     } ZEND_HASH_FOREACH_END();
 
     /* add keys to index */
-    ra_index_change_keys("SADD", &z_keys, z_redis TSRMLS_CC);
+    ra_index_change_keys("SADD", &z_keys, z_redis);
 
     /* cleanup */
     zval_dtor(&z_keys);
 }
 
 void
-ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC) {
+ra_index_key(const char *key, int key_len, zval *z_redis) {
 
     zval z_fun_sadd, z_ret, z_args[2];
 
@@ -711,7 +711,7 @@ ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC) {
     ZVAL_STRINGL(&z_args[1], key, key_len);
 
     /* run SADD */
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_sadd, &z_ret, 2, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_sadd, &z_ret, 2, z_args);
     zval_dtor(&z_fun_sadd);
     zval_dtor(&z_args[1]);
     zval_dtor(&z_args[0]);
@@ -719,13 +719,13 @@ ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC) {
 }
 
 void
-ra_index_exec(zval *z_redis, zval *return_value, int keep_all TSRMLS_DC) {
+ra_index_exec(zval *z_redis, zval *return_value, int keep_all) {
 
     zval z_fun_exec, z_ret, *zp_tmp;
 
     /* run EXEC */
     ZVAL_STRINGL(&z_fun_exec, "EXEC", 4);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_exec, &z_ret, 0, NULL TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_exec, &z_ret, 0, NULL);
     zval_dtor(&z_fun_exec);
 
     /* extract first element of exec array and put into return_value. */
@@ -742,30 +742,30 @@ ra_index_exec(zval *z_redis, zval *return_value, int keep_all TSRMLS_DC) {
     zval_dtor(&z_ret);
 
     /* zval *zptr = &z_ret; */
-    /* php_var_dump(&zptr, 0 TSRMLS_CC); */
+    /* php_var_dump(&zptr, 0); */
 }
 
 void
-ra_index_discard(zval *z_redis, zval *return_value TSRMLS_DC) {
+ra_index_discard(zval *z_redis, zval *return_value) {
 
     zval z_fun_discard, z_ret;
 
     /* run DISCARD */
     ZVAL_STRINGL(&z_fun_discard, "DISCARD", 7);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_discard, &z_ret, 0, NULL TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_discard, &z_ret, 0, NULL);
 
     zval_dtor(&z_fun_discard);
     zval_dtor(&z_ret);
 }
 
 void
-ra_index_unwatch(zval *z_redis, zval *return_value TSRMLS_DC) {
+ra_index_unwatch(zval *z_redis, zval *return_value) {
 
     zval z_fun_unwatch, z_ret;
 
     /* run UNWATCH */
     ZVAL_STRINGL(&z_fun_unwatch, "UNWATCH", 7);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_unwatch, &z_ret, 0, NULL TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_unwatch, &z_ret, 0, NULL);
 
     zval_dtor(&z_fun_unwatch);
     zval_dtor(&z_ret);
@@ -790,14 +790,14 @@ ra_is_write_cmd(RedisArray *ra, const char *cmd, int cmd_len) {
 
 /* run TYPE to find the type */
 static zend_bool
-ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long *res TSRMLS_DC) {
+ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long *res) {
 
     int i = 0;
     zval z_fun, z_ret, z_arg, *z_data;
     long success = 1;
 
     /* Pipelined */
-    ra_index_multi(z_from, PIPELINE TSRMLS_CC);
+    ra_index_multi(z_from, PIPELINE);
 
     /* prepare args */
     ZVAL_STRINGL(&z_arg, key, key_len);
@@ -805,19 +805,19 @@ ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long 
     /* run TYPE */
     ZVAL_NULL(&z_ret);
     ZVAL_STRINGL(&z_fun, "TYPE", 4);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg);
     zval_dtor(&z_fun);
     zval_dtor(&z_ret);
 
     /* run TYPE */
     ZVAL_NULL(&z_ret);
     ZVAL_STRINGL(&z_fun, "TTL", 3);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg);
     zval_dtor(&z_fun);
     zval_dtor(&z_ret);
 
     /* Get the result from the pipeline. */
-    ra_index_exec(z_from, &z_ret, 1 TSRMLS_CC);
+    ra_index_exec(z_from, &z_ret, 1);
     if (Z_TYPE(z_ret) == IS_ARRAY) {
         ZEND_HASH_FOREACH_VAL(Z_ARRVAL(z_ret), z_data) {
             if (z_data == NULL || Z_TYPE_P(z_data) != IS_LONG) {
@@ -835,7 +835,7 @@ ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long 
 
 /* delete key from source server index during rehashing */
 static void
-ra_remove_from_index(zval *z_redis, const char *key, int key_len TSRMLS_DC) {
+ra_remove_from_index(zval *z_redis, const char *key, int key_len) {
 
     zval z_fun_srem, z_ret, z_args[2];
 
@@ -844,7 +844,7 @@ ra_remove_from_index(zval *z_redis, const char *key, int key_len TSRMLS_DC) {
     ZVAL_STRINGL(&z_args[0], PHPREDIS_INDEX_NAME, sizeof(PHPREDIS_INDEX_NAME) - 1);
     ZVAL_STRINGL(&z_args[1], key, key_len);
 
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_srem, &z_ret, 2, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun_srem, &z_ret, 2, z_args);
 
     /* cleanup */
     zval_dtor(&z_fun_srem);
@@ -856,32 +856,32 @@ ra_remove_from_index(zval *z_redis, const char *key, int key_len TSRMLS_DC) {
 
 /* delete key from source server during rehashing */
 static zend_bool
-ra_del_key(const char *key, int key_len, zval *z_from TSRMLS_DC) {
+ra_del_key(const char *key, int key_len, zval *z_from) {
 
     zval z_fun_del, z_ret, z_args[1];
 
     /* in a transaction */
-    ra_index_multi(z_from, MULTI TSRMLS_CC);
+    ra_index_multi(z_from, MULTI);
 
     /* run DEL on source */
     ZVAL_STRINGL(&z_fun_del, "DEL", 3);
     ZVAL_STRINGL(&z_args[0], key, key_len);
-    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_del, &z_ret, 1, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_del, &z_ret, 1, z_args);
     zval_dtor(&z_fun_del);
     zval_dtor(&z_args[0]);
     zval_dtor(&z_ret);
 
     /* remove key from index */
-    ra_remove_from_index(z_from, key, key_len TSRMLS_CC);
+    ra_remove_from_index(z_from, key, key_len);
 
     /* close transaction */
-    ra_index_exec(z_from, NULL, 0 TSRMLS_CC);
+    ra_index_exec(z_from, NULL, 0);
 
     return 1;
 }
 
 static zend_bool
-ra_expire_key(const char *key, int key_len, zval *z_to, long ttl TSRMLS_DC) {
+ra_expire_key(const char *key, int key_len, zval *z_to, long ttl) {
 
     zval z_fun_expire, z_ret, z_args[2];
 
@@ -891,7 +891,7 @@ ra_expire_key(const char *key, int key_len, zval *z_to, long ttl TSRMLS_DC) {
         ZVAL_STRINGL(&z_fun_expire, "EXPIRE", 6);
         ZVAL_STRINGL(&z_args[0], key, key_len);
         ZVAL_LONG(&z_args[1], ttl);
-        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_expire, &z_ret, 2, z_args TSRMLS_CC);
+        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_expire, &z_ret, 2, z_args);
         zval_dtor(&z_fun_expire);
         zval_dtor(&z_args[0]);
         zval_dtor(&z_ret);
@@ -901,7 +901,7 @@ ra_expire_key(const char *key, int key_len, zval *z_to, long ttl TSRMLS_DC) {
 }
 
 static zend_bool
-ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
 
     zval z_fun_zrange, z_fun_zadd, z_ret, z_ret_dest, z_args[4], *z_zadd_args, *z_score_p;
     int i, count;
@@ -915,7 +915,7 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
     ZVAL_STRINGL(&z_args[1], "0", 1);
     ZVAL_STRINGL(&z_args[2], "-1", 2);
     ZVAL_BOOL(&z_args[3], 1);
-    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_zrange, &z_ret, 4, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_zrange, &z_ret, 4, z_args);
     zval_dtor(&z_fun_zrange);
     zval_dtor(&z_args[2]);
     zval_dtor(&z_args[1]);
@@ -953,10 +953,10 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 
     /* run ZADD on target */
     ZVAL_STRINGL(&z_fun_zadd, "ZADD", 4);
-    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_zadd, &z_ret_dest, 1 + 2 * count, z_zadd_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_zadd, &z_ret_dest, 1 + 2 * count, z_zadd_args);
 
     /* Expire if needed */
-    ra_expire_key(key, key_len, z_to, ttl TSRMLS_CC);
+    ra_expire_key(key, key_len, z_to, ttl);
 
     /* cleanup */
     zval_dtor(&z_fun_zadd);
@@ -973,14 +973,14 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 }
 
 static zend_bool
-ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
 
     zval z_fun_get, z_fun_set, z_ret, z_args[3];
 
     /* run GET on source */
     ZVAL_STRINGL(&z_fun_get, "GET", 3);
     ZVAL_STRINGL(&z_args[0], key, key_len);
-    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_get, &z_ret, 1, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_get, &z_ret, 1, z_args);
     zval_dtor(&z_fun_get);
 
     if(Z_TYPE(z_ret) != IS_STRING) { /* key not found or replaced */
@@ -996,14 +996,14 @@ ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl 
         ZVAL_LONG(&z_args[1], ttl);
         ZVAL_STRINGL(&z_args[2], Z_STRVAL(z_ret), Z_STRLEN(z_ret)); /* copy z_ret to arg 1 */
         zval_dtor(&z_ret); /* free memory from our previous call */
-        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 3, z_args TSRMLS_CC);
+        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 3, z_args);
         /* cleanup */
         zval_dtor(&z_args[2]);
     } else {
         ZVAL_STRINGL(&z_fun_set, "SET", 3);
         ZVAL_STRINGL(&z_args[1], Z_STRVAL(z_ret), Z_STRLEN(z_ret)); /* copy z_ret to arg 1 */
         zval_dtor(&z_ret); /* free memory from our previous return value */
-        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 2, z_args TSRMLS_CC);
+        ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 2, z_args);
         /* cleanup */
         zval_dtor(&z_args[1]);
     }
@@ -1015,13 +1015,13 @@ ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl 
 }
 
 static zend_bool
-ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
     zval z_fun_hgetall, z_fun_hmset, z_ret_dest, z_args[2];
 
     /* run HGETALL on source */
     ZVAL_STRINGL(&z_args[0], key, key_len);
     ZVAL_STRINGL(&z_fun_hgetall, "HGETALL", 7);
-    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_hgetall, &z_args[1], 1, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_hgetall, &z_args[1], 1, z_args);
     zval_dtor(&z_fun_hgetall);
 
     if (Z_TYPE(z_args[1]) != IS_ARRAY) { /* key not found or replaced */
@@ -1033,12 +1033,12 @@ ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 
     /* run HMSET on target */
     ZVAL_STRINGL(&z_fun_hmset, "HMSET", 5);
-    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_hmset, &z_ret_dest, 2, z_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_hmset, &z_ret_dest, 2, z_args);
     zval_dtor(&z_fun_hmset);
     zval_dtor(&z_ret_dest);
 
     /* Expire if needed */
-    ra_expire_key(key, key_len, z_to, ttl TSRMLS_CC);
+    ra_expire_key(key, key_len, z_to, ttl);
 
     /* cleanup */
     zval_dtor(&z_args[1]);
@@ -1050,7 +1050,7 @@ ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TS
 static zend_bool
 ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
         int list_count, const char **cmd_list,
-        int add_count, const char **cmd_add, long ttl TSRMLS_DC) {
+        int add_count, const char **cmd_add, long ttl) {
 
     zval z_fun_retrieve, z_fun_sadd, z_ret, *z_retrieve_args, *z_sadd_args, *z_data_p;
     int count, i;
@@ -1068,7 +1068,7 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
         ZVAL_STRING(&z_retrieve_args[i], cmd_list[i]);
     }
 
-    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_retrieve, &z_ret, list_count, z_retrieve_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_from, &z_fun_retrieve, &z_ret, list_count, z_retrieve_args);
 
     /* cleanup */
     zval_dtor(&z_fun_retrieve);
@@ -1100,7 +1100,7 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
     /* Clean up our input return value */
     zval_dtor(&z_ret);
 
-    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_sadd, &z_ret, count, z_sadd_args TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_to, &z_fun_sadd, &z_ret, count, z_sadd_args);
 
     /* cleanup */
     zval_dtor(&z_fun_sadd);
@@ -1113,56 +1113,56 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
     zval_dtor(&z_ret);
 
     /* Expire if needed */
-    ra_expire_key(key, key_len, z_to, ttl TSRMLS_CC);
+    ra_expire_key(key, key_len, z_to, ttl);
 
     return 1;
 }
 
 static zend_bool
-ra_move_set(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_set(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
 
     const char *cmd_list[] = {"SMEMBERS"};
     const char *cmd_add[] = {"SADD"};
-    return ra_move_collection(key, key_len, z_from, z_to, 1, cmd_list, 1, cmd_add, ttl TSRMLS_CC);
+    return ra_move_collection(key, key_len, z_from, z_to, 1, cmd_list, 1, cmd_add, ttl);
 }
 
 static zend_bool
-ra_move_list(const char *key, int key_len, zval *z_from, zval *z_to, long ttl TSRMLS_DC) {
+ra_move_list(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
 
     const char *cmd_list[] = {"LRANGE", "0", "-1"};
     const char *cmd_add[] = {"RPUSH"};
-    return ra_move_collection(key, key_len, z_from, z_to, 3, cmd_list, 1, cmd_add, ttl TSRMLS_CC);
+    return ra_move_collection(key, key_len, z_from, z_to, 3, cmd_list, 1, cmd_add, ttl);
 }
 
 void
-ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to TSRMLS_DC) {
+ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to) {
 
     long res[2] = {0}, type, ttl;
     zend_bool success = 0;
-    if (ra_get_key_type(z_from, key, key_len, z_from, res TSRMLS_CC)) {
+    if (ra_get_key_type(z_from, key, key_len, z_from, res)) {
         type = res[0];
         ttl = res[1];
         /* open transaction on target server */
-        ra_index_multi(z_to, MULTI TSRMLS_CC);
+        ra_index_multi(z_to, MULTI);
         switch(type) {
             case REDIS_STRING:
-                success = ra_move_string(key, key_len, z_from, z_to, ttl TSRMLS_CC);
+                success = ra_move_string(key, key_len, z_from, z_to, ttl);
                 break;
 
             case REDIS_SET:
-                success = ra_move_set(key, key_len, z_from, z_to, ttl TSRMLS_CC);
+                success = ra_move_set(key, key_len, z_from, z_to, ttl);
                 break;
 
             case REDIS_LIST:
-                success = ra_move_list(key, key_len, z_from, z_to, ttl TSRMLS_CC);
+                success = ra_move_list(key, key_len, z_from, z_to, ttl);
                 break;
 
             case REDIS_ZSET:
-                success = ra_move_zset(key, key_len, z_from, z_to, ttl TSRMLS_CC);
+                success = ra_move_zset(key, key_len, z_from, z_to, ttl);
                 break;
 
             case REDIS_HASH:
-                success = ra_move_hash(key, key_len, z_from, z_to, ttl TSRMLS_CC);
+                success = ra_move_hash(key, key_len, z_from, z_to, ttl);
                 break;
 
             default:
@@ -1172,18 +1172,18 @@ ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to TSRMLS_DC) {
     }
 
     if(success) {
-        ra_del_key(key, key_len, z_from TSRMLS_CC);
-        ra_index_key(key, key_len, z_to TSRMLS_CC);
+        ra_del_key(key, key_len, z_from);
+        ra_index_key(key, key_len, z_to);
     }
 
     /* close transaction */
-    ra_index_exec(z_to, NULL, 0 TSRMLS_CC);
+    ra_index_exec(z_to, NULL, 0);
 }
 
 /* callback with the current progress, with hostname and count */
 static void
 zval_rehash_callback(zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache,
-    zend_string *hostname, long count TSRMLS_DC) {
+    zend_string *hostname, long count) {
 
     zval zv, *z_ret = &zv;
 
@@ -1201,7 +1201,7 @@ zval_rehash_callback(zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache,
     z_cb->param_count = 2;
 
     /* run cb(hostname, count) */
-    zend_call_function(z_cb, z_cb_cache TSRMLS_CC);
+    zend_call_function(z_cb, z_cb_cache);
 
     /* cleanup */
     zval_dtor(&z_args[0]);
@@ -1210,7 +1210,7 @@ zval_rehash_callback(zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache,
 
 static void
 ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool b_index,
-        zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache TSRMLS_DC) {
+        zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache) {
 
     HashTable *h_keys;
     long count = 0;
@@ -1225,7 +1225,7 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
         ZVAL_STRING(&z_argv, "*");
     }
     ZVAL_NULL(&z_ret);
-    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_argv TSRMLS_CC);
+    ra_call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_argv);
     zval_dtor(&z_argv);
     zval_dtor(&z_fun);
 
@@ -1241,17 +1241,17 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
 
     /* callback */
     if(z_cb && z_cb_cache) {
-        zval_rehash_callback(z_cb, z_cb_cache, hostname, count TSRMLS_CC);
+        zval_rehash_callback(z_cb, z_cb_cache, hostname, count);
     }
 
     /* for each key, redistribute */
     ZEND_HASH_FOREACH_VAL(h_keys, z_ele) {
         int pos = 0;
         /* check that we're not moving to the same node. */
-        zval *z_target = ra_find_node(ra, Z_STRVAL_P(z_ele), Z_STRLEN_P(z_ele), &pos TSRMLS_CC);
+        zval *z_target = ra_find_node(ra, Z_STRVAL_P(z_ele), Z_STRLEN_P(z_ele), &pos);
 
         if (z_target && !zend_string_equals(hostname, ra->hosts[pos])) { /* different host */
-            ra_move_key(Z_STRVAL_P(z_ele), Z_STRLEN_P(z_ele), z_redis, z_target TSRMLS_CC);
+            ra_move_key(Z_STRVAL_P(z_ele), Z_STRLEN_P(z_ele), z_redis, z_target);
         }
 
     } ZEND_HASH_FOREACH_END();
@@ -1261,7 +1261,7 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
 }
 
 void
-ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache TSRMLS_DC) {
+ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache) {
     int i;
 
     /* redistribute the data, server by server. */
@@ -1269,7 +1269,7 @@ ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cac
         return; /* TODO: compare the two rings for equality */
 
     for(i = 0; i < ra->prev->count; ++i) {
-        ra_rehash_server(ra, &ra->prev->redis[i], ra->prev->hosts[i], ra->index, z_cb, z_cb_cache TSRMLS_CC);
+        ra_rehash_server(ra, &ra->prev->redis[i], ra->prev->hosts[i], ra->index, z_cb, z_cb_cache);
     }
 }
 

--- a/redis_array_impl.h
+++ b/redis_array_impl.h
@@ -9,23 +9,23 @@
 
 #include "redis_array.h"
 
-RedisArray *ra_load_array(const char *name TSRMLS_DC);
-RedisArray *ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, long retry_interval, zend_bool b_lazy_connect, double connect_timeout, double read_timeout, zend_bool consistent, zend_string *algorithm, zend_string *auth TSRMLS_DC);
-zval *ra_find_node_by_name(RedisArray *ra, const char *host, int host_len TSRMLS_DC);
-zval *ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos TSRMLS_DC);
+RedisArray *ra_load_array(const char *name);
+RedisArray *ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev, zend_bool b_index, zend_bool b_pconnect, long retry_interval, zend_bool b_lazy_connect, double connect_timeout, double read_timeout, zend_bool consistent, zend_string *algorithm, zend_string *auth);
+zval *ra_find_node_by_name(RedisArray *ra, const char *host, int host_len);
+zval *ra_find_node(RedisArray *ra, const char *key, int key_len, int *out_pos);
 void ra_init_function_table(RedisArray *ra);
 
-void ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to TSRMLS_DC);
-void ra_index_multi(zval *z_redis, long multi_value TSRMLS_DC);
+void ra_move_key(const char *key, int key_len, zval *z_from, zval *z_to);
+void ra_index_multi(zval *z_redis, long multi_value);
 
-void ra_index_key(const char *key, int key_len, zval *z_redis TSRMLS_DC);
-void ra_index_keys(zval *z_pairs, zval *z_redis TSRMLS_DC);
-void ra_index_del(zval *z_keys, zval *z_redis TSRMLS_DC);
-void ra_index_exec(zval *z_redis, zval *return_value, int keep_all TSRMLS_DC);
-void ra_index_discard(zval *z_redis, zval *return_value TSRMLS_DC);
-void ra_index_unwatch(zval *z_redis, zval *return_value TSRMLS_DC);
+void ra_index_key(const char *key, int key_len, zval *z_redis);
+void ra_index_keys(zval *z_pairs, zval *z_redis);
+void ra_index_del(zval *z_keys, zval *z_redis);
+void ra_index_exec(zval *z_redis, zval *return_value, int keep_all);
+void ra_index_discard(zval *z_redis, zval *return_value);
+void ra_index_unwatch(zval *z_redis, zval *return_value);
 zend_bool ra_is_write_cmd(RedisArray *ra, const char *cmd, int cmd_len);
 
-void ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache TSRMLS_DC);
+void ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache);
 
 #endif

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -302,7 +302,7 @@ static void ht_free_node(zval *data) {
 }
 
 /* Create redisCluster context */
-zend_object * create_cluster_context(zend_class_entry *class_type TSRMLS_DC) {
+zend_object * create_cluster_context(zend_class_entry *class_type) {
     redisCluster *cluster;
 
     // Allocate our actual struct
@@ -323,7 +323,7 @@ zend_object * create_cluster_context(zend_class_entry *class_type TSRMLS_DC) {
     zend_hash_init(cluster->nodes, 0, NULL, ht_free_node, 0);
 
     // Initialize it
-    zend_object_std_init(&cluster->std, class_type TSRMLS_CC);
+    zend_object_std_init(&cluster->std, class_type);
 
     object_properties_init(&cluster->std, class_type);
     memcpy(&RedisCluster_handlers, zend_get_std_object_handlers(), sizeof(RedisCluster_handlers));
@@ -339,8 +339,8 @@ zend_object * create_cluster_context(zend_class_entry *class_type TSRMLS_DC) {
 void free_cluster_context(zend_object *object) {
     redisCluster *cluster = (redisCluster*)((char*)(object) - XtOffsetOf(redisCluster, std));
 
-    cluster_free(cluster, 0 TSRMLS_CC);
-    zend_object_std_dtor(&cluster->std TSRMLS_CC);
+    cluster_free(cluster, 0);
+    zend_object_std_dtor(&cluster->std);
 }
 
 /* Turn a seed array into a zend_string we can use to look up a slot cache */
@@ -365,7 +365,7 @@ static zend_string *cluster_hash_seeds(HashTable *ht) {
 }
 
 #define SLOT_CACHING_ENABLED() (INI_INT("redis.clusters.cache_slots") == 1)
-static redisCachedCluster *cluster_cache_load(HashTable *ht_seeds TSRMLS_DC) {
+static redisCachedCluster *cluster_cache_load(HashTable *ht_seeds) {
     zend_resource *le;
     zend_string *h;
 
@@ -382,7 +382,7 @@ static redisCachedCluster *cluster_cache_load(HashTable *ht_seeds TSRMLS_DC) {
     if (le != NULL) {
         /* Sanity check on our list type */
         if (le->type != le_cluster_slot_cache) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING, "Invalid slot cache resource");
+            php_error_docref(0, E_WARNING, "Invalid slot cache resource");
             return NULL;
         }
 
@@ -395,7 +395,7 @@ static redisCachedCluster *cluster_cache_load(HashTable *ht_seeds TSRMLS_DC) {
 }
 
 /* Cache a cluster's slot information in persistent_list if it's enabled */
-static int cluster_cache_store(HashTable *ht_seeds, HashTable *nodes TSRMLS_DC) {
+static int cluster_cache_store(HashTable *ht_seeds, HashTable *nodes) {
     redisCachedCluster *cc;
     zend_string *hash;
 
@@ -445,7 +445,7 @@ cluster_validate_args(double timeout, double read_timeout, HashTable *seeds) {
 /* Attempt to connect to a Redis cluster provided seeds and timeout options */
 static void redis_cluster_init(redisCluster *c, HashTable *ht_seeds, double timeout,
                                double read_timeout, int persistent, char *auth,
-                               size_t auth_len TSRMLS_DC)
+                               size_t auth_len)
 {
     redisCachedCluster *cc;
 
@@ -464,18 +464,18 @@ static void redis_cluster_init(redisCluster *c, HashTable *ht_seeds, double time
     c->waitms = (long)(timeout * 1000);
 
     /* Attempt to load from cache */
-    if ((cc = cluster_cache_load(ht_seeds TSRMLS_CC))) {
+    if ((cc = cluster_cache_load(ht_seeds))) {
         cluster_init_cache(c, cc);
     } else if (cluster_init_seeds(c, ht_seeds) == SUCCESS &&
-               cluster_map_keyspace(c TSRMLS_CC) == SUCCESS)
+               cluster_map_keyspace(c) == SUCCESS)
     {
-        cluster_cache_store(ht_seeds, c->nodes TSRMLS_CC);
+        cluster_cache_store(ht_seeds, c->nodes);
     }
 }
 
 
 /* Attempt to load a named cluster configured in php.ini */
-void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
+void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     zval z_seeds, z_timeout, z_read_timeout, z_persistent, z_auth, *z_value;
     char *iptr, *auth = NULL;
     size_t auth_len = 0;
@@ -486,7 +486,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     /* Seeds */
     array_init(&z_seeds);
     if ((iptr = INI_STR("redis.clusters.seeds")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_seeds TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_seeds);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_seeds), name, name_len)) != NULL) {
         ht_seeds = Z_ARRVAL_P(z_value);
@@ -499,7 +499,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     /* Connection timeout */
     array_init(&z_timeout);
     if ((iptr = INI_STR("redis.clusters.timeout")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_timeout TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_timeout);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_timeout), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_value) == IS_STRING) {
@@ -514,7 +514,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     /* Read timeout */
     array_init(&z_read_timeout);
     if ((iptr = INI_STR("redis.clusters.read_timeout")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_read_timeout TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_read_timeout);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_read_timeout), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_value) == IS_STRING) {
@@ -529,7 +529,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     /* Persistent connections */
     array_init(&z_persistent);
     if ((iptr = INI_STR("redis.clusters.persistent")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_persistent TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_persistent);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_persistent), name, name_len)) != NULL) {
         if (Z_TYPE_P(z_value) == IS_STRING) {
@@ -542,7 +542,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     /* Cluster auth */
     array_init(&z_auth);
     if ((iptr = INI_STR("redis.clusters.auth")) != NULL) {
-        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_auth TSRMLS_CC);
+        sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_auth);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_auth), name, name_len)) != NULL &&
         Z_TYPE_P(z_value) == IS_STRING && Z_STRLEN_P(z_value) > 0
@@ -552,7 +552,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len TSRMLS_DC) {
     }
 
     /* Attempt to create/connect to the cluster */
-    redis_cluster_init(c, ht_seeds, timeout, read_timeout, persistent, auth, auth_len TSRMLS_CC);
+    redis_cluster_init(c, ht_seeds, timeout, read_timeout, persistent, auth, auth_len);
 
     /* Clean up our arrays */
     zval_dtor(&z_seeds);
@@ -576,7 +576,7 @@ PHP_METHOD(RedisCluster, __construct) {
     redisCluster *context = GET_CONTEXT();
 
     // Parse arguments
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS() TSRMLS_CC, getThis(),
+    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
                                     "Os!|addbs", &object, redis_cluster_ce, &name,
                                     &name_len, &z_seeds, &timeout, &read_timeout,
                                     &persistent, &auth, &auth_len) == FAILURE)
@@ -593,9 +593,9 @@ PHP_METHOD(RedisCluster, __construct) {
      * to a named cluster, stored in php.ini, otherwise we'll need manual seeds */
     if (ZEND_NUM_ARGS() > 1) {
         redis_cluster_init(context, Z_ARRVAL_P(z_seeds), timeout, read_timeout,
-            persistent, auth, auth_len TSRMLS_CC);
+            persistent, auth, auth_len);
     } else {
-        redis_cluster_load(context, name, name_len TSRMLS_CC);
+        redis_cluster_load(context, name, name_len);
     }
 }
 
@@ -605,7 +605,7 @@ PHP_METHOD(RedisCluster, __construct) {
 
 /* {{{ proto bool RedisCluster::close() */
 PHP_METHOD(RedisCluster, close) {
-    cluster_disconnect(GET_CONTEXT(), 1 TSRMLS_CC);
+    cluster_disconnect(GET_CONTEXT(), 1);
     RETURN_TRUE;
 }
 
@@ -638,7 +638,7 @@ distcmd_resp_handler(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, short slot,
     ctx->last    = last;
 
     // Attempt to send the command
-    if (cluster_send_command(c,slot,mc->cmd.c,mc->cmd.len TSRMLS_CC) < 0 ||
+    if (cluster_send_command(c,slot,mc->cmd.c,mc->cmd.len) < 0 ||
        c->err != NULL)
     {
         cluster_multi_free(mc);
@@ -676,7 +676,7 @@ typedef struct clusterKeyValHT {
 
 /* Helper to pull a key/value pair from a HashTable */
 static int get_key_val_ht(redisCluster *c, HashTable *ht, HashPosition *ptr,
-                          clusterKeyValHT *kv TSRMLS_DC)
+                          clusterKeyValHT *kv)
 {
     zval *z_val;
     zend_ulong idx;
@@ -709,7 +709,7 @@ static int get_key_val_ht(redisCluster *c, HashTable *ht, HashPosition *ptr,
     }
 
     // Serialize our value if required
-    kv->val_free = redis_pack(c->flags,z_val,&(kv->val),&(kv->val_len) TSRMLS_CC);
+    kv->val_free = redis_pack(c->flags,z_val,&(kv->val),&(kv->val_len));
 
     // Success
     return 0;
@@ -717,7 +717,7 @@ static int get_key_val_ht(redisCluster *c, HashTable *ht, HashPosition *ptr,
 
 /* Helper to pull, prefix, and hash a key from a HashTable value */
 static int get_key_ht(redisCluster *c, HashTable *ht, HashPosition *ptr,
-                      clusterKeyValHT *kv TSRMLS_DC)
+                      clusterKeyValHT *kv)
 {
     zval *z_key;
 
@@ -805,7 +805,7 @@ static int cluster_mkey_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len,
     // Process the first key outside of our loop, so we don't have to check if
     // it's the first iteration every time, needlessly
     zend_hash_internal_pointer_reset_ex(ht_arr, &ptr);
-    if (get_key_ht(c, ht_arr, &ptr, &kv TSRMLS_CC) < 0) {
+    if (get_key_ht(c, ht_arr, &ptr, &kv) < 0) {
         efree(z_args);
         return -1;
     }
@@ -822,7 +822,7 @@ static int cluster_mkey_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len,
     // Iterate over keys 2...N
     slot = kv.slot;
     while (zend_hash_has_more_elements_ex(ht_arr, &ptr) ==SUCCESS) {
-        if (get_key_ht(c, ht_arr, &ptr, &kv TSRMLS_CC) < 0) {
+        if (get_key_ht(c, ht_arr, &ptr, &kv) < 0) {
             cluster_multi_free(&mc);
             if (ht_free) {
                 zend_hash_destroy(ht_arr);
@@ -907,7 +907,7 @@ static int cluster_mset_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len,
     short slot;
 
     // Parse our arguments
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &z_arr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &z_arr) == FAILURE) {
         return -1;
     }
 
@@ -925,7 +925,7 @@ static int cluster_mset_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len,
 
     // Process the first key/value pair outside of our loop
     zend_hash_internal_pointer_reset_ex(ht_arr, &ptr);
-    if (get_key_val_ht(c, ht_arr, &ptr, &kv TSRMLS_CC) ==-1) return -1;
+    if (get_key_val_ht(c, ht_arr, &ptr, &kv) ==-1) return -1;
     zend_hash_move_forward_ex(ht_arr, &ptr);
 
     // Add this to our multi cmd, set slot, free key if we prefixed
@@ -938,7 +938,7 @@ static int cluster_mset_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len,
     slot = kv.slot;
     while (zend_hash_has_more_elements_ex(ht_arr, &ptr) ==SUCCESS) {
         // Pull the next key/value pair
-        if (get_key_val_ht(c, ht_arr, &ptr, &kv TSRMLS_CC) ==-1) {
+        if (get_key_val_ht(c, ht_arr, &ptr, &kv) ==-1) {
             return -1;
         }
 
@@ -1102,14 +1102,14 @@ PHP_METHOD(RedisCluster, keys) {
     clusterReply *resp;
     int i, cmd_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &pat, &pat_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pat, &pat_len)
                              == FAILURE)
     {
         RETURN_FALSE;
     }
 
     /* Prefix and then build our command */
-    cmd_len = redis_spprintf(c->flags, NULL TSRMLS_CC, &cmd, "KEYS", "k", pat, pat_len);
+    cmd_len = redis_spprintf(c->flags, NULL, &cmd, "KEYS", "k", pat, pat_len);
 
     array_init(return_value);
 
@@ -1120,9 +1120,9 @@ PHP_METHOD(RedisCluster, keys) {
     ZEND_HASH_FOREACH_PTR(c->nodes, node) {
         if (node == NULL) continue;
         if (cluster_send_slot(c, node->slot, cmd, cmd_len, TYPE_MULTIBULK
-                             TSRMLS_CC) < 0)
+                            ) < 0)
         {
-            php_error_docref(0 TSRMLS_CC, E_ERROR, "Can't send KEYS to %s:%d",
+            php_error_docref(0, E_ERROR, "Can't send KEYS to %s:%d",
                 ZSTR_VAL(node->sock->host), node->sock->port);
             zval_dtor(return_value);
             efree(cmd);
@@ -1130,9 +1130,9 @@ PHP_METHOD(RedisCluster, keys) {
         }
 
         /* Ensure we can get a response */
-        resp = cluster_read_resp(c, 0 TSRMLS_CC);
+        resp = cluster_read_resp(c, 0);
         if (!resp) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING,
+            php_error_docref(0, E_WARNING,
                 "Can't read response from %s:%d", ZSTR_VAL(node->sock->host),
                 node->sock->port);
             continue;
@@ -1210,7 +1210,7 @@ PHP_METHOD(RedisCluster, srandmember) {
         RETURN_FALSE;
     }
 
-    if (cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC) < 0 || c->err != NULL) {
+    if (cluster_send_command(c,slot,cmd,cmd_len) < 0 || c->err != NULL) {
         efree(cmd);
         RETURN_FALSE;
     }
@@ -1738,7 +1738,7 @@ static void generic_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw,
         RETURN_FALSE;
     }
 
-    if (cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC) < 0 || c->err != NULL) {
+    if (cluster_send_command(c,slot,cmd,cmd_len) < 0 || c->err != NULL) {
         efree(cmd);
         RETURN_FALSE;
     }
@@ -1881,7 +1881,7 @@ PHP_METHOD(RedisCluster, sort) {
         RETURN_FALSE;
     }
 
-    if (cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC) < 0 || c->err != NULL) {
+    if (cluster_send_command(c,slot,cmd,cmd_len) < 0 || c->err != NULL) {
         efree(cmd);
         RETURN_FALSE;
     }
@@ -1908,7 +1908,7 @@ PHP_METHOD(RedisCluster, object) {
         RETURN_FALSE;
     }
 
-     if (cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC) < 0 || c->err != NULL) {
+     if (cluster_send_command(c,slot,cmd,cmd_len) < 0 || c->err != NULL) {
         efree(cmd);
         RETURN_FALSE;
     }
@@ -1945,7 +1945,7 @@ static void generic_unsub_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
     // There is not reason to unsubscribe outside of a subscribe loop
     if (c->subscribed_slot == -1) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "You can't unsubscribe outside of a subscribe loop");
         RETURN_FALSE;
     }
@@ -1960,7 +1960,7 @@ static void generic_unsub_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
     // This has to operate on our subscribe slot
     if (cluster_send_slot(c, c->subscribed_slot, cmd, cmd_len, TYPE_MULTIBULK
-                         TSRMLS_CC) == FAILURE)
+                        ) == FAILURE)
     {
         CLUSTER_THROW_EXCEPTION("Failed to UNSUBSCRIBE within our subscribe loop!", 0);
         RETURN_FALSE;
@@ -2110,7 +2110,7 @@ PHP_METHOD(RedisCluster, multi) {
     redisCluster *c = GET_CONTEXT();
 
     if (c->flags->mode == MULTI) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "RedisCluster is already in MULTI mode, ignoring");
         RETURN_FALSE;
     }
@@ -2135,7 +2135,7 @@ PHP_METHOD(RedisCluster, watch) {
 
     // Disallow in MULTI mode
     if (c->flags->mode == MULTI) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "WATCH command not allowed in MULTI mode");
         RETURN_FALSE;
     }
@@ -2189,7 +2189,7 @@ PHP_METHOD(RedisCluster, watch) {
         }
 
         // If we get a failure from this, we have to abort
-        if (cluster_send_command(c,(short)slot,cmd.c,cmd.len TSRMLS_CC) ==-1) {
+        if (cluster_send_command(c,(short)slot,cmd.c,cmd.len) ==-1) {
             RETURN_FALSE;
         }
 
@@ -2218,7 +2218,7 @@ PHP_METHOD(RedisCluster, unwatch) {
         if (c->master[slot] && SLOT_SOCK(c,slot)->watching) {
             if (cluster_send_slot(c, slot, RESP_UNWATCH_CMD,
                                  sizeof(RESP_UNWATCH_CMD)-1,
-                                 TYPE_LINE TSRMLS_CC) ==-1)
+                                 TYPE_LINE) ==-1)
             {
                 CLUSTER_RETURN_BOOL(c, 0);
             }
@@ -2238,7 +2238,7 @@ PHP_METHOD(RedisCluster, exec) {
 
     // Verify we are in fact in multi mode
     if (CLUSTER_IS_ATOMIC(c)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "RedisCluster is not in MULTI mode");
+        php_error_docref(NULL, E_WARNING, "RedisCluster is not in MULTI mode");
         RETURN_FALSE;
     }
 
@@ -2246,8 +2246,8 @@ PHP_METHOD(RedisCluster, exec) {
     fi = c->multi_head;
     while (fi) {
         if (SLOT_SOCK(c, fi->slot)->mode == MULTI) {
-            if ( cluster_send_exec(c, fi->slot TSRMLS_CC) < 0) {
-                cluster_abort_exec(c TSRMLS_CC);
+            if ( cluster_send_exec(c, fi->slot) < 0) {
+                cluster_abort_exec(c);
                 CLUSTER_THROW_EXCEPTION("Error processing EXEC across the cluster", 0);
 
                 // Free our queue, reset MULTI state
@@ -2276,11 +2276,11 @@ PHP_METHOD(RedisCluster, discard) {
     redisCluster *c = GET_CONTEXT();
 
     if (CLUSTER_IS_ATOMIC(c)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cluster is not in MULTI mode");
+        php_error_docref(NULL, E_WARNING, "Cluster is not in MULTI mode");
         RETURN_FALSE;
     }
 
-    if (cluster_abort_exec(c TSRMLS_CC) < 0) {
+    if (cluster_abort_exec(c) < 0) {
         CLUSTER_RESET_MULTI(c);
     }
 
@@ -2291,7 +2291,7 @@ PHP_METHOD(RedisCluster, discard) {
 
 /* Get a slot either by key (string) or host/port array */
 static short
-cluster_cmd_get_slot(redisCluster *c, zval *z_arg TSRMLS_DC)
+cluster_cmd_get_slot(redisCluster *c, zval *z_arg)
 {
     size_t key_len;
     int key_free;
@@ -2326,11 +2326,11 @@ cluster_cmd_get_slot(redisCluster *c, zval *z_arg TSRMLS_DC)
 
         /* Inform the caller if they've passed bad data */
         if (slot < 0) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING, "Unknown node %s:%ld",
+            php_error_docref(0, E_WARNING, "Unknown node %s:%ld",
                 Z_STRVAL_P(z_host), Z_LVAL_P(z_port));
         }
     } else {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Direted commands musty be passed a key or [host,port] array");
         return -1;
     }
@@ -2350,22 +2350,22 @@ cluster_empty_node_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw,
     zval *z_arg;
     short slot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &z_arg) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &z_arg) == FAILURE) {
         RETURN_FALSE;
     }
 
     // One argument means find the node (treated like a key), and two means
     // send the command to a specific host and port
-    slot = cluster_cmd_get_slot(c, z_arg TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_arg);
     if (slot < 0) {
         RETURN_FALSE;
     }
 
     // Construct our command
-    cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, kw, "");
+    cmd_len = redis_spprintf(NULL, NULL, &cmd, kw, "");
 
     // Kick off our command
-    if (cluster_send_slot(c, slot, cmd, cmd_len, reply_type TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd, cmd_len, reply_type) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send command at a specific node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -2388,27 +2388,27 @@ cluster_flush_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, REDIS_REPLY_TYPE reply
     zend_bool async = 0;
     short slot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|b", &z_arg, &async) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|b", &z_arg, &async) == FAILURE) {
         RETURN_FALSE;
     }
 
     // One argument means find the node (treated like a key), and two means
     // send the command to a specific host and port
-    slot = cluster_cmd_get_slot(c, z_arg TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_arg);
     if (slot < 0) {
         RETURN_FALSE;
     }
 
     // Construct our command
     if (async) {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, kw, "s", "ASYNC", sizeof("ASYNC") - 1);
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, kw, "s", "ASYNC", sizeof("ASYNC") - 1);
     } else {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, kw, "");
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, kw, "");
     }
 
 
     // Kick off our command
-    if (cluster_send_slot(c, slot, cmd, cmd_len, reply_type TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd, cmd_len, reply_type) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send command at a specific node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -2434,14 +2434,14 @@ static void cluster_raw_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
 
     /* Commands using this pass-thru don't need to be enabled in MULTI mode */
     if (!CLUSTER_IS_ATOMIC(c)) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Command can't be issued in MULTI mode");
         RETURN_FALSE;
     }
 
     /* We at least need the key or [host,port] argument */
     if (argc < 1) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Command requires at least an argument to direct to a node");
         RETURN_FALSE;
     }
@@ -2456,7 +2456,7 @@ static void cluster_raw_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
     }
 
     /* First argument needs to be the "where" */
-    if ((slot = cluster_cmd_get_slot(c, &z_args[0] TSRMLS_CC)) < 0) {
+    if ((slot = cluster_cmd_get_slot(c, &z_args[0])) < 0) {
         efree(z_args);
         RETURN_FALSE;
     }
@@ -2472,7 +2472,7 @@ static void cluster_raw_cmd(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
     }
 
     /* Send it off */
-    if (cluster_send_slot(c, slot, cmd.c, cmd.len, TYPE_EOF TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd.c, cmd.len, TYPE_EOF) < 0) {
         CLUSTER_THROW_EXCEPTION("Couldn't send command to node", 0);
         efree(cmd.c);
         efree(z_args);
@@ -2507,7 +2507,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
     }
 
     /* Parse arguments */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz/|s!l", &key,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz/|s!l", &key,
                              &key_len, &z_it, &pat, &pat_len, &count) == FAILURE)
     {
         RETURN_FALSE;
@@ -2545,7 +2545,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
             count);
 
         // Send it off
-        if (cluster_send_command(c, slot, cmd, cmd_len TSRMLS_CC) == FAILURE)
+        if (cluster_send_command(c, slot, cmd, cmd_len) == FAILURE)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN command", 0);
             if (key_free) efree(key);
@@ -2599,7 +2599,7 @@ PHP_METHOD(RedisCluster, scan) {
     }
 
     /* Parse arguments */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z/z|s!l", &z_it,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z/z|s!l", &z_it,
                              &z_node, &pat, &pat_len, &count) == FAILURE)
     {
         RETURN_FALSE;
@@ -2628,12 +2628,12 @@ PHP_METHOD(RedisCluster, scan) {
         cmd_len = redis_fmt_scan_cmd(&cmd, TYPE_SCAN, NULL, 0, it, pat, pat_len,
             count);
 
-        if ((slot = cluster_cmd_get_slot(c, z_node TSRMLS_CC)) < 0) {
+        if ((slot = cluster_cmd_get_slot(c, z_node)) < 0) {
            RETURN_FALSE;
         }
 
         // Send it to the node in question
-        if (cluster_send_command(c, slot, cmd, cmd_len TSRMLS_CC) < 0)
+        if (cluster_send_command(c, slot, cmd, cmd_len) < 0)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN to node", 0);
             efree(cmd);
@@ -2744,7 +2744,7 @@ PHP_METHOD(RedisCluster, info) {
     zval *z_arg;
     short slot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|s", &z_arg, &opt,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|s", &z_arg, &opt,
                              &opt_len) == FAILURE)
     {
         RETURN_FALSE;
@@ -2753,19 +2753,19 @@ PHP_METHOD(RedisCluster, info) {
     /* Treat INFO as non read-only, as we probably want the master */
     c->readonly = 0;
 
-    slot = cluster_cmd_get_slot(c, z_arg TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_arg);
     if (slot < 0) {
         RETURN_FALSE;
     }
 
     if (opt != NULL) {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "INFO", "s", opt, opt_len);
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, "INFO", "s", opt, opt_len);
     } else {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "INFO", "");
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, "INFO", "");
     }
 
     rtype = CLUSTER_IS_ATOMIC(c) ? TYPE_BULK : TYPE_LINE;
-    if (cluster_send_slot(c, slot, cmd, cmd_len, rtype TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd, cmd_len, rtype) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send INFO command to specific node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -2797,14 +2797,14 @@ PHP_METHOD(RedisCluster, client) {
     cluster_cb cb;
 
     /* Parse args */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zs|s", &z_node, &opt,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs|s", &z_node, &opt,
                               &opt_len, &arg, &arg_len) == FAILURE)
     {
         RETURN_FALSE;
     }
 
     /* Make sure we can properly resolve the slot */
-    slot = cluster_cmd_get_slot(c, z_node TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_node);
     if (slot < 0) RETURN_FALSE;
 
     /* Our return type and reply callback is different for all subcommands */
@@ -2820,25 +2820,25 @@ PHP_METHOD(RedisCluster, client) {
         rtype = CLUSTER_IS_ATOMIC(c) ? TYPE_BULK : TYPE_LINE;
         cb = cluster_bulk_resp;
     } else {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Invalid CLIENT subcommand (LIST, KILL, GETNAME, and SETNAME are valid");
         RETURN_FALSE;
     }
 
     /* Construct the command */
     if (ZEND_NUM_ARGS() == 3) {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "CLIENT", "ss",
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, "CLIENT", "ss",
             opt, opt_len, arg, arg_len);
     } else if (ZEND_NUM_ARGS() == 2) {
-        cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "CLIENT", "s",
+        cmd_len = redis_spprintf(NULL, NULL, &cmd, "CLIENT", "s",
             opt, opt_len);
     } else {
-        zend_wrong_param_count(TSRMLS_C);
+        zend_wrong_param_count();
         RETURN_FALSE;
     }
 
     /* Attempt to write our command */
-    if (cluster_send_slot(c, slot, cmd, cmd_len, rtype TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd, cmd_len, rtype) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send CLIENT command to specific node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -2891,14 +2891,14 @@ PHP_METHOD(RedisCluster, script) {
 
     /* Commands using this pass-thru don't need to be enabled in MULTI mode */
     if (!CLUSTER_IS_ATOMIC(c)) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Command can't be issued in MULTI mode");
         RETURN_FALSE;
     }
 
     /* We at least need the key or [host,port] argument */
     if (argc < 2) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Command requires at least an argument to direct to a node");
         RETURN_FALSE;
     }
@@ -2908,7 +2908,7 @@ PHP_METHOD(RedisCluster, script) {
 
     /* Grab args */
     if (zend_get_parameters_array(ht, argc, z_args) == FAILURE ||
-        (slot = cluster_cmd_get_slot(c, &z_args[0] TSRMLS_CC)) < 0 ||
+        (slot = cluster_cmd_get_slot(c, &z_args[0])) < 0 ||
         redis_build_script_cmd(&cmd, argc - 1, &z_args[1]) == NULL
     ) {
         efree(z_args);
@@ -2916,7 +2916,7 @@ PHP_METHOD(RedisCluster, script) {
     }
 
     /* Send it off */
-    if (cluster_send_slot(c, slot, cmd.c, cmd.len, TYPE_EOF TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd.c, cmd.len, TYPE_EOF) < 0) {
         CLUSTER_THROW_EXCEPTION("Couldn't send command to node", 0);
         efree(cmd.c);
         efree(z_args);
@@ -3014,7 +3014,7 @@ PHP_METHOD(RedisCluster, ping) {
     size_t arglen;
     short slot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|s!", &z_node, &arg,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|s!", &z_node, &arg,
                               &arglen) == FAILURE)
     {
         RETURN_FALSE;
@@ -3024,21 +3024,21 @@ PHP_METHOD(RedisCluster, ping) {
     c->readonly = CLUSTER_IS_ATOMIC(c);
 
     /* Grab slot either by key or host/port */
-    slot = cluster_cmd_get_slot(c, z_node TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_node);
     if (slot < 0) {
         RETURN_FALSE;
     }
 
     /* Construct our command */
     if (arg != NULL) {
-        cmdlen = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "PING", "s", arg, arglen);
+        cmdlen = redis_spprintf(NULL, NULL, &cmd, "PING", "s", arg, arglen);
     } else {
-        cmdlen = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "PING", "");
+        cmdlen = redis_spprintf(NULL, NULL, &cmd, "PING", "");
     }
 
     /* Send it off */
     rtype = CLUSTER_IS_ATOMIC(c) && arg != NULL ? TYPE_BULK : TYPE_LINE;
-    if (cluster_send_slot(c, slot, cmd, cmdlen, rtype TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c, slot, cmd, cmdlen, rtype) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send commnad at the specificed node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -3140,7 +3140,7 @@ PHP_METHOD(RedisCluster, echo) {
     size_t msg_len;
     short slot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zs", &z_arg, &msg,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs", &z_arg, &msg,
                              &msg_len) == FAILURE)
     {
         RETURN_FALSE;
@@ -3150,17 +3150,17 @@ PHP_METHOD(RedisCluster, echo) {
     c->readonly = CLUSTER_IS_ATOMIC(c);
 
     /* Grab slot either by key or host/port */
-    slot = cluster_cmd_get_slot(c, z_arg TSRMLS_CC);
+    slot = cluster_cmd_get_slot(c, z_arg);
     if (slot < 0) {
         RETURN_FALSE;
     }
 
     /* Construct our command */
-    cmd_len = redis_spprintf(NULL, NULL TSRMLS_CC, &cmd, "ECHO", "s", msg, msg_len);
+    cmd_len = redis_spprintf(NULL, NULL, &cmd, "ECHO", "s", msg, msg_len);
 
     /* Send it off */
     rtype = CLUSTER_IS_ATOMIC(c) ? TYPE_BULK : TYPE_LINE;
-    if (cluster_send_slot(c,slot,cmd,cmd_len,rtype TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c,slot,cmd,cmd_len,rtype) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send commnad at the specificed node", 0);
         efree(cmd);
         RETURN_FALSE;
@@ -3190,18 +3190,18 @@ PHP_METHOD(RedisCluster, rawcommand) {
 
     /* Sanity check on our arguments */
     if (argc < 2) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "You must pass at least node information as well as at least a command.");
         RETURN_FALSE;
     }
     z_args = emalloc(argc * sizeof(zval));
     if (zend_get_parameters_array(ht, argc, z_args) == FAILURE) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Internal PHP error parsing method parameters.");
         efree(z_args);
         RETURN_FALSE;
-    } else if (redis_build_raw_cmd(&z_args[1], argc-1, &cmd, &cmd_len TSRMLS_CC) ||
-               (slot = cluster_cmd_get_slot(c, &z_args[0] TSRMLS_CC)) < 0)
+    } else if (redis_build_raw_cmd(&z_args[1], argc-1, &cmd, &cmd_len) ||
+               (slot = cluster_cmd_get_slot(c, &z_args[0])) < 0)
     {
         if (cmd) efree(cmd);
         efree(z_args);
@@ -3213,7 +3213,7 @@ PHP_METHOD(RedisCluster, rawcommand) {
 
     /* Direct the command */
     rtype = CLUSTER_IS_ATOMIC(c) ? TYPE_EOF : TYPE_LINE;
-    if (cluster_send_slot(c,slot,cmd,cmd_len,rtype TSRMLS_CC) < 0) {
+    if (cluster_send_slot(c,slot,cmd,cmd_len,rtype) < 0) {
         CLUSTER_THROW_EXCEPTION("Unable to send command to the specified node", 0);
         efree(cmd);
         RETURN_FALSE;

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -65,7 +65,7 @@
                              &cmd_len, &slot, &ctx)==FAILURE) { \
         RETURN_FALSE; \
     } \
-    if(cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC)<0 || c->err!=NULL) {\
+    if(cluster_send_command(c,slot,cmd,cmd_len)<0 || c->err!=NULL) {\
         efree(cmd); \
         RETURN_FALSE; \
     } \
@@ -85,7 +85,7 @@
                &slot,&ctx)==FAILURE) { \
         RETURN_FALSE; \
     } \
-    if(cluster_send_command(c,slot,cmd,cmd_len TSRMLS_CC)<0 || c->err!=NULL) { \
+    if(cluster_send_command(c,slot,cmd,cmd_len)<0 || c->err!=NULL) { \
         efree(cmd); \
         RETURN_FALSE; \
     } \
@@ -97,17 +97,17 @@
     resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx); 
 
 /* For the creation of RedisCluster specific exceptions */
-PHP_REDIS_API zend_class_entry *rediscluster_get_exception_base(int root TSRMLS_DC);
+PHP_REDIS_API zend_class_entry *rediscluster_get_exception_base(int root);
 
 /* Create cluster context */
-zend_object *create_cluster_context(zend_class_entry *class_type TSRMLS_DC);
+zend_object *create_cluster_context(zend_class_entry *class_type);
 
 /* Free cluster context struct */
 void free_cluster_context(zend_object *object);
 
 
 /* Inittialize our class with PHP */
-void init_rediscluster(TSRMLS_D);
+void init_rediscluster(void);
 
 /* RedisCluster method implementation */
 PHP_METHOD(RedisCluster, __construct);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -61,9 +61,9 @@ typedef struct geoOptions {
 
 /* Local passthrough macro for command construction.  Given that these methods
  * are generic (so they work whether the caller is Redis or RedisCluster) we
- * will always have redis_sock, slot*, and TSRMLS_CC */
+ * will always have redis_sock, slot*, and */
 #define REDIS_CMD_SPPRINTF(ret, kw, fmt, ...) \
-    redis_spprintf(redis_sock, slot TSRMLS_CC, ret, kw, fmt, ##__VA_ARGS__)
+    redis_spprintf(redis_sock, slot, ret, kw, fmt, ##__VA_ARGS__)
 
 /* Generic commands based on method signature and what kind of things we're
  * processing.  Lots of Redis commands take something like key, value, or
@@ -81,14 +81,14 @@ int redis_empty_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 /* Helper to construct a raw command.  Given that the cluster and non cluster
  * versions are different (RedisCluster needs an additional argument to direct
  * the command) we take the start of our array and count */
-int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_DC)
+int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len)
 {
     smart_string cmdstr = {0};
     int i;
 
     /* Make sure our first argument is a string */
     if (Z_TYPE(z_args[0]) != IS_STRING) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "When sending a 'raw' command, the first argument must be a string!");
         return FAILURE;
     }
@@ -109,7 +109,7 @@ int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_
                 redis_cmd_append_sstr_dbl(&cmdstr,Z_DVAL(z_args[i]));
                 break;
             default:
-                php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "Raw command arguments must be scalar values!");
                 efree(cmdstr.c);
                 return FAILURE;
@@ -175,7 +175,7 @@ int redis_opt_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char 
     char *arg = NULL;
     size_t arglen;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!", &arg, &arglen) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!", &arg, &arglen) == FAILURE) {
         return FAILURE;
     }
 
@@ -196,7 +196,7 @@ int redis_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw,
     size_t arg_len;
 
     // Parse args
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &arg, &arg_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &arg, &arg_len)
                              ==FAILURE)
     {
         return FAILURE;
@@ -218,7 +218,7 @@ int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long expire;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slz", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "slz", &key, &key_len,
                              &expire, &z_val) == FAILURE)
     {
         return FAILURE;
@@ -238,7 +238,7 @@ int redis_key_long_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, val_len;
     zend_long lval;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sls", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sls", &key, &key_len,
                              &lval, &val, &val_len) == FAILURE)
     {
         return FAILURE;
@@ -258,7 +258,7 @@ int redis_kv_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz", &key, &key_len,
                              &z_val) == FAILURE)
     {
         return FAILURE;
@@ -277,7 +277,7 @@ int redis_key_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *val;
     size_t key_len, val_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &key, &key_len,
                              &val, &val_len) == FAILURE)
     {
         return FAILURE;
@@ -297,7 +297,7 @@ int redis_key_str_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *k, *v1, *v2;
     size_t klen, v1len, v2len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &k, &klen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss", &k, &klen,
                              &v1, &v1len, &v2, &v2len) == FAILURE)
     {
         return FAILURE;
@@ -318,7 +318,7 @@ int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t k1len, k2len;
     int k1free, k2free;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &k1, &k1len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &k1, &k1len,
                              &k2, &k2len) == FAILURE)
     {
         return FAILURE;
@@ -336,7 +336,7 @@ int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
         // Check if Redis would give us a CROSSLOT error
         if (slot1 != slot2) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING, "Keys don't hash to the same slot");
+            php_error_docref(0, E_WARNING, "Keys don't hash to the same slot");
             if (k1free) efree(k1);
             if (k2free) efree(k2);
             return FAILURE;
@@ -366,7 +366,7 @@ int redis_key_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t keylen;
     zend_long lval;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl", &key, &keylen, &lval)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl", &key, &keylen, &lval)
                               ==FAILURE)
     {
         return FAILURE;
@@ -385,7 +385,7 @@ int redis_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 {
     zend_long v1, v2;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &v1, &v2)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &v1, &v2)
                               == FAILURE)
     {
         return FAILURE;
@@ -405,7 +405,7 @@ int redis_key_long_long_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     zend_long val1, val2;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll", &key, &key_len,
                              &val1, &val2) == FAILURE)
     {
         return FAILURE;
@@ -424,7 +424,7 @@ int redis_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     size_t key_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len)
                              ==FAILURE)
     {
         return FAILURE;
@@ -440,7 +440,7 @@ int redis_flush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 {
     zend_bool async = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &async) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &async) == FAILURE) {
         return FAILURE;
     }
 
@@ -462,7 +462,7 @@ int redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     double val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sd", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sd", &key, &key_len,
                              &val) == FAILURE)
     {
         return FAILURE;
@@ -528,7 +528,7 @@ int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_string *zkey;
     zval *z_ws = NULL, *z_ele;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sll|z", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sll|z", &key, &key_len,
                              &start, &end, &z_ws) == FAILURE)
     {
         return FAILURE;
@@ -577,7 +577,7 @@ int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     PHPREDIS_NOTUSED(idx);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|a", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss|a", &key, &key_len,
                              &start, &start_len, &end, &end_len, &z_opt)
                              ==FAILURE)
     {
@@ -647,7 +647,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     smart_string cmdstr = {0};
 
     // Parse args
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa|a!s", &key,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sa|a!s", &key,
                              &key_len, &z_keys, &z_weights, &agg_op,
                              &agg_op_len) == FAILURE)
     {
@@ -668,7 +668,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     if (z_weights != NULL) {
         ht_weights = Z_ARRVAL_P(z_weights);
         if (zend_hash_num_elements(ht_weights) != keys_count) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "WEIGHTS and keys array should be the same size!");
             return FAILURE;
         }
@@ -683,7 +683,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
            strncasecmp(agg_op, "MIN", sizeof("MIN")) &&
            strncasecmp(agg_op, "MAX", sizeof("MAX")))
         {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "Invalid AGGREGATE option provided!");
             return FAILURE;
         }
@@ -715,7 +715,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
         // If we're in Cluster mode, verify the slot is the same
         if (slot && *slot != cluster_hash_key(key,key_len)) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "All keys don't hash to the same slot!");
             efree(cmdstr.c);
             zend_string_release(zstr);
@@ -766,7 +766,7 @@ int redis_zinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     // fall through
                 }
                 default:
-                    php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                    php_error_docref(NULL, E_WARNING,
                         "Weights must be numeric or '-inf','inf','+inf'");
                     efree(cmdstr.c);
                     return FAILURE;
@@ -800,7 +800,7 @@ int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int key_free;
     char *key;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "af", &z_arr,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "af", &z_arr,
                              &(sctx->cb), &(sctx->cb_cache)) == FAILURE)
     {
         efree(sctx);
@@ -858,7 +858,7 @@ int redis_unsubscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     smart_string cmdstr = {0};
     subscribeContext *sctx = emalloc(sizeof(subscribeContext));
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &z_arr) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &z_arr) == FAILURE) {
         efree(sctx);
         return FAILURE;
     }
@@ -903,11 +903,11 @@ int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* We need either 3 or 5 arguments for this to be valid */
     if (argc != 3 && argc != 5) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING, "Must pass either 3 or 5 arguments");
+        php_error_docref(0, E_WARNING, "Must pass either 3 or 5 arguments");
         return FAILURE;
     }
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "sss|ll", &key, &key_len, &min, &min_len,
+    if (zend_parse_parameters(argc, "sss|ll", &key, &key_len, &min, &min_len,
                              &max, &max_len, &offset, &count) == FAILURE)
     {
         return FAILURE;
@@ -920,7 +920,7 @@ int redis_zrangebylex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
        (max[0] != '(' && max[0] != '[' &&
        (max[0] != '-' || max_len > 1) && (max[0] != '+' || max_len > 1)))
     {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "min and max arguments must start with '[' or '('");
         return FAILURE;
     }
@@ -952,7 +952,7 @@ int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, min_len, max_len;
 
     /* Parse args */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss", &key, &key_len,
                              &min, &min_len, &max, &max_len) == FAILURE)
     {
         return FAILURE;
@@ -960,7 +960,7 @@ int redis_gen_zlex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Quick sanity check on min/max */
     if (!validate_zlex_arg(min, min_len) || !validate_zlex_arg(max, max_len)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Min/Max args can be '-' or '+', or start with '[' or '('");
         return FAILURE;
     }
@@ -987,7 +987,7 @@ int redis_eval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw
     short prevslot = -1;
 
     /* Parse args */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|al", &lua, &lua_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|al", &lua, &lua_len,
                              &z_arr, &num_keys) == FAILURE)
     {
         return FAILURE;
@@ -1017,7 +1017,7 @@ int redis_eval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw
                 if (slot) {
                     if (prevslot != -1 && prevslot != *slot) {
                         zend_string_release(zstr);
-                        php_error_docref(0 TSRMLS_CC, E_WARNING, "All keys do not map to the same slot");
+                        php_error_docref(0, E_WARNING, "All keys do not map to the same slot");
                         return FAILURE;
                     }
                     prevslot = *slot;
@@ -1071,7 +1071,7 @@ int redis_key_varval_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Add members */
     for (i = 1; i < argc; i++ ){
-        redis_cmd_append_sstr_zval(&cmdstr, &z_args[i], redis_sock TSRMLS_CC);
+        redis_cmd_append_sstr_zval(&cmdstr, &z_args[i], redis_sock);
     }
 
     // Push out values
@@ -1100,7 +1100,7 @@ static int gen_key_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t val_len, key_len;
     char *key, *val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sa", &key, &key_len,
                               &z_arr) == FAILURE ||
                               zend_hash_num_elements(Z_ARRVAL_P(z_arr)) == 0)
     {
@@ -1122,7 +1122,7 @@ static int gen_key_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     assert(valtype == VAL_TYPE_VALUES || valtype == VAL_TYPE_STRINGS);
     ZEND_HASH_FOREACH_VAL(ht_arr, z_val) {
         if (valtype == VAL_TYPE_VALUES) {
-            val_free = redis_pack(redis_sock, z_val, &val, &val_len TSRMLS_CC);
+            val_free = redis_pack(redis_sock, z_val, &val, &val_len);
             redis_cmd_append_sstr(&cmdstr, val, val_len);
             if (val_free) efree(val);
         } else {
@@ -1173,7 +1173,7 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_string *zstr;
 
     if (argc < min_argc) {
-        zend_wrong_param_count(TSRMLS_C);
+        zend_wrong_param_count();
         return FAILURE;
     }
 
@@ -1222,7 +1222,7 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 } else if (cluster_hash_key(key,key_len)!=kslot) {
                     zend_string_release(zstr);
                     if (key_free) efree(key);
-                    php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                    php_error_docref(NULL, E_WARNING,
                         "Not all keys hash to the same slot!");
                     return FAILURE;
                 }
@@ -1238,7 +1238,7 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         }
     } else {
         if (has_timeout && Z_TYPE(z_args[argc-1])!=IS_LONG) {
-            php_error_docref(NULL TSRMLS_CC, E_ERROR,
+            php_error_docref(NULL, E_ERROR,
                 "Timeout value must be a LONG");
             efree(z_args);
             return FAILURE;
@@ -1257,7 +1257,7 @@ static int gen_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 if ( kslot == -1) {
                     kslot = cluster_hash_key(key, key_len);
                 } else if (cluster_hash_key(key,key_len)!=kslot) {
-                    php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                    php_error_docref(NULL, E_WARNING,
                         "Not all keys hash to the same slot");
                     zend_string_release(zstr);
                     if (key_free) efree(key);
@@ -1311,7 +1311,7 @@ int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
 
     // Make sure the function is being called correctly
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|z", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz|z", &key, &key_len,
                              &z_value, &z_opts) == FAILURE)
     {
         return FAILURE;
@@ -1400,7 +1400,7 @@ int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     short slot1, slot2;
     zend_long timeout;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssl", &key1, &key1_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssl", &key1, &key1_len,
                              &key2, &key2_len, &timeout) == FAILURE)
     {
         return FAILURE;
@@ -1415,7 +1415,7 @@ int redis_brpoplpush_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         slot1 = cluster_hash_key(key1, key1_len);
         slot2 = cluster_hash_key(key2, key2_len);
         if (slot1 != slot2) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                "Keys hash to different slots!");
             if (key1_free) efree(key1);
             if (key2_free) efree(key2);
@@ -1456,7 +1456,7 @@ redis_atomic_increment(INTERNAL_FUNCTION_PARAMETERS, int type,
     size_t key_len;
     zend_long val = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &key, &key_len,
                               &val) == FAILURE)
     {
         return FAILURE;
@@ -1506,7 +1506,7 @@ int redis_hincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, mem_len;
     zend_long byval;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssl", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssl", &key, &key_len,
                              &mem, &mem_len, &byval) == FAILURE)
     {
         return FAILURE;
@@ -1527,7 +1527,7 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, mem_len;
     double byval;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssd", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssd", &key, &key_len,
                              &mem, &mem_len, &byval) == FAILURE)
     {
         return FAILURE;
@@ -1553,7 +1553,7 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     smart_string cmdstr = {0};
 
     // Parse arguments
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sa", &key, &key_len,
                              &z_arr) == FAILURE)
     {
         return FAILURE;
@@ -1640,7 +1640,7 @@ int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zval *z_val;
 
     // Parse args
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sa", &key, &key_len,
                              &z_arr) == FAILURE)
     {
         return FAILURE;
@@ -1678,7 +1678,7 @@ int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         }
 
         // Serialize value (if directed)
-        val_free = redis_pack(redis_sock, z_val, &val, &val_len TSRMLS_CC);
+        val_free = redis_pack(redis_sock, z_val, &val, &val_len);
 
         // Append the key and value to our command
         redis_cmd_append_sstr(&cmdstr, mem, mem_len);
@@ -1710,7 +1710,7 @@ redis_hstrlen_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *field;
     size_t key_len, field_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &key, &key_len,
                               &field, &field_len) == FAILURE
     ) {
         return FAILURE;
@@ -1731,7 +1731,7 @@ int redis_bitpos_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
 
     argc = ZEND_NUM_ARGS();
-    if (zend_parse_parameters(argc TSRMLS_CC, "sl|ll", &key, &key_len, &bit,
+    if (zend_parse_parameters(argc, "sl|ll", &key, &key_len, &bit,
                              &start, &end) == FAILURE)
     {
         return FAILURE;
@@ -1801,7 +1801,7 @@ int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         if (slot) {
             kslot = cluster_hash_key(key, key_len);
             if (*slot == -1 || kslot != *slot) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "Warning, not all keys hash to the same slot!");
                 zend_string_release(zstr);
                 if (key_free) efree(key);
@@ -1833,7 +1833,7 @@ int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     zend_long start = 0, end = -1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|ll", &key, &key_len,
                              &start, &end) == FAILURE)
     {
         return FAILURE;
@@ -1860,7 +1860,7 @@ static int redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_string *zstr;
 
     // Parse arguments
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sa", &key, &key_len,
                              &z_arr) == FAILURE)
     {
         return FAILURE;
@@ -1899,14 +1899,14 @@ static int redis_gen_pf_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
             // Verify slot
             if (slot && *slot != cluster_hash_key(mem, mem_len)) {
-                php_error_docref(0 TSRMLS_CC, E_WARNING,
+                php_error_docref(0, E_WARNING,
                     "All keys must hash to the same slot!");
                 zend_string_release(zstr);
                 if (key_free) efree(key);
                 return FAILURE;
             }
         } else {
-            mem_free = redis_pack(redis_sock, z_ele, &mem, &mem_len TSRMLS_CC);
+            mem_free = redis_pack(redis_sock, z_ele, &mem, &mem_len);
 
             zstr = NULL;
             if (!mem_free) {
@@ -1960,7 +1960,7 @@ int redis_pfcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     short kslot=-1;
     zend_string *zstr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,"z",&z_keys) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(),"z",&z_keys) == FAILURE) {
         return FAILURE;
     }
 
@@ -2000,7 +2000,7 @@ int redis_pfcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     if (key_free) efree(key);
                     efree(cmdstr.c);
 
-                    php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                    php_error_docref(NULL, E_WARNING,
                         "Not all keys hash to the same slot!");
                     return FAILURE;
                 }
@@ -2042,7 +2042,7 @@ int redis_auth_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *pw;
     size_t pw_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &pw, &pw_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pw, &pw_len)
                              ==FAILURE)
     {
         return FAILURE;
@@ -2068,7 +2068,7 @@ int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long offset;
     zend_bool val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slb", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "slb", &key, &key_len,
                              &offset, &val) == FAILURE)
     {
         return FAILURE;
@@ -2076,7 +2076,7 @@ int redis_setbit_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     // Validate our offset
     if (offset < BITOP_MIN_OFFSET || offset > BITOP_MAX_OFFSET) {
-        php_error_docref(0 TSRMLS_CC, E_WARNING,
+        php_error_docref(0, E_WARNING,
             "Invalid OFFSET for bitop command (must be between 0-2^32-1)");
         return FAILURE;
     }
@@ -2094,7 +2094,7 @@ int redis_linsert_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, pos_len;
     zval *z_val, *z_pivot;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sszz", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sszz", &key, &key_len,
                              &pos, &pos_len, &z_pivot, &z_val) == FAILURE)
     {
         return FAILURE;
@@ -2102,7 +2102,7 @@ int redis_linsert_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     // Validate position
     if (strncasecmp(pos, "after", 5) && strncasecmp(pos, "before", 6)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Position must be either 'BEFORE' or 'AFTER'");
         return FAILURE;
     }
@@ -2124,7 +2124,7 @@ int redis_lrem_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long count = 0;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz|l", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sz|l", &key, &key_len,
                              &z_val, &count) == FAILURE)
     {
         return FAILURE;
@@ -2145,7 +2145,7 @@ int redis_smove_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int src_free, dst_free;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssz", &src, &src_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssz", &src, &src_len,
                              &dst, &dst_len, &z_val) == FAILURE)
     {
         return FAILURE;
@@ -2159,7 +2159,7 @@ int redis_smove_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         short slot1 = cluster_hash_key(src, src_len);
         short slot2 = cluster_hash_key(dst, dst_len);
         if (slot1 != slot2) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING,
+            php_error_docref(0, E_WARNING,
                 "Source and destination keys don't hash to the same slot!");
             if (src_free) efree(src);
             if (dst_free) efree(dst);
@@ -2188,7 +2188,7 @@ static int gen_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len, mem_len;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssz", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssz", &key, &key_len,
                              &mem, &mem_len, &z_val) == FAILURE)
     {
         return FAILURE;
@@ -2226,7 +2226,7 @@ int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     zend_long count;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &key, &key_len,
                              &count) == FAILURE)
     {
         return FAILURE;
@@ -2254,7 +2254,7 @@ int redis_zincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     double incrby;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sdz", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sdz", &key, &key_len,
                              &incrby, &z_val) == FAILURE)
     {
         return FAILURE;
@@ -2277,7 +2277,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t key_len;
     int key_free;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|a", &key, &key_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|a", &key, &key_len,
                              &z_opts) == FAILURE)
     {
         return FAILURE;
@@ -2318,7 +2318,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     ) {
         // "BY" option is disabled in cluster
         if (slot) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "SORT BY option is not allowed in Redis Cluster");
             zval_dtor(&z_argv);
             return FAILURE;
@@ -2348,7 +2348,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             Z_STRVAL_P(z_ele), Z_STRLEN_P(z_ele));
 
         if (cross_slot) {
-            php_error_docref(0 TSRMLS_CC, E_WARNING,
+            php_error_docref(0, E_WARNING,
                 "Error, SORT key and STORE key have different slots!");
             zval_dtor(&z_argv);
             return FAILURE;
@@ -2369,7 +2369,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     ) {
         // Disabled in cluster
         if (slot) {
-            php_error_docref(NULL TSRMLS_CC, E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "GET option for SORT disabled in Redis Cluster");
             zval_dtor(&z_argv);
             return FAILURE;
@@ -2398,7 +2398,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
             // Make sure we were able to add at least one
             if (added == 0) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "Array of GET values requested, but none are valid");
                 zval_dtor(&z_argv);
                 return FAILURE;
@@ -2428,7 +2428,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             if ((Z_TYPE_P(z_off) != IS_STRING && Z_TYPE_P(z_off) != IS_LONG) ||
                 (Z_TYPE_P(z_cnt) != IS_STRING && Z_TYPE_P(z_cnt) != IS_LONG)
             ) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "LIMIT options on SORT command must be longs or strings");
                 zval_dtor(&z_argv);
                 return FAILURE;
@@ -2632,7 +2632,7 @@ int redis_zadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             redis_cmd_append_sstr_dbl(&cmdstr, zval_get_double(&z_args[i]));
         }
         // serialize value if requested
-        val_free = redis_pack(redis_sock, &z_args[i+1], &val, &val_len TSRMLS_CC);
+        val_free = redis_pack(redis_sock, &z_args[i+1], &val, &val_len);
         redis_cmd_append_sstr(&cmdstr, val, val_len);
 
         // Free value if we serialized
@@ -2658,7 +2658,7 @@ int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *subcmd;
     size_t key_len, subcmd_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &subcmd,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &subcmd,
                              &subcmd_len, &key, &key_len) == FAILURE)
     {
         return FAILURE;
@@ -2675,7 +2675,7 @@ int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     } else if (subcmd_len == 8 && !strncasecmp(subcmd, "encoding", 8)) {
         *rtype = TYPE_BULK;
     } else {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Invalid subcommand sent to OBJECT");
         efree(*cmd);
         return FAILURE;
@@ -2692,7 +2692,7 @@ int redis_geodist_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *source, *dest, *unit = NULL;
     size_t keylen, sourcelen, destlen, unitlen;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|s", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss|s", &key, &keylen,
                               &source, &sourcelen, &dest, &destlen, &unit,
                               &unitlen) == FAILURE)
     {
@@ -2722,7 +2722,7 @@ geoStoreType get_georadius_store_type(zend_string *key) {
 }
 
 /* Helper function to extract optional arguments for GEORADIUS and GEORADIUSBYMEMBER */
-static int get_georadius_opts(HashTable *ht, geoOptions *opts TSRMLS_DC) {
+static int get_georadius_opts(HashTable *ht, geoOptions *opts) {
     ulong idx;
     char *optstr;
     zend_string *zkey;
@@ -2738,7 +2738,7 @@ static int get_georadius_opts(HashTable *ht, geoOptions *opts TSRMLS_DC) {
         if (zkey) {
             if (ZSTR_LEN(zkey) == 5 && !strcasecmp(ZSTR_VAL(zkey), "count")) {
                 if (Z_TYPE_P(optval) != IS_LONG || Z_LVAL_P(optval) <= 0) {
-                    php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                    php_error_docref(NULL, E_WARNING,
                             "COUNT must be an integer > 0!");
                     if (opts->key) zend_string_release(opts->key);
                     return FAILURE;
@@ -2774,7 +2774,7 @@ static int get_georadius_opts(HashTable *ht, geoOptions *opts TSRMLS_DC) {
 
     /* STORE and STOREDIST are not compatible with the WITH* options */
     if (opts->key != NULL && (opts->withcoord || opts->withdist || opts->withhash)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "STORE[DIST] is not compatible with WITHCOORD, WITHDIST or WITHHASH");
 
         if (opts->key) zend_string_release(opts->key);
@@ -2847,7 +2847,7 @@ int redis_georadius_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     geoOptions gopts = {0};
     smart_string cmdstr = {0};
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sddds|a", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sddds|a", &key, &keylen,
                               &lng, &lat, &radius, &unit, &unitlen, &opts)
                               == FAILURE)
     {
@@ -2857,7 +2857,7 @@ int redis_georadius_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     /* Parse any GEORADIUS options we have */
     if (opts != NULL) {
         /* Attempt to parse our options array */
-        if (get_georadius_opts(Z_ARRVAL_P(opts), &gopts TSRMLS_CC) != SUCCESS)
+        if (get_georadius_opts(Z_ARRVAL_P(opts), &gopts) != SUCCESS)
         {
             return FAILURE;
         }
@@ -2891,7 +2891,7 @@ int redis_georadius_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Protect the user from CROSSSLOT if we're in cluster */
     if (slot && gopts.store != STORE_NONE && *slot != store_slot) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Key and STORE[DIST] key must hash to the same slot");
         efree(cmdstr.c);
         return FAILURE;
@@ -2919,7 +2919,7 @@ int redis_georadiusbymember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_s
     zval *opts = NULL;
     smart_string cmdstr = {0};
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssds|a", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssds|a", &key, &keylen,
                               &mem, &memlen, &radius, &unit, &unitlen, &opts) == FAILURE)
     {
         return FAILURE;
@@ -2927,7 +2927,7 @@ int redis_georadiusbymember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_s
 
     if (opts != NULL) {
         /* Attempt to parse our options array */
-        if (get_georadius_opts(Z_ARRVAL_P(opts), &gopts TSRMLS_CC) == FAILURE) {
+        if (get_georadius_opts(Z_ARRVAL_P(opts), &gopts) == FAILURE) {
             return FAILURE;
         }
     }
@@ -2959,7 +2959,7 @@ int redis_georadiusbymember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_s
 
     /* Protect the user from CROSSSLOT if we're in cluster */
     if (slot && gopts.store != STORE_NONE && *slot != store_slot) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Key and STORE[DIST] key must hash to the same slot");
         efree(cmdstr.c);
         return FAILURE;
@@ -2984,7 +2984,7 @@ int redis_migrate_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_bool copy = 0, replace = 0;
     zend_string *zstr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slzll|bb", &host, &hostlen, &port,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "slzll|bb", &host, &hostlen, &port,
                               &z_keys, &destdb, &timeout, &copy, &replace) == FAILURE)
     {
         return FAILURE;
@@ -2992,7 +2992,7 @@ int redis_migrate_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Protect against being passed an array with zero elements */
     if (Z_TYPE_P(z_keys) == IS_ARRAY && zend_hash_num_elements(Z_ARRVAL_P(z_keys)) == 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Keys array cannot be empty");
+        php_error_docref(NULL, E_WARNING, "Keys array cannot be empty");
         return FAILURE;
     }
 
@@ -3146,7 +3146,7 @@ int redis_command_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t kw_len;
 
     /* Parse our args */
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|sz", &kw, &kw_len,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sz", &kw, &kw_len,
                              &z_arg) == FAILURE)
     {
         return FAILURE;
@@ -3220,7 +3220,7 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key, *id;
     size_t keylen, idlen;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssa|lb", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssa|lb", &key, &keylen,
                               &id, &idlen, &z_fields, &maxlen, &approx) == FAILURE)
     {
         return FAILURE;
@@ -3233,7 +3233,7 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     }
 
     if (maxlen < 0 || (maxlen == 0 && approx != 0)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Warning:  Invalid MAXLEN argument or approximate flag");
     }
 
@@ -3258,7 +3258,7 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     redis_cmd_append_sstr(&cmdstr, id, idlen);
     ZEND_HASH_FOREACH_KEY_VAL(ht_fields, idx, arrkey, value) {
         redis_cmd_append_sstr_arrkey(&cmdstr, arrkey, idx);
-        redis_cmd_append_sstr_zval(&cmdstr, value, redis_sock TSRMLS_CC);
+        redis_cmd_append_sstr_zval(&cmdstr, value, redis_sock);
     } ZEND_HASH_FOREACH_END();
 
     *cmd = cmdstr.c;
@@ -3277,7 +3277,7 @@ int redis_xpending_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long count = -1;
 
     // XPENDING mystream group55 - + 10 consumer-123
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss|ssls", &key,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|ssls", &key,
                               &keylen, &group, &grouplen, &start, &startlen,
                               &end, &endlen, &count, &consumer, &consumerlen)
                               == FAILURE)
@@ -3323,7 +3323,7 @@ int redis_xrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     size_t keylen, startlen, endlen;
     zend_long count = -1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss|l", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss|l", &key, &keylen,
                               &start, &startlen, &end, &endlen, &count)
                               == FAILURE)
     {
@@ -3349,7 +3349,7 @@ int redis_xrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
  * STREAMS stream [stream...] id [id ...] arguments to a command string. */
 static int
 append_stream_args(smart_string *cmdstr, HashTable *ht, RedisSock *redis_sock,
-                   short *slot TSRMLS_DC)
+                   short *slot)
 {
     char *kptr, kbuf[40];
     int klen, i, pos = 0;
@@ -3384,7 +3384,7 @@ append_stream_args(smart_string *cmdstr, HashTable *ht, RedisSock *redis_sock,
         /* Protect the user against CROSSSLOT to avoid confusion */
         if (slot) {
             if (oldslot != -1 && *slot != oldslot) {
-                php_error_docref(NULL TSRMLS_CC, E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "Warning, not all keys hash to the same slot!");
                 efree(id);
                 return FAILURE;
@@ -3416,7 +3416,7 @@ int redis_xread_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     int argc, scount;
     HashTable *kt;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a|ll", &z_streams,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "a|ll", &z_streams,
                               &count, &block) == FAILURE)
     {
         return FAILURE;
@@ -3445,7 +3445,7 @@ int redis_xread_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     }
 
     /* Append final STREAM key [key ...] id [id ...] arguments */
-    if (append_stream_args(&cmdstr, kt, redis_sock, slot TSRMLS_CC) < 0) {
+    if (append_stream_args(&cmdstr, kt, redis_sock, slot) < 0) {
         efree(cmdstr.c);
         return FAILURE;
     }
@@ -3469,7 +3469,7 @@ int redis_xreadgroup_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long count, block;
     zend_bool no_count = 1, no_block = 1;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssa|l!l!", &group,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssa|l!l!", &group,
                               &grouplen, &consumer, &consumerlen, &z_streams,
                               &count, &no_count, &block, &no_block) == FAILURE)
     {
@@ -3478,7 +3478,7 @@ int redis_xreadgroup_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Negative COUNT or BLOCK is illegal so abort immediately */
     if ((!no_count && count < 0) || (!no_block && block < 0)) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "Negative values for COUNT or BLOCK are illegal.");
+        php_error_docref(NULL, E_WARNING, "Negative values for COUNT or BLOCK are illegal.");
         return FAILURE;
     }
 
@@ -3510,7 +3510,7 @@ int redis_xreadgroup_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     }
 
     /* Finally append stream and id args */
-    if (append_stream_args(&cmdstr, kt, redis_sock, slot TSRMLS_CC) < 0) {
+    if (append_stream_args(&cmdstr, kt, redis_sock, slot) < 0) {
         efree(cmdstr.c);
         return FAILURE;
     }
@@ -3532,7 +3532,7 @@ int redis_xack_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     HashTable *ht_ids;
     int idcount;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssa", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssa", &key, &keylen,
                               &group, &grouplen, &z_ids) == FAILURE)
     {
         return FAILURE;
@@ -3601,12 +3601,12 @@ static int zval_get_i64(zval *zv, int64_t *retval) {
  * 32-bit PHP long so we have to extract it as an int64_t.  If the value is
  * not a valid number or negative, we'll inform the user of the problem and
  * that the argument is being ignored. */
-static int64_t get_xclaim_i64_arg(const char *key, zval *zv TSRMLS_DC) {
+static int64_t get_xclaim_i64_arg(const char *key, zval *zv) {
     int64_t retval = -1;
 
     /* Extract an i64, and if we can't let the user know there is an issue. */
     if (zval_get_i64(zv, &retval) == FAILURE || retval < 0) {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "Invalid XCLAIM option '%s' will be ignored", key);
     }
 
@@ -3614,7 +3614,7 @@ static int64_t get_xclaim_i64_arg(const char *key, zval *zv TSRMLS_DC) {
 }
 
 /* Helper to extract XCLAIM options */
-static void get_xclaim_options(zval *z_arr, xclaimOptions *opt TSRMLS_DC) {
+static void get_xclaim_options(zval *z_arr, xclaimOptions *opt) {
     HashTable *ht;
     zend_string *zkey;
     char *kval;
@@ -3643,10 +3643,10 @@ static void get_xclaim_options(zval *z_arr, xclaimOptions *opt TSRMLS_DC) {
             if (klen == 4) {
                 if (!strncasecmp(kval, "TIME", 4)) {
                     opt->idle.type = "TIME";
-                    opt->idle.time = get_xclaim_i64_arg("TIME", zv TSRMLS_CC);
+                    opt->idle.time = get_xclaim_i64_arg("TIME", zv);
                 } else if (!strncasecmp(kval, "IDLE", 4)) {
                     opt->idle.type = "IDLE";
-                    opt->idle.time = get_xclaim_i64_arg("IDLE", zv TSRMLS_CC);
+                    opt->idle.time = get_xclaim_i64_arg("IDLE", zv);
                 }
             } else if (klen == 10 && !strncasecmp(kval, "RETRYCOUNT", 10)) {
                 opt->retrycount = zval_get_long(zv);
@@ -3718,7 +3718,7 @@ int redis_xclaim_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     HashTable *ht_ids;
     xclaimOptions opts;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sssla|a", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sssla|a", &key, &keylen,
                               &group, &grouplen, &consumer, &consumerlen, &min_idle,
                               &z_ids, &z_opts) == FAILURE)
     {
@@ -3732,7 +3732,7 @@ int redis_xclaim_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     }
 
     /* Extract options array if we've got them */
-    get_xclaim_options(z_opts, &opts TSRMLS_CC);
+    get_xclaim_options(z_opts, &opts);
 
     /* Now we have enough information to calculate argc */
     argc = 4 + id_count + xclaim_options_argc(&opts);
@@ -3773,7 +3773,7 @@ int redis_xgroup_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_bool mkstream = 0;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sssb", &op, &oplen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|sssb", &op, &oplen,
                               &key, &keylen, &arg1, &arg1len, &arg2, &arg2len,
                               &mkstream) == FAILURE)
     {
@@ -3823,7 +3823,7 @@ int redis_xinfo_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char fmt[4];
     int argc = ZEND_NUM_ARGS();
 
-    if (argc > 3 || zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ss",
+    if (argc > 3 || zend_parse_parameters(ZEND_NUM_ARGS(), "s|ss",
                                           &op, &oplen, &key, &keylen, &arg,
                                           &arglen) == FAILURE)
     {
@@ -3848,7 +3848,7 @@ int redis_xtrim_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long maxlen;
     zend_bool approx = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|b", &key, &keylen,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|b", &key, &keylen,
                               &maxlen, &approx) == FAILURE)
     {
         return FAILURE;
@@ -3876,7 +3876,7 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
 {
     zend_long option;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &option)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &option)
                               == FAILURE)
     {
         RETURN_FALSE;
@@ -3920,7 +3920,7 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
     int tcp_keepalive = 0;
     php_netstream_data_t *sock;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lz", &option,
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "lz", &option,
                               &val) == FAILURE)
     {
         RETURN_FALSE;
@@ -4035,7 +4035,7 @@ void redis_prefix_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
     char *key;
     size_t key_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len)
                              ==FAILURE)
     {
         RETURN_FALSE;
@@ -4057,11 +4057,11 @@ void redis_serialize_handler(INTERNAL_FUNCTION_PARAMETERS,
     char *val;
     size_t val_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &z_val) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &z_val) == FAILURE) {
         RETURN_FALSE;
     }
 
-    int val_free = redis_serialize(redis_sock, z_val, &val, &val_len TSRMLS_CC);
+    int val_free = redis_serialize(redis_sock, z_val, &val, &val_len);
 
     RETVAL_STRINGL(val, val_len);
     if (val_free) efree(val);
@@ -4074,7 +4074,7 @@ void redis_unserialize_handler(INTERNAL_FUNCTION_PARAMETERS,
     size_t value_len;
 
     // Parse our arguments
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &value, &value_len)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &value, &value_len)
                                     == FAILURE)
     {
         RETURN_FALSE;
@@ -4086,7 +4086,7 @@ void redis_unserialize_handler(INTERNAL_FUNCTION_PARAMETERS,
         RETURN_STRINGL(value, value_len);
     }
     zval zv, *z_ret = &zv;
-    if (!redis_unserialize(redis_sock, value, value_len, z_ret TSRMLS_CC)) {
+    if (!redis_unserialize(redis_sock, value, value_len, z_ret)) {
         // Badly formed input, throw an execption
         zend_throw_exception(ex, "Invalid serialized data, or unserialization error", 0);
         RETURN_FALSE;

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -22,7 +22,7 @@ typedef struct subscribeContext {
 } subscribeContext;
 
 /* Construct a raw command */
-int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len TSRMLS_DC);
+int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len);
 /* Construct a script command */
 smart_string *redis_build_script_cmd(smart_string *cmd, int argc, zval *z_args);
 


### PR DESCRIPTION
This macro are no more used since 7.0, and have been totally removed in 8.

Mostly a result of 

```
sed -e 's/ TSRMLS_CC//' -i *.c *.h 
sed -e 's/TSRMLS_C//' -i *.c *.h 
sed -e 's/ TSRMLS_DC//' -i *.c *.h 
sed -e 's/TSRMLS_D/void/' -i *.c *.h 
```