### PR TITLE
fix #1796 missing include

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -30,6 +30,7 @@
 #include <standard/php_random.h>
 #include <zend_exceptions.h>
 #include <ext/standard/info.h>
+#include <ext/hash/php_hash.h>
 
 
 #ifdef PHP_SESSION


### PR DESCRIPTION
Needed for `php_hash_bin2hex`

Only affects build without session (as missing `php_hash.h` is included from `php_session.h`)