### PR TITLE
Fix ZSTD decompression on bad data.

### DIFF
--- a/library.c
+++ b/library.c
@@ -2952,7 +2952,8 @@ redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret)
                 size_t len;
 
                 len = ZSTD_getFrameContentSize(val, val_len);
-                if (len >= 0) {
+
+                if (len != ZSTD_CONTENTSIZE_ERROR && len != ZSTD_CONTENTSIZE_UNKNOWN) {
                     data = emalloc(len);
                     len = ZSTD_decompress(data, len, val, val_len);
                     if (ZSTD_isError(len)) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4638,6 +4638,14 @@ class Redis_Test extends TestSuite
         if (!defined('Redis::COMPRESSION_ZSTD')) {
             $this->markTestSkipped();
         }
+
+        /* Issue 1936 regression.  Make sure we don't overflow on bad data */
+        $this->redis->del('badzstd');
+        $this->redis->set('badzstd', '123');
+        $this->redis->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_ZSTD);
+        $this->assertEquals('123', $this->redis->get('badzstd'));
+        $this->redis->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_NONE);
+
         $this->checkCompression(Redis::COMPRESSION_ZSTD, 0);
         $this->checkCompression(Redis::COMPRESSION_ZSTD, 9);
     }


### PR DESCRIPTION
ZSTD uses two defined error numbers to inform the caller when the
compressed data is invalid (e.g. wrong magic number) or the size is
unknown.

We should always know the size so abort if ZSTD returns either to us.

Fixes: #1936