### PR TITLE
Issue #1664

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_install:
 install: make install
 before_script:
   - mkdir -p tests/nodes/ && echo > tests/nodes/nodemap
+  - redis-server --port 0 --daemonize yes --unixsocket /tmp/redis.sock
+  - for PORT in $(seq 32767 32769); do redis-server --port $PORT --daemonize yes; done
   - for PORT in $(seq 6379 6382); do redis-server --port $PORT --daemonize yes; done
   - for PORT in $(seq 7000 7011); do redis-server --port $PORT --cluster-enabled yes --cluster-config-file $PORT.conf --daemonize yes; echo 127.0.0.1:$PORT >> tests/nodes/nodemap; done
   - echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7011) --cluster-replicas 3

--- a/README.markdown
+++ b/README.markdown
@@ -204,7 +204,6 @@ $redis->connect('tls://127.0.0.1'); // enable transport level security, port 637
 $redis->connect('127.0.0.1', 6379, 2.5); // 2.5 sec timeout.
 $redis->connect('/tmp/redis.sock'); // unix domain socket.
 $redis->connect('127.0.0.1', 6379, 1, NULL, 100); // 1 sec timeout, 100ms delay between reconnection attempts.
-$redis->connect('unix://redis.sock'); // relative path to unix domain socket requires version 5.0.0 or higher.
 ~~~
 
 ### pconnect, popen
@@ -246,7 +245,6 @@ $redis->pconnect('tls://127.0.0.1'); // enable transport level security, port 63
 $redis->pconnect('127.0.0.1', 6379, 2.5); // 2.5 sec timeout and would be another connection than the two before.
 $redis->pconnect('127.0.0.1', 6379, 2.5, 'x'); // x is sent as persistent_id and would be another connection than the three before.
 $redis->pconnect('/tmp/redis.sock'); // unix domain socket - would be another connection than the four before.
-$redis->pconnect('unix://redis.sock'); // relative path to unix domain socket requires version 5.0.0 or higher.
 ~~~
 
 ### auth

--- a/library.c
+++ b/library.c
@@ -1753,7 +1753,7 @@ PHP_REDIS_API void redis_debug_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock 
  * redis_sock_create
  */
 PHP_REDIS_API RedisSock*
-redis_sock_create(char *host, int host_len, unsigned short port,
+redis_sock_create(char *host, int host_len, int port,
                   double timeout, double read_timeout,
                   int persistent, char *persistent_id,
                   long retry_interval)

--- a/library.h
+++ b/library.h
@@ -48,7 +48,7 @@ PHP_REDIS_API void redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *
 PHP_REDIS_API void redis_parse_info_response(char *response, zval *z_ret);
 PHP_REDIS_API void redis_parse_client_list_response(char *response, zval *z_ret);
 PHP_REDIS_API void redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
-PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, unsigned short port, double timeout, double read_timeout, int persistent, char *persistent_id, long retry_interval);
+PHP_REDIS_API RedisSock* redis_sock_create(char *host, int host_len, int port, double timeout, double read_timeout, int persistent, char *persistent_id, long retry_interval);
 PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock);
 PHP_REDIS_API int redis_sock_server_open(RedisSock *redis_sock);
 PHP_REDIS_API int redis_sock_auth(RedisSock *redis_sock);


### PR DESCRIPTION
In PR #1602 we decided to use unsigned short for storing RedisSock->port
but in previous release I reverted that change. In this PR I changed
signatire of redis_sock_create to prevent unneccecary convertion of types.