### PR TITLE
Issue.1694 session lifetime

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -127,6 +127,9 @@ static int session_gc_maxlifetime() {
     if (value > INT_MAX) {
         php_error_docref(NULL, E_NOTICE, "session.gc_maxlifetime overflows INT_MAX, truncating.");
         return INT_MAX;
+    } else if (value <= 0) {
+        php_error_docref(NULL, E_NOTICE, "session.gc_maxlifetime is <= 0, defaulting to 1440 seconds");
+        return 1440;
     }
 
     return value;


### PR DESCRIPTION
This fix protects `session.gc_maxlifetime` from an integer overflow or from a value <= 0 as a negative expire in Redis is an error.  

I'm not totally sure if this is the correct strategy, as we could instead just treat the value as a `zend_long` but a timeout >= INT_MAX is nearly 70 years in the future so strikes me as rather meaningless.

@yatsukhnenko What do you think?

Addresses #1694