### PR TITLE
Added support for LZ4 Compression

### DIFF
--- a/common.h
+++ b/common.h
@@ -71,15 +71,17 @@ typedef enum _PUBSUB_TYPE {
 } PUBSUB_TYPE;
 
 /* options */
-#define REDIS_OPT_SERIALIZER         1
-#define REDIS_OPT_PREFIX             2
-#define REDIS_OPT_READ_TIMEOUT       3
-#define REDIS_OPT_SCAN               4
-#define REDIS_OPT_FAILOVER           5
-#define REDIS_OPT_TCP_KEEPALIVE      6
-#define REDIS_OPT_COMPRESSION        7
-#define REDIS_OPT_REPLY_LITERAL      8
-#define REDIS_OPT_COMPRESSION_LEVEL  9
+#define REDIS_OPT_SERIALIZER            1
+#define REDIS_OPT_PREFIX                2
+#define REDIS_OPT_READ_TIMEOUT          3
+#define REDIS_OPT_SCAN                  4
+#define REDIS_OPT_FAILOVER              5
+#define REDIS_OPT_TCP_KEEPALIVE         6
+#define REDIS_OPT_COMPRESSION           7
+#define REDIS_OPT_REPLY_LITERAL         8
+#define REDIS_OPT_COMPRESSION_LEVEL     9
+#define REDIS_OPT_COMPRESSION_MIN_SIZE  10
+#define REDIS_OPT_COMPRESSION_MIN_RATIO 11
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -261,6 +263,8 @@ typedef struct {
     redis_serializer  serializer;
     int               compression;
     int               compression_level;
+    int               compression_min_size;
+    double            compression_min_ratio;
     long              dbNumber;
 
     zend_string       *prefix;

--- a/common.h
+++ b/common.h
@@ -100,6 +100,7 @@ typedef enum {
 #define REDIS_COMPRESSION_NONE 0
 #define REDIS_COMPRESSION_LZF  1
 #define REDIS_COMPRESSION_ZSTD 2
+#define REDIS_COMPRESSION_LZ4 3
 
 /* SCAN options */
 #define REDIS_SCAN_NORETRY 0

--- a/library.c
+++ b/library.c
@@ -2267,7 +2267,7 @@ redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len)
     size_t len;
 
     valfree = redis_serialize(redis_sock, z, &buf, &len);
-    if (redis_sock->compression && len >= redis_sock->compression_min_size) {
+    if (redis_sock->compression && redis_sock->compression_min_size > 0 && len < redis_sock->compression_min_size) {
         *val = buf;
         *val_len = len;
         return valfree;

--- a/library.c
+++ b/library.c
@@ -2367,13 +2367,16 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret)
 #ifdef HAVE_REDIS_ZSTD
             {
                 char *data;
-                size_t len;
+                long long len;
 
-                if (redis_sock->compression_min_size > 0 && !ZSTD_isFrame(val, val_len)) {
+                len = ZSTD_getFrameContentSize(val, val_len);
+                if (
+                    (redis_sock->compression_min_ratio > 0 || redis_sock->compression_min_size > 0)
+                    && (len == ZSTD_CONTENTSIZE_UNKNOWN || len == ZSTD_CONTENTSIZE_ERROR || len <= 0)
+                ) {
                     return redis_unserialize(redis_sock, val, val_len, z_ret);
                 }
 
-                len = ZSTD_getFrameContentSize(val, val_len);
                 if (len >= 0) {
                     data = emalloc(len);
                     len = ZSTD_decompress(data, len, val, val_len);

--- a/library.c
+++ b/library.c
@@ -2463,8 +2463,6 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret)
                 if (res > 0) {
                     if (redis_unserialize(redis_sock, data, size, z_ret) == 0) {
                         ZVAL_STRINGL(z_ret, data, size);
-                    } else {
-                        ZVAL_STRINGL(z_ret, data, size);
                     }
                     efree(data);
                     return 1;

--- a/library.c
+++ b/library.c
@@ -2359,7 +2359,7 @@ redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len)
                 size = LZ4_compressBound(len) + offset;
                 data = emalloc(size + offset);
                 data[0] = '\0';
-                memcpy(data + 1, &old_len, offset);
+                memcpy(data + 1, &old_len, sizeof(int));
 
                 if (redis_sock->compression_level <= 0 || redis_sock->compression_level > REDIS_LZ4_MAX_CLEVEL) {
                     size = LZ4_compress_default(buf, data + offset, len, size - offset - 1);

--- a/redis.c
+++ b/redis.c
@@ -40,6 +40,10 @@
 #include <zstd.h>
 #endif
 
+#ifdef HAVE_REDIS_LZ4
+#include <lz4.h>
+#endif
+
 #ifdef PHP_SESSION
 extern ps_module ps_mod_redis;
 extern ps_module ps_mod_redis_cluster;
@@ -721,6 +725,10 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster) {
     zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_ZSTD_MAX"), ZSTD_maxCLevel());
 #endif
 
+#ifdef HAVE_REDIS_LZ4
+    zend_declare_class_constant_long(ce, ZEND_STRL("COMPRESSION_LZ4"), REDIS_COMPRESSION_LZ4);
+#endif
+
     /* scan options*/
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_SCAN"), REDIS_OPT_SCAN);
     zend_declare_class_constant_long(ce, ZEND_STRL("SCAN_RETRY"), REDIS_SCAN_RETRY);
@@ -894,6 +902,12 @@ PHP_MINFO_FUNCTION(redis)
         smart_str_appends(&names, ", ");
     }
     smart_str_appends(&names, "zstd");
+#endif
+#ifdef HAVE_REDIS_LZ4
+    if (names.s) {
+        smart_str_appends(&names, ", ");
+    }
+    smart_str_appends(&names, "lz4");
 #endif
     if (names.s) {
         smart_str_0(&names);

--- a/redis.c
+++ b/redis.c
@@ -691,6 +691,8 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster) {
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_REPLY_LITERAL"), REDIS_OPT_REPLY_LITERAL);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_LEVEL"), REDIS_OPT_COMPRESSION_LEVEL);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_MIN_SIZE"), REDIS_OPT_COMPRESSION_MIN_SIZE);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_MIN_RATIO"), REDIS_OPT_COMPRESSION_MIN_RATIO);
 
     /* serializer */
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3982,6 +3982,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
 #ifdef HAVE_REDIS_ZSTD
                 || val_long == REDIS_COMPRESSION_ZSTD
 #endif
+#ifdef HAVE_REDIS_LZ4
+                || val_long == REDIS_COMPRESSION_LZ4
+#endif
             ) {
                 redis_sock->compression = val_long;
                 RETURN_TRUE;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3912,6 +3912,10 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->compression);
         case REDIS_OPT_COMPRESSION_LEVEL:
             RETURN_LONG(redis_sock->compression_level);
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            RETURN_LONG(redis_sock->compression_min_size)
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            RETURN_DOUBLE(redis_sock->compression_min_ratio)
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 RETURN_STRINGL(ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
@@ -3983,6 +3987,13 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 RETURN_TRUE;
             }
             break;
+        case REDIS_OPT_COMPRESSION_MIN_SIZE:
+            val_long = zval_get_long(val);
+            redis_sock->compression_min_size = val_long;
+            RETURN_TRUE;
+        case REDIS_OPT_COMPRESSION_MIN_RATIO:
+            redis_sock->compression_min_ratio = zval_get_double(val);
+            RETURN_TRUE;
         case REDIS_OPT_COMPRESSION_LEVEL:
             val_long = zval_get_long(val);
             redis_sock->compression_level = val_long;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4488,6 +4488,56 @@ class Redis_Test extends TestSuite
         $this->checkCompression(Redis::COMPRESSION_LZF, 0);
     }
 
+    public function testCompressionLZFLimited()
+    {
+        if (!defined('Redis::COMPRESSION_LZF')) {
+            $this->markTestSkipped();
+        }
+
+        $checks = [
+            "test123"            => strlen("test123"),
+            str_repeat('a', 101) => 9,
+            random_bytes(110)    => 110,
+        ];
+
+        $this->limitedCompressionCheck($checks, Redis::COMPRESSION_LZF);
+    }
+
+    public function testCompressionZSTDLimited()
+    {
+        if (!defined('Redis::COMPRESSION_ZSTD')) {
+            $this->markTestSkipped();
+        }
+
+        $checks = [
+            "test123"            => strlen("test123"),
+            str_repeat('a', 101) => 17,
+            random_bytes(110)    => 110,
+        ];
+
+        $this->limitedCompressionCheck($checks, Redis::COMPRESSION_ZSTD);
+    }
+
+    private function limitedCompressionCheck($checks, $mode)
+    {
+        $settings = [
+            Redis::OPT_COMPRESSION => $mode,
+            Redis::OPT_COMPRESSION_MIN_SIZE => 100,
+            Redis::OPT_COMPRESSION_MIN_RATIO => 0.3,
+            Redis::OPT_COMPRESSION_LEVEL => 0
+        ];
+        foreach ($settings as $k => $v) {
+            $this->assertTrue($this->redis->setOption($k, $v));
+            $this->assertEquals($this->redis->getOption($k), $v);
+        }
+
+        foreach ($checks as $v => $len) {
+            $this->assertTrue($this->redis->set('foo', $v));
+            $this->assertEquals($this->redis->get('foo'), $v);
+            $this->assertEquals($this->redis->strlen('foo'), $len);
+        }
+    }
+
     public function testCompressionZSTD()
     {
         if (!defined('Redis::COMPRESSION_ZSTD')) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4488,6 +4488,25 @@ class Redis_Test extends TestSuite
         $this->checkCompression(Redis::COMPRESSION_LZF, 0);
     }
 
+    public function testCompressionZSTD()
+    {
+        if (!defined('Redis::COMPRESSION_ZSTD')) {
+            $this->markTestSkipped();
+        }
+        $this->checkCompression(Redis::COMPRESSION_ZSTD, 0);
+        $this->checkCompression(Redis::COMPRESSION_ZSTD, 9);
+    }
+
+
+    public function testCompressionLZ4()
+    {
+        if (!defined('Redis::COMPRESSION_LZ4')) {
+            $this->markTestSkipped();
+        }
+        $this->checkCompression(Redis::COMPRESSION_LZ4, 0);
+        $this->checkCompression(Redis::COMPRESSION_LZ4, 9);
+    }
+
     public function testCompressionLZFLimited()
     {
         if (!defined('Redis::COMPRESSION_LZF')) {
@@ -4518,6 +4537,21 @@ class Redis_Test extends TestSuite
         $this->limitedCompressionCheck($checks, Redis::COMPRESSION_ZSTD);
     }
 
+    public function testCompressionLZ4Limited()
+    {
+        if (!defined('Redis::COMPRESSION_LZ4')) {
+            $this->markTestSkipped();
+        }
+
+        $checks = [
+            "test123"            => strlen("test123"),
+            str_repeat('a', 101) => 16,
+            random_bytes(110)    => 110,
+        ];
+
+        $this->limitedCompressionCheck($checks, Redis::COMPRESSION_LZ4);
+    }
+
     private function limitedCompressionCheck($checks, $mode)
     {
         $settings = [
@@ -4536,15 +4570,6 @@ class Redis_Test extends TestSuite
             $this->assertEquals($this->redis->get('foo'), $v);
             $this->assertEquals($this->redis->strlen('foo'), $len);
         }
-    }
-
-    public function testCompressionZSTD()
-    {
-        if (!defined('Redis::COMPRESSION_ZSTD')) {
-            $this->markTestSkipped();
-        }
-        $this->checkCompression(Redis::COMPRESSION_ZSTD, 0);
-        $this->checkCompression(Redis::COMPRESSION_ZSTD, 9);
     }
 
     private function checkCompression($mode, $level)


### PR DESCRIPTION
This builds on top of an earlier patch that adds size & compression ration limits.

The main part here is to add support for very fast lz4 compression algorithm, it is considerably faster then zstd (https://facebook.github.io/zstd/)