### PR TITLE
Check liveness via php_stream_set_option.

### DIFF
--- a/library.c
+++ b/library.c
@@ -1808,6 +1808,11 @@ redis_sock_check_liveness(RedisSock *redis_sock)
     struct timeval tv;
     size_t len;
 
+    /* Check socket liveness using 0 second timeout */
+    if (php_stream_set_option(redis_sock->stream, PHP_STREAM_OPTION_CHECK_LIVENESS, 0, NULL) != PHP_STREAM_OPTION_RETURN_OK) {
+        return FAILURE;
+    }
+
     if (redis_sock->auth) {
         redis_cmd_init_sstr(&cmd, 1, "AUTH", sizeof("AUTH") - 1);
         redis_cmd_append_sstr(&cmd, ZSTR_VAL(redis_sock->auth), ZSTR_LEN(redis_sock->auth));


### PR DESCRIPTION
Check socket liveness using 0 second timeout before sync check.