### PR TITLE
Fail if session lock can't be acquired, more sane lock wait defaults, and add more logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ run-tests.php
 idea/*
 .cquery
 tags
+.vscode/*

--- a/README.markdown
+++ b/README.markdown
@@ -90,10 +90,10 @@ Following INI variables can be used to configure session locking:
 redis.session.locking_enabled = 1
 ; How long should the lock live (in seconds)? Defaults to: value of max_execution_time.
 redis.session.lock_expire = 60
-; How long to wait between attempts to acquire lock, in microseconds (µs)?. Defaults to: 2000
+; How long to wait between attempts to acquire lock, in microseconds (µs)?. Defaults to: 20000
 redis.session.lock_wait_time = 50000
-; Maximum number of times to retry (-1 means infinite). Defaults to: 10
-redis.session.lock_retries = 10
+; Maximum number of times to retry (-1 means infinite). Defaults to: 1000
+redis.session.lock_retries = 2000
 ~~~
 
 ## Distributed Redis Array

--- a/redis.c
+++ b/redis.c
@@ -103,8 +103,8 @@ PHP_INI_BEGIN()
     /* redis session */
     PHP_INI_ENTRY("redis.session.locking_enabled", "0", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.lock_expire", "0", PHP_INI_ALL, NULL)
-    PHP_INI_ENTRY("redis.session.lock_retries", "10", PHP_INI_ALL, NULL)
-    PHP_INI_ENTRY("redis.session.lock_wait_time", "2000", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.lock_retries", "1000", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.lock_wait_time", "20000", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 /** {{{ Argument info for commands in redis 1.0 */

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6441,7 +6441,7 @@ class Redis_Test extends TestSuite
         usleep(100000);
 
         $start = microtime(true);
-        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 200000, 0);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 2000, 0);
         $end = microtime(true);
         $elapsedTime = $end - $start;
 


### PR DESCRIPTION
I have run into several issues with using the session handler that this PR attempts to fix:

1. When session locking is enabled, the defaults used by this module for the number of retries and how long to wait between retries are unrealistic for real world use.  The default is to only wait 2m between retries, then only retry 10 times.  This gives a maximum of 20ms (plus packet round trips) that a script using this session handler will wait for a lock by default if locking is enabled.  This PR changes the default to waiting a more reasonable 20ms between retries by default and retrying up to 1000 times for a total potential lock wait time of 20s, which is 2/3 of the default max execution time of 30s.
2. Compounding the first item is the fact that, if the extension fails to acquire the lock, it continues on, not returning a failure status.  The PHP script then continues on as usual, unaware of the fact that, when `session_write_close()` is called, the script won't actually be able to write out the session data, because it never had the lock.  This, of course, can lead to data loss.  In this update, if locking is enabled and the lock can't be acquired per the retry limits, then a failure is immediately returned.
3. Very little logging exists as has been pointed out in other issues.

The PHP session handling interface writes session data as a single serialized blob.  Because of this, unless the application is extremely careful about reading and writing data to the session, it is entirely likely that simultaneous (ie XHR, images, etc) using the same session without locking in place can result in race conditions where old data can clobber new data.  I have most recently experienced this using this session handler with the Nextcloud Talk application, which makes multiple XHR requests to the backend to get updated room info, messages, manage room membership, etc simultaneously.  In fact, I would argue that session locking should be enabled by default, as there is an inherent expectation of this based on how PHP sessions work.  The built in handlers (files and shared memory) both do locking without the possibility of disabling it.  The memcached extension enables locking by default, as it should.  As a PHP developer, you expect session data to be safe, and that can only be accomplished through locking.  Much PHP code is written with this in mind.  In fact, much PHP code is also written with the expectation that sessions are never expected to fail.  The default `files` session handler waits indefinitely for the file lock.  Essentially, the only limit there is the script execution time limit.  I believe the shared memory handler is the same way, though I believe it to have a bug in that it releases the lock in between read and write operations, potentially leading to the race conditions mentioned above.

Returning a failure from `session_start` only became possible with PHP 7.1, but it is important that, should locking be enabled, if it fails, that failure gets bubbled up to the PHP script at the very least.  As I mentioned before, most PHP code is probably written with the idea that `session_start()` never returns until the session is actually started.  To return with a "broken" session is inviting failure later.  In fact, I would also argue that, in addition to enabling locking by default, the retry limit should be infinite in the same way that the `files` handler waits indefinitely for the lock.  That is not what this PR does, though it can be changed.  I just didn't want to change too much in the way of expectations for developers that were already using this extension.  That being said, as I mentioned before, much code is written with this expectation in mind, and projects that *do* utilize the return value from `session_start()` to see if it failed and handle that failure could choose to change the defaults if the default were changed to retry indefinitely.

Related issues/PRs:
https://github.com/phpredis/phpredis/issues/1411
https://github.com/phpredis/phpredis/issues/1422
https://github.com/phpredis/phpredis/issues/1872
https://github.com/phpredis/phpredis/issues/1390
https://github.com/nextcloud/docker/pull/1364
https://github.com/nextcloud/spreed/issues/4670
https://github.com/nextcloud/server/pull/1936#issuecomment-282008712 (note on the expectation that session access is serialized via locking)