### PR TITLE
Issue.1847 cluster segfault

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -234,7 +234,7 @@ cluster_read_sock_resp(RedisSock *redis_sock, REDIS_REPLY_TYPE type,
             break;
         case TYPE_MULTIBULK:
             r->elements = len;
-            if (r->elements > -1) {
+            if (r->elements > 0) {
                 r->element = ecalloc(len, sizeof(clusterReply*));
                 if (cluster_multibulk_resp_recursive(redis_sock, len, r->element, line_reply != NULL) < 0) {
                     cluster_free_reply(r, 1);

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -325,14 +325,14 @@ typedef struct clusterReply {
     size_t integer;                /* Integer reply */
     long long len;                 /* Length of our string */
     char *str;                     /* String reply */
-    size_t elements;               /* Count of array elements */
+    long long elements;            /* Count of array elements */
     struct clusterReply **element; /* Array elements */
 } clusterReply;
 
 /* Direct variant response handler */
 clusterReply *cluster_read_resp(redisCluster *c, int status_strings);
 clusterReply *cluster_read_sock_resp(RedisSock *redis_sock,
-    REDIS_REPLY_TYPE type, char *line_reply, size_t reply_len);
+    REDIS_REPLY_TYPE type, char *line_reply, long long reply_len);
 void cluster_free_reply(clusterReply *reply, int free_data);
 
 /* Cluster distribution helpers for WATCH */

--- a/common.h
+++ b/common.h
@@ -82,6 +82,7 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_OPT_COMPRESSION        7
 #define REDIS_OPT_REPLY_LITERAL      8
 #define REDIS_OPT_COMPRESSION_LEVEL  9
+#define REDIS_OPT_NULL_MBULK_AS_NULL 10
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -296,6 +297,7 @@ typedef struct {
 
     int                readonly;
     int                reply_literal;
+    int                null_mbulk_as_null;
     int                tcp_keepalive;
 } RedisSock;
 /* }}} */

--- a/library.h
+++ b/library.h
@@ -144,7 +144,7 @@ PHP_REDIS_API int redis_acl_log_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *r
 
 PHP_REDIS_API int redis_read_reply_type(RedisSock *redis_sock, REDIS_REPLY_TYPE *reply_type, long *reply_info);
 PHP_REDIS_API int redis_read_variant_bulk(RedisSock *redis_sock, int size, zval *z_ret);
-PHP_REDIS_API int redis_read_multibulk_recursive(RedisSock *redis_sock, int elements, int status_strings, zval *z_ret);
+PHP_REDIS_API int redis_read_multibulk_recursive(RedisSock *redis_sock, long long elements, int status_strings, zval *z_ret);
 PHP_REDIS_API int redis_read_variant_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_read_variant_reply_strings(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -713,6 +713,7 @@ static void add_class_constants(zend_class_entry *ce, int is_cluster) {
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION"), REDIS_OPT_COMPRESSION);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_REPLY_LITERAL"), REDIS_OPT_REPLY_LITERAL);
     zend_declare_class_constant_long(ce, ZEND_STRL("OPT_COMPRESSION_LEVEL"), REDIS_OPT_COMPRESSION_LEVEL);
+    zend_declare_class_constant_long(ce, ZEND_STRL("OPT_NULL_MULTIBULK_AS_NULL"), REDIS_OPT_NULL_MBULK_AS_NULL);
 
     /* serializer */
     zend_declare_class_constant_long(ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3996,6 +3996,8 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->scan);
         case REDIS_OPT_REPLY_LITERAL:
             RETURN_LONG(redis_sock->reply_literal);
+        case REDIS_OPT_NULL_MBULK_AS_NULL:
+            RETURN_LONG(redis_sock->null_mbulk_as_null);
         case REDIS_OPT_FAILOVER:
             RETURN_LONG(c->failover);
         default:
@@ -4040,6 +4042,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             val_long = zval_get_long(val);
             redis_sock->reply_literal = val_long != 0;
             RETURN_TRUE;
+        case REDIS_OPT_NULL_MBULK_AS_NULL:
+            val_long = zval_get_long(val);
+            redis_sock->null_mbulk_as_null = val_long != 0;
         case REDIS_OPT_COMPRESSION:
             val_long = zval_get_long(val);
             if (val_long == REDIS_COMPRESSION_NONE

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4045,6 +4045,7 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
         case REDIS_OPT_NULL_MBULK_AS_NULL:
             val_long = zval_get_long(val);
             redis_sock->null_mbulk_as_null = val_long != 0;
+            RETURN_TRUE;
         case REDIS_OPT_COMPRESSION:
             val_long = zval_get_long(val);
             if (val_long == REDIS_COMPRESSION_NONE

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -751,5 +751,20 @@ class Redis_Cluster_Test extends Redis_Test {
             return 'seed[]=' . $host;
         }, self::$_arr_node_map)) . ($auth ? "&$auth" : '');
     }
+
+    /* Test correct handling of null multibulk replies */
+    public function testNullArray()
+    {
+        $key = "key:arr";
+        $this->redis->del($key);
+
+        $r = $this->redis->rawCommand($key, "BLPOP", $key, "1");
+        $this->assertEquals(null, $r);
+
+        $this->redis->multi();
+        $this->redis->rawCommand($key, "BLPOP", $key, "1");
+        $r = $this->redis->exec();
+        $this->assertEquals([null], $r);
+    }
 }
 ?>

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4978,6 +4978,22 @@ class Redis_Test extends TestSuite
         $this->redis->setOption(Redis::OPT_NULL_MULTIBULK_AS_NULL, false);
     }
 
+    /* Test that we can configure PhpRedis to return NULL for *-1 even nestedwithin replies */
+    public function testNestedNullArray() {
+        $this->redis->del('{notaset}');
+
+        foreach ([false => [], true => NULL] as $opt => $test) {
+            $this->redis->setOption(Redis::OPT_NULL_MULTIBULK_AS_NULL, $opt);
+            $this->assertEquals([$test, $test], $this->redis->geoPos('{notaset}', 'm1', 'm2'));
+
+            $this->redis->multi();
+            $this->redis->geoPos('{notaset}', 'm1', 'm2');
+            $this->assertEquals([[$test, $test]], $this->redis->exec());
+        }
+
+        $this->redis->setOption(Redis::OPT_NULL_MULTIBULK_AS_NULL, false);
+    }
+
     public function testReconnectSelect() {
         $key = 'reconnect-select';
         $value = 'Has been set!';


### PR DESCRIPTION
The PR contains the commit from #1848 and adds a new option that lets users tell PhpRedis to return `NULL` when we read a NULL multibulk response.

Also see #1847