### PR TITLE
Make unit test authentication configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ before_script:
   - echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7011) --cluster-replicas 3 -a phpredis
   - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 script:
-  - php tests/TestRedis.php --class Redis
-  - php tests/TestRedis.php --class RedisArray
-  - php tests/TestRedis.php --class RedisCluster
-  - php tests/TestRedis.php --class RedisSentinel
-  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class Redis
-  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisArray
-  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisCluster
-  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisSentinel
+  - php tests/TestRedis.php --class Redis --auth phpredis
+  - php tests/TestRedis.php --class RedisArray --auth phpredis
+  - php tests/TestRedis.php --class RedisCluster --auth phpredis
+  - php tests/TestRedis.php --class RedisSentinel --auth phpredis
+  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class Redis --auth phpredis
+  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisArray --auth phpredis
+  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisCluster --auth phpredis
+  - USE_ZEND_ALLOC=0 valgrind --error-exitcode=1 php tests/TestRedis.php --class RedisSentinel --auth phpredis

--- a/tests/RedisArrayTest.php
+++ b/tests/RedisArrayTest.php
@@ -56,8 +56,8 @@ class Redis_Array_Test extends TestSuite
 
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         $this->ra = new RedisArray($newRing, $options);
         $this->min_version = getMinVersion($this->ra);
@@ -84,8 +84,8 @@ class Redis_Array_Test extends TestSuite
 
             $r = new Redis;
             $r->pconnect($host, (int)$port);
-            if (self::AUTH) {
-                $this->assertTrue($r->auth(self::AUTH));
+            if ($this->getAuth()) {
+                $this->assertTrue($r->auth($this->getAuth()));
             }
             $this->assertTrue($v === $r->get($k));
         }
@@ -126,8 +126,8 @@ class Redis_Array_Test extends TestSuite
         // with common hashing function
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex, 'function' => 'custom_hash'];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         $this->ra = new RedisArray($newRing, $options);
 
@@ -149,8 +149,8 @@ class Redis_Array_Test extends TestSuite
     {
         global $newRing, $useIndex;
         $options = ['index' => $useIndex, 'function' => 'custom_hash', 'distributor' => [$this, "customDistributor"]];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         $this->ra = new RedisArray($newRing, $options);
 
@@ -218,8 +218,8 @@ class Redis_Rehashing_Test extends TestSuite
 
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         // create array
         $this->ra = new RedisArray($newRing, $options);
@@ -234,8 +234,8 @@ class Redis_Rehashing_Test extends TestSuite
 
             $r = new Redis();
             $r->pconnect($host, (int)$port, 0);
-            if (self::AUTH) {
-                $this->assertTrue($r->auth(self::AUTH));
+            if ($this->getAuth()) {
+                $this->assertTrue($r->auth($this->getAuth()));
             }
             $r->flushdb();
         }
@@ -371,8 +371,8 @@ class Redis_Auto_Rehashing_Test extends TestSuite {
 
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex, 'autorehash' => TRUE];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         // create array
         $this->ra = new RedisArray($newRing, $options);
@@ -416,8 +416,8 @@ class Redis_Auto_Rehashing_Test extends TestSuite {
 
             $r = new Redis;
             $r->pconnect($host, $port);
-            if (self::AUTH) {
-                $this->assertTrue($r->auth(self::AUTH));
+            if ($this->getAuth()) {
+                $this->assertTrue($r->auth($this->getAuth()));
             }
 
             $this->assertTrue($v === $r->get($k));  // check that the key has actually been migrated to the new node.
@@ -433,8 +433,8 @@ class Redis_Multi_Exec_Test extends TestSuite {
     public function setUp() {
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         // create array
         $this->ra = new RedisArray($newRing, $options);
@@ -578,8 +578,8 @@ class Redis_Distributor_Test extends TestSuite {
     public function setUp() {
         global $newRing, $oldRing, $useIndex;
         $options = ['previous' => $oldRing, 'index' => $useIndex, 'distributor' => [$this, 'distribute']];
-        if (self::AUTH) {
-            $options['auth'] = self::AUTH;
+        if ($this->getAuth()) {
+            $options['auth'] = $this->getAuth();
         }
         // create array
         $this->ra = new RedisArray($newRing, $options);
@@ -616,7 +616,7 @@ class Redis_Distributor_Test extends TestSuite {
     }
 }
 
-function run_tests($className, $str_filter, $str_host) {
+function run_tests($className, $str_filter, $str_host, $str_auth) {
         // reset rings
         global $newRing, $oldRing, $serverList;
 
@@ -625,7 +625,7 @@ function run_tests($className, $str_filter, $str_host) {
         $serverList = ["$str_host:6379", "$str_host:6380", "$str_host:6381", "$str_host:6382"];
 
         // run
-        return TestSuite::run($className, $str_filter);
+        return TestSuite::run($className, $str_filter, $str_host, $str_auth);
 }
 
 ?>

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -62,7 +62,9 @@ class Redis_Cluster_Test extends Redis_Test {
     public function testSession_lockWaitTime() { return $this->markTestSkipped(); }
 
     /* Load our seeds on construction */
-    public function __construct() {
+    public function __construct($str_host, $str_auth) {
+        parent::__construct($str_host, $str_auth);
+
         $str_nodemap_file = dirname($_SERVER['PHP_SELF']) . '/nodes/nodemap';
 
         if (!file_exists($str_nodemap_file)) {
@@ -87,7 +89,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
     /* Override newInstance as we want a RedisCluster object */
     protected function newInstance() {
-        return new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, self::AUTH);
+        return new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, $this->getAuth());
     }
 
     /* Overrides for RedisTest where the function signature is different.  This
@@ -654,7 +656,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         $pong = 0;
         for ($i = 0; $i < 10; $i++) {
-            $obj_rc = new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, self::AUTH);
+            $obj_rc = new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, $this->getAuth());
             $pong += $obj_rc->ping("key:$i");
         }
 
@@ -670,7 +672,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         $pong = 0;
         for ($i = 0; $i < 10; $i++) {
-            $obj_rc = new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, self::AUTH);
+            $obj_rc = new RedisCluster(NULL, self::$_arr_node_map, 30, 30, true, $this->getAuth());
             $pong += $obj_rc->ping("key:$i");
         }
 
@@ -685,7 +687,7 @@ class Redis_Cluster_Test extends Redis_Test {
     {
         return implode('&', array_map(function ($host) {
             return 'seed[]=' . $host;
-        }, self::$_arr_node_map)) . (self::AUTH ? '&auth=' . self::AUTH : '');
+        }, self::$_arr_node_map)) . ($this->getAuth() ? '&auth=' . $this->getAuth() : '');
     }
 }
 ?>

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -56,8 +56,8 @@ class Redis_Test extends TestSuite
     protected function getFullHostPath()
     {
         $fullHostPath = parent::getFullHostPath();
-        if (isset($fullHostPath) && self::AUTH) {
-            $fullHostPath .= '?auth=' . self::AUTH;
+        if (isset($fullHostPath) && $this->getAuth()) {
+            $fullHostPath .= '?auth=' . $this->getAuth();
         }
         return $fullHostPath;
     }
@@ -67,8 +67,8 @@ class Redis_Test extends TestSuite
 
         $r->connect($this->getHost(), self::PORT);
 
-        if(self::AUTH) {
-            $this->assertTrue($r->auth(self::AUTH));
+        if($this->getAuth()) {
+            $this->assertTrue($r->auth($this->getAuth()));
         }
         return $r;
     }
@@ -4923,7 +4923,7 @@ class Redis_Test extends TestSuite
         // Simple introspection tests
         $this->assertTrue($this->redis->getHost() === $this->getHost());
         $this->assertTrue($this->redis->getPort() === self::PORT);
-        $this->assertTrue($this->redis->getAuth() === self::AUTH);
+        $this->assertTrue($this->redis->getAuth() === $this->getAuth());
     }
 
     /**
@@ -5951,8 +5951,8 @@ class Redis_Test extends TestSuite
                 } else {
                     @$obj_r->connect($arr_args[0]);
                 }
-                if (self::AUTH) {
-                    $this->assertTrue($obj_r->auth(self::AUTH));
+                if ($this->getAuth()) {
+                    $this->assertTrue($obj_r->auth($this->getAuth()));
                 }
                 $this->assertTrue($obj_r->ping());
             }
@@ -5980,8 +5980,8 @@ class Redis_Test extends TestSuite
             $obj_r = new Redis();
             try {
                 @$obj_r->connect('localhost', $port);
-                if (self::AUTH) {
-                    $this->assertTrue($obj_r->auth(self::AUTH));
+                if ($this->getAuth()) {
+                    $this->assertTrue($obj_r->auth($this->getAuth()));
                 }
                 $this->assertTrue($obj_r->ping());
             } catch(Exception $ex) {
@@ -6168,8 +6168,8 @@ class Redis_Test extends TestSuite
 
         for($i = 0; $i < 5; $i++) {
             $this->redis->connect($host, $port);
-            if (self::AUTH) {
-                $this->assertTrue($this->redis->auth(self::AUTH));
+            if ($this->getAuth()) {
+                $this->assertTrue($this->redis->auth($this->getAuth()));
             }
             $this->assertTrue($this->redis->ping());
         }

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -11,7 +11,7 @@ error_reporting(E_ALL);
 ini_set( 'display_errors','1');
 
 /* Grab options */
-$arr_args = getopt('', ['host:', 'class:', 'test:', 'nocolors']);
+$arr_args = getopt('', ['host:', 'class:', 'test:', 'nocolors', 'auth:']);
 
 /* Grab the test the user is trying to run */
 $arr_valid_classes = ['redis', 'redisarray', 'rediscluster', 'redissentinel'];
@@ -23,6 +23,9 @@ $str_filter = isset($arr_args['test']) ? $arr_args['test'] : NULL;
 
 /* Grab override test host if it was passed */
 $str_host = isset($arr_args['host']) ? $arr_args['host'] : '127.0.0.1';
+
+/* Grab redis authentication password */
+$str_auth = isset($arr_args['auth']) ? $arr_args['auth'] : NULL;
 
 /* Validate the class is known */
 if (!in_array($str_class, $arr_valid_classes)) {
@@ -41,7 +44,7 @@ echo "Using PHP version " . PHP_VERSION . " (" . (PHP_INT_SIZE*8) . " bits)\n";
 echo "Testing class ";
 if ($str_class == 'redis') {
     echo TestSuite::make_bold("Redis") . "\n";
-    exit(TestSuite::run("Redis_Test", $str_filter, $str_host));
+    exit(TestSuite::run("Redis_Test", $str_filter, $str_host, $str_auth));
 } else if ($str_class == 'redisarray') {
     echo TestSuite::make_bold("RedisArray") . "\n";
     global $useIndex;
@@ -52,16 +55,16 @@ if ($str_class == 'redis') {
         $arr_ra_tests = ['Redis_Array_Test', 'Redis_Rehashing_Test', 'Redis_Auto_Rehashing_Test', 'Redis_Multi_Exec_Test', 'Redis_Distributor_Test'];
         foreach ($arr_ra_tests as $str_test) {
             /* Run until we encounter a failure */
-            if (run_tests($str_test, $str_filter, $str_host) != 0) {
+            if (run_tests($str_test, $str_filter, $str_host, $str_auth) != 0) {
                 exit(1);
             }
         }
     }
 } else if ($str_class == 'rediscluster') {
     echo TestSuite::make_bold("RedisCluster") . "\n";
-    exit(TestSuite::run("Redis_Cluster_Test", $str_filter, $str_host));
+    exit(TestSuite::run("Redis_Cluster_Test", $str_filter, $str_host, $str_auth));
 } else {
     echo TestSuite::make_bold("RedisSentinel") . "\n";
-    exit(TestSuite::run("Redis_Sentinel_Test", $str_filter, $str_host));
+    exit(TestSuite::run("Redis_Sentinel_Test", $str_filter, $str_host, $str_auth));
 }
 ?>

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -6,10 +6,11 @@ class TestSkippedException extends Exception {}
 // phpunit is such a pain to install, we're going with pure-PHP here.
 class TestSuite
 {
-    const AUTH = 'phpredis'; //replace with a string to use Redis authentication
-
     /* Host the tests will use */
     private $str_host;
+
+    /* Redis authentication we'll use */
+    private $str_auth;
 
     private static $_boo_colorize = false;
 
@@ -27,11 +28,13 @@ class TestSuite
     public static $errors = [];
     public static $warnings = [];
 
-    public function __construct($str_host) {
+    public function __construct($str_host, $str_auth) {
         $this->str_host = $str_host;
+        $this->str_auth = $str_auth;
     }
 
     public function getHost() { return $this->str_host; }
+    public function getAuth() { return $this->str_auth; }
 
     /**
      * Returns the fully qualified host path,
@@ -154,7 +157,7 @@ class TestSuite
             posix_isatty(STDOUT);
     }
 
-    public static function run($className, $str_limit = NULL, $str_host = NULL) {
+    public static function run($className, $str_limit = NULL, $str_host = NULL, $str_auth = NULL) {
         /* Lowercase our limit arg if we're passed one */
         $str_limit = $str_limit ? strtolower($str_limit) : $str_limit;
 
@@ -178,7 +181,7 @@ class TestSuite
             echo self::make_bold($str_out_name);
 
             $count = count($className::$errors);
-            $rt = new $className($str_host);
+            $rt = new $className($str_host, $str_auth);
 
             try {
                 $rt->setUp();


### PR DESCRIPTION
Right now cloning the repo and running unit tests will all fail if the
Redis/RedisCluster instances aren't configured with the password
'phpredis'.

This commit simply makes authentication during the tests optional via a
command-line argument.