### PR TITLE
Fixed checks for lzf when headers are inside include/liblzf (ubuntu 20.04) 

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -170,7 +170,15 @@ if test "$PHP_REDIS" != "no"; then
         if test -r $i/include/lzf.h; then
           AC_MSG_RESULT(found in $i)
           LIBLZF_DIR=$i
+          LIBLZF_INCLUDE_DIR=$i/include
           break
+        fi
+        if test -r $i/include/liblzf/lzf.h; then
+            AC_MSG_RESULT(found in $i)
+            LIBLZF_DIR=$i
+            LIBLZF_INCLUDE_DIR=$i/include/liblzf
+            PHP_ADD_INCLUDE($LIBLZF_INCLUDE_DIR)
+            break
         fi
       done
       if test -z "$LIBLZF_DIR"; then
@@ -183,7 +191,7 @@ if test "$PHP_REDIS" != "no"; then
       ], [
         AC_MSG_ERROR([could not find usable liblzf])
       ], [
-        -L$LIBLZF_DIR/$PHP_LIBDIR
+        -L$LIBLZF_DIR/$PHP_LIBDIR -I$LIBLZF_INCLUDE_DIR
       ])
       PHP_SUBST(REDIS_SHARED_LIBADD)
     else


### PR DESCRIPTION
Fixed checks for lzf when headers are inside include/liblzf (ubuntu 20.04) 

In some distributions lzf.h is not inside include/ but instead in include/libzlf this tweak adds extra checks for that allowing lzf support to be enabled.

Updated PR to be based on develop branch