### PR TITLE
Updated README with correct return value for ping command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -364,8 +364,9 @@ _**Description**_: Check the current connection status
 
 ##### *Return value*
 
-*STRING*: `+PONG` on success. Throws a [RedisException](#class-redisexception) object on connectivity error, as described above.
+*BOOL*: `TRUE` in case of success. Throws a [RedisException](#class-redisexception) object on connectivity error, as described above.
 
+Staring from version 5.0.0, the command returns boolean `TRUE` instead of *STRING* `+PONG` as in previous versions.
 
 ### echo
 -----


### PR DESCRIPTION
Spent much time understand the issue in my code with redis when migrating from php 7.2 (redis 4.1.1) to php 7.3 (redis 5.0.2) so I thought this correction of the documentation may help others.