### PR TITLE
fix [-Wformat=] warning on 32-bit

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -552,7 +552,7 @@ unsigned short cluster_hash_key_zval(zval *z_key) {
             klen = Z_STRLEN_P(z_key);
             break;
         case IS_LONG:
-            klen = snprintf(buf,sizeof(buf),"%ld",Z_LVAL_P(z_key));
+            klen = snprintf(buf,sizeof(buf),ZEND_LONG_FMT,Z_LVAL_P(z_key));
             kptr = (const char *)buf;
             break;
         case IS_DOUBLE:

--- a/redis_array.c
+++ b/redis_array.c
@@ -926,7 +926,7 @@ PHP_METHOD(RedisArray, mget)
             key_len = Z_STRLEN_P(data);
             key_lookup = Z_STRVAL_P(data);
         } else {
-            key_len = snprintf(kbuf, sizeof(kbuf), "%ld", Z_LVAL_P(data));
+            key_len = snprintf(kbuf, sizeof(kbuf), ZEND_LONG_FMT, Z_LVAL_P(data));
             key_lookup = (char*)kbuf;
         }
 
@@ -1052,7 +1052,7 @@ PHP_METHOD(RedisArray, mset)
             key_len = ZSTR_LEN(zkey);
             key = ZSTR_VAL(zkey);
         } else {
-            key_len = snprintf(kbuf, sizeof(kbuf), "%lu", idx);
+            key_len = snprintf(kbuf, sizeof(kbuf), ZEND_ULONG_FMT, idx);
             key = kbuf;
         }
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2245,7 +2245,7 @@ cluster_cmd_get_slot(redisCluster *c, zval *z_arg)
 
         /* Inform the caller if they've passed bad data */
         if (slot < 0) {
-            php_error_docref(0, E_WARNING, "Unknown node %s:%ld",
+            php_error_docref(0, E_WARNING, "Unknown node %s:" ZEND_LONG_FMT,
                 Z_STRVAL_P(z_host), Z_LVAL_P(z_port));
         }
     } else {


### PR DESCRIPTION
```
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_array.c: In function 'zim_RedisArray_mget':
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_array.c:944:55: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'zend_long' {aka 'int'} [-Wformat=]
  944 |             key_len = snprintf(kbuf, sizeof(kbuf), "%ld", Z_LVAL_P(data));
      |                                                     ~~^
      |                                                       |
      |                                                       long int
      |                                                     %d
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_array.c: In function 'zim_RedisArray_mset':
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_array.c:1070:55: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'zend_ulong' {aka 'unsigned int'} [-Wformat=]
 1070 |             key_len = snprintf(kbuf, sizeof(kbuf), "%lu", idx);
      |                                                     ~~^   ~~~
      |                                                       |   |
      |                                                       |   zend_ulong {aka unsigned int}
      |                                                       long unsigned int
      |                                                     %u
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/cluster_library.c: In function 'cluster_hash_key_zval':
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/cluster_library.c:566:48: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'zend_long' {aka 'int'} [-Wformat=]
  566 |             klen = snprintf(buf,sizeof(buf),"%ld",Z_LVAL_P(z_key));
      |                                              ~~^
      |                                                |
      |                                                long int
      |                                              %d
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_cluster.c: In function 'cluster_cmd_get_slot':
/builddir/build/BUILD/php-pecl-redis5-5.2.2/NTS/redis_cluster.c:2247:63: warning: format '%ld' expects argument of type 'long int', but argument 5 has type 'zend_long' {aka 'int'} [-Wformat=]
 2247 |             php_error_docref(0, E_WARNING, "Unknown node %s:%ld",
      |                                                             ~~^
      |                                                               |
      |                                                               long int
      |                                                             %d

```