### PR TITLE
Group persistent connections by persistent_id.

### DIFF
--- a/library.c
+++ b/library.c
@@ -61,12 +61,16 @@ static ConnectionPool *
 redis_sock_get_connection_pool(RedisSock *redis_sock)
 {
     ConnectionPool *p;
-    zend_string *persistent_id = strpprintf(0, "phpredis_%s:%d", ZSTR_VAL(redis_sock->host), redis_sock->port);
-    zend_resource *le = zend_hash_find_ptr(&EG(persistent_list), persistent_id);
+    zend_string *persistent_id;
+    zend_resource *le;
 
-    if (le) {
-        p = le->ptr;
+    if (INI_INT("redis.pconnect.group_by_persistent_id") && redis_sock->persistent_id) {
+        persistent_id = strpprintf(0, "phpredis_%s:%d_%s", ZSTR_VAL(redis_sock->host), redis_sock->port, ZSTR_VAL(redis_sock->persistent_id));
     } else {
+        persistent_id = strpprintf(0, "phpredis_%s:%d", ZSTR_VAL(redis_sock->host), redis_sock->port);
+    }
+
+    if ((le = zend_hash_find_ptr(&EG(persistent_list), persistent_id)) == NULL) {
         p = pecalloc(1, sizeof(*p), 1);
         zend_llist_init(&p->list, sizeof(php_stream *), NULL, 1);
 #if (PHP_VERSION_ID < 70300)
@@ -80,7 +84,7 @@ redis_sock_get_connection_pool(RedisSock *redis_sock)
 #endif
     }
     zend_string_release(persistent_id);
-    return p;
+    return le->ptr;
 }
 
 /* Helper to reselect the proper DB number when we reconnect */

--- a/redis.c
+++ b/redis.c
@@ -90,6 +90,7 @@ PHP_INI_BEGIN()
     /* redis pconnect */
     PHP_INI_ENTRY("redis.pconnect.pooling_enabled", "1", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.pconnect.connection_limit", "0", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.pconnect.group_by_persistent_id", "0", PHP_INI_ALL, NULL)
 
     /* redis session */
     PHP_INI_ENTRY("redis.session.locking_enabled", "0", PHP_INI_ALL, NULL)


### PR DESCRIPTION
This change allows to create multiple connection pools.
Disabled by default for compatibility reasons.