### PR TITLE
For regular strings avoid igbinary serialization overhead

### DIFF
--- a/common.h
+++ b/common.h
@@ -80,6 +80,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_COMPRESSION        7
 #define REDIS_OPT_REPLY_LITERAL      8
 #define REDIS_OPT_COMPRESSION_LEVEL  9
+#define REDIS_OPT_IGBINARY_NO_STRINGS    10
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -259,6 +260,7 @@ typedef struct {
     zend_string       *persistent_id;
 
     redis_serializer  serializer;
+    int               no_strings;
     int               compression;
     int               compression_level;
     long              dbNumber;

--- a/library.c
+++ b/library.c
@@ -2445,7 +2445,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
             if (Z_TYPE_P(z) == IS_STRING) {
                 *val = Z_STRVAL_P(z);
                 *val_len = Z_STRLEN_P(z);
-                return 1;
+                return 0;
             }
             if(igbinary_serialize(&val8, (size_t *)&sz, z) == 0) {
                 *val = (char*)val8;

--- a/library.c
+++ b/library.c
@@ -2442,6 +2442,11 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len
             break;
         case REDIS_SERIALIZER_IGBINARY:
 #ifdef HAVE_REDIS_IGBINARY
+            if (Z_TYPE_P(z) == IS_STRING) {
+                *val = Z_STRVAL_P(z);
+                *val_len = Z_STRLEN_P(z);
+                return 1;
+            }
             if(igbinary_serialize(&val8, (size_t *)&sz, z) == 0) {
                 *val = (char*)val8;
                 *val_len = sz;

--- a/library.c
+++ b/library.c
@@ -2518,6 +2518,10 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
                     || (memcmp(val, "\x00\x00\x00\x01", 4) != 0
                     && memcmp(val, "\x00\x00\x00\x02", 4) != 0))
             {
+                if (*val != '\0') {
+                    ZVAL_STRINGL(z_ret, val, val_len);
+                    return 1;
+                }
                 /* This is most definitely not an igbinary string, so do
                    not try to unserialize this as one. */
                 break;

--- a/redis.c
+++ b/redis.c
@@ -697,6 +697,7 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster) {
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_PHP"), REDIS_SERIALIZER_PHP);
 #ifdef HAVE_REDIS_IGBINARY
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_IGBINARY_NO_STRINGS"), REDIS_OPT_IGBINARY_NO_STRINGS);
 #endif
 #ifdef HAVE_REDIS_MSGPACK
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_MSGPACK"), REDIS_SERIALIZER_MSGPACK);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3908,6 +3908,10 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
     switch(option) {
         case REDIS_OPT_SERIALIZER:
             RETURN_LONG(redis_sock->serializer);
+#ifdef HAVE_REDIS_IGBINARY
+        case REDIS_OPT_IGBINARY_NO_STRINGS:
+            RETURN_LONG(redis_sock->no_strings);
+#endif
         case REDIS_OPT_COMPRESSION:
             RETURN_LONG(redis_sock->compression);
         case REDIS_OPT_COMPRESSION_LEVEL:
@@ -3969,6 +3973,12 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             val_long = zval_get_long(val);
             redis_sock->reply_literal = val_long != 0;
             RETURN_TRUE;
+#ifdef HAVE_REDIS_IGBINARY
+        case REDIS_OPT_IGBINARY_NO_STRINGS:
+            val_long = zval_get_long(val);
+            redis_sock->no_strings = val_long != 0;
+            RETURN_TRUE;
+#endif
         case REDIS_OPT_COMPRESSION:
             val_long = zval_get_long(val);
             if (val_long == REDIS_COMPRESSION_NONE

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4480,6 +4480,18 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_NONE);       // get ok
     }
 
+    public function testIgbinaryNoStrings()
+    {
+        if (!defined('Redis::OPT_IGBINARY_NO_STRINGS')) {
+            $this->markTestSkipped();
+        }
+        $this->assertTrue($this->redis->setOption(Redis::OPT_IGBINARY_NO_STRINGS, true));
+        $this->assertTrue($this->redis->getOption(Redis::OPT_IGBINARY_NO_STRINGS));
+
+        var_dump($this->redis->set("no_binary", "test string"));
+        $this->assertEquals($this->redis->rawCommand('get', 'no_binary'), "test string");
+    }
+
     public function testCompressionLZF()
     {
         if (!defined('Redis::COMPRESSION_LZF')) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4488,7 +4488,7 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->setOption(Redis::OPT_IGBINARY_NO_STRINGS, true));
         $this->assertTrue($this->redis->getOption(Redis::OPT_IGBINARY_NO_STRINGS));
 
-        var_dump($this->redis->set("no_binary", "test string"));
+        $this->assertTrue($this->redis->set("no_binary", "test string"));
         $this->assertEquals($this->redis->rawCommand('get', 'no_binary'), "test string");
     }
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4489,7 +4489,7 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->getOption(Redis::OPT_IGBINARY_NO_STRINGS));
 
         $this->assertTrue($this->redis->set("no_binary", "test string"));
-        $this->assertEquals($this->redis->rawCommand('get', 'no_binary'), "test string");
+        $this->assertEquals($this->redis->get('no_binary'), "test string");
     }
 
     public function testCompressionLZF()


### PR DESCRIPTION
This simple change ensures that string data is stored as is without introducing overhead in speed/memory involved in serialization/deserialization steps.