### PR TITLE
Added prefix support into pool_pattern setting.

### DIFF
--- a/library.c
+++ b/library.c
@@ -788,6 +788,11 @@ redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...) {
             case 'a':
                 append_auth_hash(&str, redis_sock->user, redis_sock->pass);
                 break;
+            case 'x':
+                smart_str_append(&str, ':');
+                if (redis_sock->prefix) {
+                    smart_str_append_ex(&str, redis_sock->prefix, 0);
+                }
             default:
                 /* Maybe issue a php_error_docref? */
                 break;

--- a/library.c
+++ b/library.c
@@ -789,7 +789,7 @@ redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...) {
                 append_auth_hash(&str, redis_sock->user, redis_sock->pass);
                 break;
             case 'x':
-                smart_str_append(&str, ':');
+                smart_str_appendс(&str, ':');
                 if (redis_sock->prefix) {
                     smart_str_append_ex(&str, redis_sock->prefix, 0);
                 }


### PR DESCRIPTION
Hi.

Thanks for your efforts and good prject.

Right now pool_pattern uses templates which are really hard to customize:
persistent_id - is generated by PYP Core
user + password - supported starting redis v 6.0
password - is 1 per redis instance till v 6.0

So that I've added prefix support. 
Using this feature developer can split network traffic with several sockets if it was is specified in constructor