### PR TITLE
Issue #1607

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -186,12 +186,8 @@ typedef struct clusterFoldItem clusterFoldItem;
 /* RedisCluster implementation structure */
 typedef struct redisCluster {
 
-    /* Timeout and read timeout (for normal operations) */
-    double timeout;
-    double read_timeout;
-
-    /* Are we using persistent connections */
-    int persistent;
+    /* One RedisSock struct for serialization and prefix information */
+    RedisSock *flags;
 
     /* How long in milliseconds should we wait when being bounced around */
     long waitms;
@@ -240,9 +236,6 @@ typedef struct redisCluster {
 
     /* The slot where we're subscribed */
     short subscribed_slot;
-
-    /* One RedisSock struct for serialization and prefix information */
-    RedisSock *flags;
 
     /* The first line of our last reply, not including our reply type byte
      * or the trailing \r\n */


### PR DESCRIPTION
I added new parameter to `RedisCluster::__constructor` to specify stream context options. Seeds must be specified in `host:port` form. It is not difficult to add parsing scheme but `CLUSTER SEEDS` and `ASK/MOVED` returns address without information about protocol and we need need to add some hardcoded value anyway.
As side effect of this PR added ability to not specify scheme in `Redis::connect`.
Also some configuration attributes moved to `RedisSock` flags.