### PR TITLE
Fix wording in changelog: 'latest' should be 'last'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -134,7 +134,7 @@ serializers, soft deprecation of non-Redis commands.
 
 ## [4.3.0] - 2019-03-13 ([GitHub](https://github.com/phpredis/phpredis/releases/tag/4.3.0), [PECL](https://pecl.php.net/package/redis/4.3.0))
 
-This is probably the latest release with PHP 5 suport!!!
+This is probably the last release with PHP 5 suport!!!
 
 ### Added
 

--- a/package.xml
+++ b/package.xml
@@ -193,7 +193,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <notes>
       phpredis 4.3.0
 
-      This is probably the latest release with PHP 5 suport!!!
+      This is probably the last release with PHP 5 suport!!!
 
       * Proper persistent connections pooling implementation [a3703820, c76e00fb, 0433dc03, c75b3b93] (Pavlo Yatsukhnenko)
       * RedisArray auth [b5549cff, 339cfa2b, 6b411aa8] (Pavlo Yatsukhnenko)


### PR DESCRIPTION
"Latest" means most recent, whereas "last" means that nothing will follow.