### PR TITLE
Fix "No such file or directory" when connecting to ports >= 32768

### DIFF
--- a/common.h
+++ b/common.h
@@ -248,7 +248,7 @@ typedef struct fold_item {
 typedef struct {
     php_stream        *stream;
     zend_string       *host;
-    short             port;
+    unsigned short    port;
     zend_string       *auth;
     double            timeout;
     double            read_timeout;

--- a/redis.c
+++ b/redis.c
@@ -1003,7 +1003,7 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
         port = 6379;
     }
 
-    if (port <= 0) {
+    if (port < 0) {
         port = 0;
     }
 

--- a/redis.c
+++ b/redis.c
@@ -1003,6 +1003,10 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
         port = 6379;
     }
 
+    if (port <= 0) {
+        port = 0;
+    }
+
     redis = PHPREDIS_GET_OBJECT(redis_object, object);
     /* if there is a redis sock already we have to remove it */
     if (redis->sock) {


### PR DESCRIPTION
Since 5.0.0, trying to connect to redis on a high enough port number gives a "No such file or directory" error. Various internal type casts end up treating port numbers from 2^15 as negative, which awkwardly triggers the unix-socket-path behaviour. This is a regression from 4.3.0.

```
  $ redis-server --daemonize yes --port 32768
  $ php -r '(new Redis())->connect("127.0.0.1", 32768);'
  # on 5.0.0, this causes "PHP Fatal error:  Uncaught RedisException: No such file or directory in Command line code:1"
```

The port number comes in to phpredis internals as a `long`, gets forced to `unsigned short` when passed to `redis_sock_create`, then cast to `short` when put in the `RedisSock` structure; at that point, half of possible values effectively become negative thanks to two's-complement.

Amazingly, this always worked before: the string formatting that builds up the `host` arg to give to `php_stream_xport_create` formatted it as a negative number – producing something like `"myhost:-25536"` for port 40000. Several hops through PHP stream API internals later, this was [parsed back out to an `int`](https://github.com/php/php-src/blob/623911f993f39ebbe75abe2771fc89faf6b15b9b/main/streams/xp_socket.c#L726), then fed to `php_network_connect_socket_to_host` – which takes an `unsigned short`, so it ends up being reinterpreted as 40000 right before it's needed.

The reason it breaks since 5.0.0 is due to changes to how unix sockets are detected (I assume as part of supporting relative socket paths). Currently, it [only checks for port <1](https://github.com/phpredis/phpredis/blob/d084f334a5521def54e6be76b58ec6604cfd8bd6/library.c#L1810).

This bug is the root cause of the particular failure message seen in the previously-reported #1587 (that case should have failed with a networking error b/c 71234 isn't a valid port).

This patch is a bare-minimum change to avoid the cast & keep it as `unsigned short`... but the handling of various `connect` args does still feels generally shaky.

I did some extra sanitizing early on too, to handle when port isn't specified at all; in that case the initial `long` is -1, so would get treated as 65535 later with this change.

:warning: I haven't checked the comparable Cluster code for similar problems: advice on how to proceed would be appreciated :warning:

Results of some tests I've run for various combinations:

| Redis listening on | `connect()` args | 4.3.0 | current `develop` | this branch|
| --- | --- | --- | --- | ---|
| `/tmp/redis.sock` | `("/tmp/redis.sock")` | OK | OK | OK|
| `/tmp/redis.sock` | `("/tmp/redis.sock", null)` | OK | OK | OK|
| `/tmp/redis.sock` | `("/tmp/redis.sock", 0)` | OK | OK | OK|
| `/tmp/redis.sock` | `("/tmp/redis.sock", 6379)` | fails | fails | fails |
| `/tmp/redis.sock` | `("/tmp/redis.sock", -1)` | OK | OK | OK|
| 6379 | `("127.0.0.1)"` | OK | OK | OK|
| 6379 | `("127.0.0.1", null)` | OK | fails | fails |
| 6379 | `("127.0.0.1", 0)` | OK | fails | fails |
| 6379 | `("127.0.0.1", 6379)` | OK | OK | OK |
| 6379 | `("127.0.0.1", -1)` | OK | OK | OK |
| 32767 | `("127.0.0.1", 32767)` | OK | OK | OK |
| 32768 | `("127.0.0.1", 32768)` | OK | fails | OK |
| 32769 | `("127.0.0.1", 32769)` | OK | fails | OK |
