### PR TITLE
PHP 8 compatibility Windows

### DIFF
--- a/redis_array.h
+++ b/redis_array.h
@@ -1,7 +1,7 @@
 #ifndef REDIS_ARRAY_H
 #define REDIS_ARRAY_H
 
-#ifdef PHP_WIN32
+#if (defined(_MSC_VER) && _MSC_VER <= 1920)
 #include "win32/php_stdint.h"
 #else
 #include <stdint.h>

--- a/redis_array_impl.h
+++ b/redis_array_impl.h
@@ -1,7 +1,7 @@
 #ifndef REDIS_ARRAY_IMPL_H
 #define REDIS_ARRAY_IMPL_H
 
-#ifdef PHP_WIN32
+#if (defined(_MSC_VER) && _MSC_VER <= 1920)
 #include <win32/php_stdint.h>
 #else
 #include <stdint.h>


### PR DESCRIPTION
PHP 8 does not have `win32/php_stdint.h` any longer, but Visual Studio 2019 provides its own `stdint.h`.
Include stdint.h when phpredis is compiled with Visual Studio 2019 (_MSC_VER 1920).
@remicollet Can you review and merge this PR?