### PR TITLE
fixed *scan bug

### DIFF
--- a/library.c
+++ b/library.c
@@ -416,9 +416,23 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
             break;
         }
 
+        zval_dtor(&z_resp);
+        // return if user func return NON-NULL value
+        if (Z_TYPE(z_ret) != IS_NULL) {
+            // when will be IS_UNDEF?
+            if (Z_TYPE(z_ret) == IS_UNDEF) {
+                RETVAL_FALSE;
+            } else {
+                if (Z_ISREF(z_ret)) {
+                    zend_unwrap_reference(&z_ret);
+                }
+                ZVAL_COPY_VALUE(return_value, &z_ret);
+            }
+            return 0;
+        }
+
         // If we have a return value free it
         zval_ptr_dtor(&z_ret);
-        zval_dtor(&z_resp);
     }
 
     // This is an error state, clean up

--- a/library.c
+++ b/library.c
@@ -267,6 +267,17 @@ redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     if(redis_read_reply_type(redis_sock, &reply_type, &reply_info)<0
        || reply_type != TYPE_MULTIBULK || reply_info != 2)
     {
+        // set error
+        if (reply_type == TYPE_ERR) {
+            char err_buf[128];
+            size_t err_len;
+
+            /* Throws exception on failure */
+            if (!redis_sock_gets(redis_sock, err_buf, sizeof(err_buf) - 1, &err_len)) {
+                redis_sock_set_err(redis_sock, err_buf, err_len);
+                redis_error_throw(redis_sock);
+            }
+        }
         return -1;
     }
 

--- a/redis.c
+++ b/redis.c
@@ -773,6 +773,9 @@ PHP_MINIT_FUNCTION(redis)
     redis_ce = zend_register_internal_class(&redis_class_entry);
     redis_ce->create_object = create_redis_object;
 
+    /* ADD PATCH SIGN*/
+    REGISTER_BOOL_CONSTANT("REDIS_SUBSCRIBE_PATCHED", 1, CONST_CS | CONST_PERSISTENT);
+
     /* RedisArray class */
     INIT_CLASS_ENTRY(redis_array_class_entry, "RedisArray", redis_array_functions);
     redis_array_ce = zend_register_internal_class(&redis_array_class_entry);


### PR DESCRIPTION
when hscan/sscan/zscan operate on error type key, will not read all data from socket but first byte