### PR TITLE
Fix connect proto reserved was missing

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -978,7 +978,8 @@ PHP_METHOD(Redis,__destruct) {
     }
 }
 
-/* {{{ proto boolean Redis::connect(string host, int port [, double timeout [, long retry_interval]])
+/* {{{ proto boolean Redis::connect(string host, int port
+ * [, double timeout [, NULL reserved, long retry_interval [, float read_timeout]]])
  */
 PHP_METHOD(Redis, connect)
 {
@@ -990,7 +991,8 @@ PHP_METHOD(Redis, connect)
 }
 /* }}} */
 
-/* {{{ proto boolean Redis::pconnect(string host, int port [, double timeout])
+/* {{{ proto boolean Redis::pconnect(string host, int port
+ * [, double timeout[, string persistent_id, long retry_interval [, float read_timeout]]])
  */
 PHP_METHOD(Redis, pconnect)
 {


### PR DESCRIPTION
From the Readme, connect arguments are:
* *host*: string. can be a host, or the path to a unix domain socket. Starting from version 5.0.0 it is possible to specify schema-
* *port*: int, optional--
* *timeout*: float, value in seconds (optional, default is 0 meaning unlimited)--
* *reserved*: should be NULL if retry_interval is specified--
* *retry_interval*: int, value in milliseconds (optional)--
* *read_timeout*: float, value in seconds (optional, default is 0 meaning unlimited)

The reserved field was missing as read_timeout