### PR TITLE
Added ability to set compression minimums

### DIFF
--- a/common.h
+++ b/common.h
@@ -71,15 +71,17 @@ typedef enum _PUBSUB_TYPE {
 } PUBSUB_TYPE;
 
 /* options */
-#define REDIS_OPT_SERIALIZER         1
-#define REDIS_OPT_PREFIX             2
-#define REDIS_OPT_READ_TIMEOUT       3
-#define REDIS_OPT_SCAN               4
-#define REDIS_OPT_FAILOVER           5
-#define REDIS_OPT_TCP_KEEPALIVE      6
-#define REDIS_OPT_COMPRESSION        7
-#define REDIS_OPT_REPLY_LITERAL      8
-#define REDIS_OPT_COMPRESSION_LEVEL  9
+#define REDIS_OPT_SERIALIZER            1
+#define REDIS_OPT_PREFIX                2
+#define REDIS_OPT_READ_TIMEOUT          3
+#define REDIS_OPT_SCAN                  4
+#define REDIS_OPT_FAILOVER              5
+#define REDIS_OPT_TCP_KEEPALIVE         6
+#define REDIS_OPT_COMPRESSION           7
+#define REDIS_OPT_REPLY_LITERAL         8
+#define REDIS_OPT_COMPRESSION_LEVEL     9
+#define REDIS_OPT_COMPRESSION_MIN_SIZE  10
+#define REDIS_OPT_COMPRESSION_MIN_RATIO 11
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -261,6 +263,8 @@ typedef struct {
     redis_serializer  serializer;
     int               compression;
     int               compression_level;
+    int               compression_min_size;
+    double            compression_min_ratio;
     long              dbNumber;
 
     zend_string       *prefix;

--- a/library.c
+++ b/library.c
@@ -2267,7 +2267,7 @@ redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len)
     size_t len;
 
     valfree = redis_serialize(redis_sock, z, &buf, &len);
-    if (redis_sock->compression && len >= redis_sock->compression_min_size) {
+    if (redis_sock->compression && redis_sock->compression_min_size > 0 && len < redis_sock->compression_min_size) {
         *val = buf;
         *val_len = len;
         return valfree;

--- a/library.c
+++ b/library.c
@@ -2367,13 +2367,16 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret)
 #ifdef HAVE_REDIS_ZSTD
             {
                 char *data;
-                size_t len;
+                long long len;
 
-                if (redis_sock->compression_min_size > 0 && !ZSTD_isFrame(val, val_len)) {
+                len = ZSTD_getFrameContentSize(val, val_len);
+                if (
+                    (redis_sock->compression_min_ratio > 0 || redis_sock->compression_min_size > 0)
+                    && (len == ZSTD_CONTENTSIZE_UNKNOWN || len == ZSTD_CONTENTSIZE_ERROR || len <= 0)
+                ) {
                     return redis_unserialize(redis_sock, val, val_len, z_ret);
                 }
 
-                len = ZSTD_getFrameContentSize(val, val_len);
                 if (len >= 0) {
                     data = emalloc(len);
                     len = ZSTD_decompress(data, len, val, val_len);

--- a/redis.c
+++ b/redis.c
@@ -691,6 +691,8 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster) {
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_REPLY_LITERAL"), REDIS_OPT_REPLY_LITERAL);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_LEVEL"), REDIS_OPT_COMPRESSION_LEVEL);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_MIN_SIZE"), REDIS_OPT_COMPRESSION_MIN_SIZE);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_MIN_RATIO"), REDIS_OPT_COMPRESSION_MIN_RATIO);
 
     /* serializer */
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3912,6 +3912,10 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->compression);
         case REDIS_OPT_COMPRESSION_LEVEL:
             RETURN_LONG(redis_sock->compression_level);
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            RETURN_LONG(redis_sock->compression_min_size)
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            RETURN_DOUBLE(redis_sock->compression_min_ratio)
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 RETURN_STRINGL(ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
@@ -3983,6 +3987,13 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 RETURN_TRUE;
             }
             break;
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            val_long = zval_get_long(val);
+            redis_sock->compression_min_size = val_long;
+            RETURN_TRUE;
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            redis_sock->compression_min_ratio = zval_get_double(val);
+            RETURN_TRUE;
         case REDIS_OPT_COMPRESSION_LEVEL:
             val_long = zval_get_long(val);
             redis_sock->compression_level = val_long;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4488,6 +4488,56 @@ class Redis_Test extends TestSuite
         $this->checkCompression(Redis::COMPRESSION_LZF, 0);
     }
 
+    public function testCompressionLZFLimited()
+    {
+        if (!defined('Redis::COMPRESSION_LZF')) {
+            $this->markTestSkipped();
+        }
+
+        $checks = [
+            "test123"            => strlen("test123"),
+            str_repeat('a', 101) => 9,
+            random_bytes(110)    => 110,
+        ];
+
+        $this->limitedCompressionCheck($checks, Redis::COMPRESSION_LZF);
+    }
+
+    public function testCompressionZSTDLimited()
+    {
+        if (!defined('Redis::COMPRESSION_ZSTD')) {
+            $this->markTestSkipped();
+        }
+
+        $checks = [
+            "test123"            => strlen("test123"),
+            str_repeat('a', 101) => 17,
+            random_bytes(110)    => 110,
+        ];
+
+        $this->limitedCompressionCheck($checks, Redis::COMPRESSION_ZSTD);
+    }
+
+    private function limitedCompressionCheck($checks, $mode)
+    {
+        $settings = [
+            Redis::OPT_COMPRESSION => $mode,
+            Redis::OPT_COMPRESSION_MIN_SIZE => 100,
+            Redis::OPT_COMPRESSION_MIN_RATIO => 0.3,
+            Redis::OPT_COMPRESSION_LEVEL => 0
+        ];
+        foreach ($settings as $k => $v) {
+            $this->assertTrue($this->redis->setOption($k, $v));
+            $this->assertEquals($this->redis->getOption($k), $v);
+        }
+
+        foreach ($checks as $v => $len) {
+            $this->assertTrue($this->redis->set('foo', $v));
+            $this->assertEquals($this->redis->get('foo'), $v);
+            $this->assertEquals($this->redis->strlen('foo'), $len);
+        }
+    }
+
     public function testCompressionZSTD()
     {
         if (!defined('Redis::COMPRESSION_ZSTD')) {


### PR DESCRIPTION
To optimize compression 2 new limits were added. Length based limit to prevent compression from being used on short strings and minimum compression ratio limit to prevent decompression overhead when benefit of compression is below minimum threshold.