### PR TITLE
Fixed crash with clone of Redis object

### DIFF
--- a/common.h
+++ b/common.h
@@ -289,6 +289,7 @@ typedef struct {
 typedef struct {
     RedisSock *sock;
     zend_object std;
+    int clone;
 } redis_object;
 
 /** Argument info for any function expecting 0 args */

--- a/common.h
+++ b/common.h
@@ -278,6 +278,8 @@ typedef struct {
     int               readonly;
     int               reply_literal;
     int               tcp_keepalive;
+    
+    int               clone;
 } RedisSock;
 /* }}} */
 
@@ -289,7 +291,6 @@ typedef struct {
 typedef struct {
     RedisSock *sock;
     zend_object std;
-    int clone;
 } redis_object;
 
 /** Argument info for any function expecting 0 args */

--- a/library.c
+++ b/library.c
@@ -1993,7 +1993,7 @@ redis_sock_disconnect(RedisSock *redis_sock, int force)
 {
     if (redis_sock == NULL) {
         return FAILURE;
-    } else if (redis_sock->stream) {
+    } else if (redis_sock->stream && !redis_sock->clone) {
         if (redis_sock->persistent) {
             ConnectionPool *p = NULL;
             if (INI_INT("redis.pconnect.pooling_enabled")) {

--- a/redis.c
+++ b/redis.c
@@ -570,7 +570,7 @@ free_redis_object(zend_object *object)
     redis_object *redis = (redis_object *)((char *)(object) - XtOffsetOf(redis_object, std));
 
     zend_object_std_dtor(&redis->std);
-    if (redis->sock && !redis->clone) {
+    if (redis->sock) {
         redis_sock_disconnect(redis->sock, 0);
         redis_free_socket(redis->sock);
     }
@@ -586,7 +586,7 @@ clone_redis_object(zval *this_ptr)
     if (old_redis->sock) {
         redis->sock = ecalloc(1, sizeof(RedisSock));
         redis->sock = memcpy(redis->sock, old_redis->sock, sizeof(RedisSock));
-        redis->clone = 1;
+        redis->sock->clone = 1;
     }
 
     zend_object_std_init(&redis->std, old_object->ce);

--- a/redis.c
+++ b/redis.c
@@ -570,10 +570,35 @@ free_redis_object(zend_object *object)
     redis_object *redis = (redis_object *)((char *)(object) - XtOffsetOf(redis_object, std));
 
     zend_object_std_dtor(&redis->std);
-    if (redis->sock) {
+    if (redis->sock && !redis->clone) {
         redis_sock_disconnect(redis->sock, 0);
         redis_free_socket(redis->sock);
     }
+}
+
+static zend_object *
+clone_redis_object(zval *this_ptr)
+{
+    zend_object *old_object = Z_OBJ_P(this_ptr);
+    redis_object *old_redis = PHPREDIS_GET_OBJECT(redis_object, this_ptr);
+    redis_object *redis = ecalloc(1, sizeof(redis_object) + zend_object_properties_size(old_object->ce));
+
+    if (old_redis->sock) {
+        redis->sock = ecalloc(1, sizeof(RedisSock));
+        redis->sock = memcpy(redis->sock, old_redis->sock, sizeof(RedisSock));
+        redis->clone = 1;
+    }
+
+    zend_object_std_init(&redis->std, old_object->ce);
+    object_properties_init(&redis->std, old_object->ce);
+
+    memcpy(&redis_object_handlers, zend_get_std_object_handlers(), sizeof(redis_object_handlers));
+    redis_object_handlers.offset = XtOffsetOf(redis_object, std);
+    redis_object_handlers.free_obj = free_redis_object;
+    redis_object_handlers.clone_obj = clone_redis_object;
+    redis->std.handlers = &redis_object_handlers;
+
+    return &redis->std;
 }
 
 zend_object *
@@ -589,6 +614,7 @@ create_redis_object(zend_class_entry *ce)
     memcpy(&redis_object_handlers, zend_get_std_object_handlers(), sizeof(redis_object_handlers));
     redis_object_handlers.offset = XtOffsetOf(redis_object, std);
     redis_object_handlers.free_obj = free_redis_object;
+    redis_object_handlers.clone_obj = clone_redis_object;
     redis->std.handlers = &redis_object_handlers;
 
     return &redis->std;

--- a/redis_array.c
+++ b/redis_array.c
@@ -200,6 +200,7 @@ create_redis_array_object(zend_class_entry *ce)
     memcpy(&redis_array_object_handlers, zend_get_std_object_handlers(), sizeof(redis_array_object_handlers));
     redis_array_object_handlers.offset = XtOffsetOf(redis_array_object, std);
     redis_array_object_handlers.free_obj = free_redis_array_object;
+    redis_array_object_handlers.clone_obj = NULL;
     obj->std.handlers = &redis_array_object_handlers;
 
     return &obj->std;

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -326,6 +326,7 @@ zend_object * create_cluster_context(zend_class_entry *class_type) {
     memcpy(&RedisCluster_handlers, zend_get_std_object_handlers(), sizeof(RedisCluster_handlers));
     RedisCluster_handlers.offset = XtOffsetOf(redisCluster, std);
     RedisCluster_handlers.free_obj = free_cluster_context;
+    RedisCluster_handlers.clone_obj = NULL;
 
     cluster->std.handlers = &RedisCluster_handlers;
 

--- a/sentinel_library.c
+++ b/sentinel_library.c
@@ -25,6 +25,7 @@ create_sentinel_object(zend_class_entry *ce)
     memcpy(&redis_sentinel_object_handlers, zend_get_std_object_handlers(), sizeof(redis_sentinel_object_handlers));
     redis_sentinel_object_handlers.offset = XtOffsetOf(redis_sentinel_object, std);
     redis_sentinel_object_handlers.free_obj = free_redis_sentinel_object;
+    redis_sentinel_object_handlers.clone_obj = NULL;
     obj->std.handlers = &redis_sentinel_object_handlers;
 
     return &obj->std;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -91,6 +91,11 @@ class Redis_Test extends TestSuite
 
     public function testClone()
     {
+        if (get_class($this->redis) !== 'Redis') {
+            $this->markTestSkipped();
+            return;
+        }
+
         $new = clone $this->redis;
         /* check that connection works */
         $this->assertTrue($new->ping());

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -89,6 +89,17 @@ class Redis_Test extends TestSuite
         $this->assertTrue(version_compare($this->version, "2.4.0", "ge"));
     }
 
+    public function testClone()
+    {
+        $new = clone $this->redis;
+        /* check that connection works */
+        $this->assertTrue($new->ping());
+        /* confirm socket settings are disconnected from source object */
+        $this->assertTrue($new->setOption(Redis::OPT_PREFIX, 'test'));
+        $this->assertEquals($new->getOption(Redis::OPT_PREFIX), 'test');
+        $this->assertFalse($this->redis->getOption(Redis::OPT_PREFIX));
+    }
+
     public function testPing() {
         /* Reply literal off */
         $this->assertTrue($this->redis->ping());


### PR DESCRIPTION
Current clone of redis object results in a crash. This patch fixes the crash and allows a copy of redis object to be created. This is helpful when you want to share same connection but with different settings (i.e. different OPT_PREFIX)