### PR TITLE
Add stub-based arginfo for Redis Cluster methods b-d

### DIFF
--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -32,26 +32,45 @@ class RedisCluster {
     public function bitop(string $operation, string $deskey, string $srckey, string ...$otherkeys): bool|int;
 
     public function bitpos(string $key, int $bit, int $start = NULL, int $end = NULL): bool|int;
+
+    public function blpop(string|array $key, string|int $timeout_or_key, mixed ...$extra_args): array;
+
+    public function brpop(string|array $key, string|int $timeout_or_key, mixed ...$extra_args): array;
+
+    public function brpoplpush(string $srckey, string $deskey, int $timeout): mixed;
+
+    public function bzpopmax(string|array $key, string|int $timeout_or_key, mixed ...$extra_args): array;
+
+    public function bzpopmin(string|array $key, string|int $timeout_or_key, mixed ...$extra_args): array;
+
+    public function clearlasterror(): bool;
+
+    public function client(string|array $node, string $subcommand, string|null $arg): array|string|bool;
+
+    public function close(): bool;
+
+    public function cluster(string|array $node, string $command, mixed ...$extra_args): mixed;
+
+    public function command(mixed ...$extra_args): mixed;
+
+    public function config(string|array $node, string $subcommand, mixed ...$extra_args): mixed;
+
+    public function dbsize(string|array $key_or_address): int;
+
+    public function decr(string $key): int;
+
+    public function decrby(string $key, int $value): int;
+
+    public function del(string $key, string ...$other_keys): array;
+
+    public function discard(): bool;
+
+    public function dump(string $key): string;
+
 }
 
 /*
     TODO:
-    public function brpop
-    public function brpoplpush
-    public function clearlasterror
-    public function bzpopmax
-    public function bzpopmin
-    public function client
-    public function close
-    public function cluster
-    public function command
-    public function config
-    public function dbsize
-    public function decr
-    public function decrby
-    public function del
-    public function discard
-    public function dump
     public function echo
     public function eval
     public function evalsha

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e75f14ee54edbf3d7460402a4f445aa57b6c1d1d */
+ * Stub hash: b00398a68b9846d7266b8232d11de787fc4bae0c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -66,6 +66,75 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_RedisCluster_bitpos, 0, 2,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "NULL")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_blpop, 0, 2, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, key, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, timeout_or_key, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_brpop arginfo_class_RedisCluster_blpop
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_brpoplpush, 0, 3, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, srckey, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, deskey, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_bzpopmax arginfo_class_RedisCluster_blpop
+
+#define arginfo_class_RedisCluster_bzpopmin arginfo_class_RedisCluster_blpop
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_clearlasterror, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_RedisCluster_client, 0, 3, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_BOOL)
+	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_INFO(0, subcommand, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, arg, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_close arginfo_class_RedisCluster_clearlasterror
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_cluster, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_INFO(0, command, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_command, 0, 0, IS_MIXED, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_config, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_INFO(0, subcommand, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_dbsize, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_decr, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_decrby, 0, 2, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_del, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, other_keys, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_discard arginfo_class_RedisCluster_clearlasterror
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_dump, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_METHOD(RedisCluster, __construct);
 ZEND_METHOD(RedisCluster, _masters);
@@ -80,6 +149,23 @@ ZEND_METHOD(RedisCluster, bgsave);
 ZEND_METHOD(RedisCluster, bitcount);
 ZEND_METHOD(RedisCluster, bitop);
 ZEND_METHOD(RedisCluster, bitpos);
+ZEND_METHOD(RedisCluster, blpop);
+ZEND_METHOD(RedisCluster, brpop);
+ZEND_METHOD(RedisCluster, brpoplpush);
+ZEND_METHOD(RedisCluster, bzpopmax);
+ZEND_METHOD(RedisCluster, bzpopmin);
+ZEND_METHOD(RedisCluster, clearlasterror);
+ZEND_METHOD(RedisCluster, client);
+ZEND_METHOD(RedisCluster, close);
+ZEND_METHOD(RedisCluster, cluster);
+ZEND_METHOD(RedisCluster, command);
+ZEND_METHOD(RedisCluster, config);
+ZEND_METHOD(RedisCluster, dbsize);
+ZEND_METHOD(RedisCluster, decr);
+ZEND_METHOD(RedisCluster, decrby);
+ZEND_METHOD(RedisCluster, del);
+ZEND_METHOD(RedisCluster, discard);
+ZEND_METHOD(RedisCluster, dump);
 
 
 static const zend_function_entry class_RedisCluster_methods[] = {
@@ -96,5 +182,22 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, bitcount, arginfo_class_RedisCluster_bitcount, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, bitop, arginfo_class_RedisCluster_bitop, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, bitpos, arginfo_class_RedisCluster_bitpos, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, blpop, arginfo_class_RedisCluster_blpop, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, brpop, arginfo_class_RedisCluster_brpop, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, brpoplpush, arginfo_class_RedisCluster_brpoplpush, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, bzpopmax, arginfo_class_RedisCluster_bzpopmax, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, bzpopmin, arginfo_class_RedisCluster_bzpopmin, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, clearlasterror, arginfo_class_RedisCluster_clearlasterror, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, client, arginfo_class_RedisCluster_client, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, close, arginfo_class_RedisCluster_close, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, cluster, arginfo_class_RedisCluster_cluster, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, command, arginfo_class_RedisCluster_command, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, config, arginfo_class_RedisCluster_config, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, dbsize, arginfo_class_RedisCluster_dbsize, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, decr, arginfo_class_RedisCluster_decr, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, decrby, arginfo_class_RedisCluster_decrby, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, del, arginfo_class_RedisCluster_del, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, discard, arginfo_class_RedisCluster_discard, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, dump, arginfo_class_RedisCluster_dump, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e75f14ee54edbf3d7460402a4f445aa57b6c1d1d */
+ * Stub hash: b00398a68b9846d7266b8232d11de787fc4bae0c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -63,6 +63,65 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_bitpos, 0, 0, 2)
 	ZEND_ARG_INFO(0, end)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_blpop, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, timeout_or_key)
+	ZEND_ARG_VARIADIC_INFO(0, extra_args)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_brpop arginfo_class_RedisCluster_blpop
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_brpoplpush, 0, 0, 3)
+	ZEND_ARG_INFO(0, srckey)
+	ZEND_ARG_INFO(0, deskey)
+	ZEND_ARG_INFO(0, timeout)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_bzpopmax arginfo_class_RedisCluster_blpop
+
+#define arginfo_class_RedisCluster_bzpopmin arginfo_class_RedisCluster_blpop
+
+#define arginfo_class_RedisCluster_clearlasterror arginfo_class_RedisCluster__masters
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_client, 0, 0, 3)
+	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, subcommand)
+	ZEND_ARG_INFO(0, arg)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_close arginfo_class_RedisCluster__masters
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_cluster, 0, 0, 2)
+	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, command)
+	ZEND_ARG_VARIADIC_INFO(0, extra_args)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_command, 0, 0, 0)
+	ZEND_ARG_VARIADIC_INFO(0, extra_args)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_config, 0, 0, 2)
+	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, subcommand)
+	ZEND_ARG_VARIADIC_INFO(0, extra_args)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_dbsize arginfo_class_RedisCluster_bgrewriteaof
+
+#define arginfo_class_RedisCluster_decr arginfo_class_RedisCluster__prefix
+
+#define arginfo_class_RedisCluster_decrby arginfo_class_RedisCluster_append
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_del, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_VARIADIC_INFO(0, other_keys)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_discard arginfo_class_RedisCluster__masters
+
+#define arginfo_class_RedisCluster_dump arginfo_class_RedisCluster__prefix
+
 
 ZEND_METHOD(RedisCluster, __construct);
 ZEND_METHOD(RedisCluster, _masters);
@@ -77,6 +136,23 @@ ZEND_METHOD(RedisCluster, bgsave);
 ZEND_METHOD(RedisCluster, bitcount);
 ZEND_METHOD(RedisCluster, bitop);
 ZEND_METHOD(RedisCluster, bitpos);
+ZEND_METHOD(RedisCluster, blpop);
+ZEND_METHOD(RedisCluster, brpop);
+ZEND_METHOD(RedisCluster, brpoplpush);
+ZEND_METHOD(RedisCluster, bzpopmax);
+ZEND_METHOD(RedisCluster, bzpopmin);
+ZEND_METHOD(RedisCluster, clearlasterror);
+ZEND_METHOD(RedisCluster, client);
+ZEND_METHOD(RedisCluster, close);
+ZEND_METHOD(RedisCluster, cluster);
+ZEND_METHOD(RedisCluster, command);
+ZEND_METHOD(RedisCluster, config);
+ZEND_METHOD(RedisCluster, dbsize);
+ZEND_METHOD(RedisCluster, decr);
+ZEND_METHOD(RedisCluster, decrby);
+ZEND_METHOD(RedisCluster, del);
+ZEND_METHOD(RedisCluster, discard);
+ZEND_METHOD(RedisCluster, dump);
 
 
 static const zend_function_entry class_RedisCluster_methods[] = {
@@ -93,5 +169,22 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, bitcount, arginfo_class_RedisCluster_bitcount, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, bitop, arginfo_class_RedisCluster_bitop, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, bitpos, arginfo_class_RedisCluster_bitpos, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, blpop, arginfo_class_RedisCluster_blpop, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, brpop, arginfo_class_RedisCluster_brpop, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, brpoplpush, arginfo_class_RedisCluster_brpoplpush, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, bzpopmax, arginfo_class_RedisCluster_bzpopmax, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, bzpopmin, arginfo_class_RedisCluster_bzpopmin, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, clearlasterror, arginfo_class_RedisCluster_clearlasterror, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, client, arginfo_class_RedisCluster_client, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, close, arginfo_class_RedisCluster_close, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, cluster, arginfo_class_RedisCluster_cluster, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, command, arginfo_class_RedisCluster_command, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, config, arginfo_class_RedisCluster_config, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, dbsize, arginfo_class_RedisCluster_dbsize, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, decr, arginfo_class_RedisCluster_decr, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, decrby, arginfo_class_RedisCluster_decrby, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, del, arginfo_class_RedisCluster_del, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, discard, arginfo_class_RedisCluster_discard, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, dump, arginfo_class_RedisCluster_dump, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };


### PR DESCRIPTION
Continuing on the work in https://github.com/phpredis/phpredis/pull/1849. First set from me with 17 methods. I'm not too familiar with this (yet), so please check carefully and let me know if something needs fixing. :sweat_smile: 