### PR TITLE
Pass compression flag when performing HMGET (#1945)

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2112,6 +2112,7 @@ PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
         if (c->reply_len > 0) {
             /* Push serialization settings from the cluster into our socket */
             c->cmd_sock->serializer = c->flags->serializer;
+            c->cmd_sock->compression = c->flags->compression;
 
             /* Call our specified callback */
             if (cb(c->cmd_sock, &z_result, c->reply_len, ctx) == FAILURE) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4716,6 +4716,10 @@ class Redis_Test extends TestSuite
                 $this->assertEquals($val, $this->redis->get('key'));
             }
         }
+
+        // Issue 1945. Ensure we decompress data with hmget.
+        $this->redis->hset('hkey', 'data', 'abc');
+        $this->assertEquals('abc', current($this->redis->hmget('hkey', ['data'])));
     }
 
     public function testDumpRestore() {


### PR DESCRIPTION
Without this, performing a HMGET call fails to decompress the data before
returning it to php when using RedisCluster.