### PR TITLE
Fix session tests to soften timing issues

### DIFF
--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -49,6 +49,13 @@ class Redis_Cluster_Test extends Redis_Test {
     public function testTlsConnect() { return $this->markTestSkipped(); }
     public function testInvalidAuthArgs() { return $this->markTestSkipped(); }
 
+    public function testlMove() { return $this->markTestSkipped(); }
+    public function testsMisMember() { return $this->markTestSkipped(); }
+    public function testzDiff() { return $this->markTestSkipped(); }
+    public function testzDiffStore() { return $this->markTestSkipped(); }
+    public function testzMscore() { return $this->marktestSkipped(); }
+    public function testCopy() { return $this->marktestSkipped(); }
+
     /* Session locking feature is currently not supported in in context of Redis Cluster.
        The biggest issue for this is the distribution nature of Redis cluster */
     public function testSession_lockKeyCorrect() { return $this->markTestSkipped(); }

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6415,10 +6415,15 @@ class Redis_Test extends TestSuite
     {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $this->startSessionProcess($sessionId, 5, true);
-        usleep(100000);
 
-        $this->assertTrue($this->redis->exists($this->sessionPrefix . $sessionId . '_LOCK'));
+        $this->startSessionProcess($sessionId, 5, true);
+
+        $maxwait = (ini_get('redis.session.lock_wait_time') *
+                    ini_get('redis.session.lock_retries') /
+                    1000000.00);
+
+        $exist = $this->waitForSessionLockKey($sessionId, $maxwait);
+        $this->assertTrue($exist);
     }
 
     public function testSession_lockingDisabledByDefault()
@@ -6443,8 +6448,8 @@ class Redis_Test extends TestSuite
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 1, true);
-        usleep(1100000);
-
+        $sleep = ini_get('redis.session.lock_wait_time') * ini_get('redis.session.lock_retries');
+        usleep($sleep + 10000);
         $this->assertFalse($this->redis->exists($this->sessionPrefix . $sessionId . '_LOCK'));
     }
 
@@ -6503,20 +6508,23 @@ class Redis_Test extends TestSuite
         $this->assertTrue('firstProcess' !== $this->getSessionData($sessionId));
     }
 
-    public function testSession_correctLockRetryCount()
-    {
+    public function testSession_correctLockRetryCount() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
+
+        /* Start another process and wait until it has the lock */
         $this->startSessionProcess($sessionId, 10, true);
-        usleep(100000);
+        if ( ! $this->waitForSessionLockKey($sessionId, 2)) {
+            $this->assertTrue(false);
+            return;
+        }
 
-        $start = microtime(true);
-        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 1000000, 3);
-        $end = microtime(true);
-        $elapsedTime = $end - $start;
+        $t1 = microtime(true);
+        $ok = $this->startSessionProcess($sessionId, 0, false, 10, true, 100000, 10);
+        if ( ! $this->assertFalse($ok)) return;
+        $t2 = microtime(true);
 
-        $this->assertTrue($elapsedTime > 3 && $elapsedTime < 4);
-        $this->assertFalse($sessionSuccessful);
+        $this->assertTrue($t2 - $t1 >= 1 && $t2 - $t1 <= 3);
     }
 
     public function testSession_defaultLockRetryCount()
@@ -6524,14 +6532,21 @@ class Redis_Test extends TestSuite
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
         $this->startSessionProcess($sessionId, 10, true);
-        usleep(100000);
+
+        $keyname = $this->sessionPrefix . $sessionId . '_LOCK';
+        $begin = microtime(true);
+
+        if ( ! $this->waitForSessionLockKey($sessionId, 3)) {
+            $this->assertTrue(false);
+            return;
+        }
 
         $start = microtime(true);
-        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 2000, 0);
+        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false, 10, true, 20000, 0);
         $end = microtime(true);
         $elapsedTime = $end - $start;
 
-        $this->assertTrue($elapsedTime > .2 && $elapsedTime < .3);
+        $this->assertTrue($elapsedTime > 2 && $elapsedTime < 3);
         $this->assertFalse($sessionSuccessful);
     }
 
@@ -6539,20 +6554,27 @@ class Redis_Test extends TestSuite
     {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();
-        $this->startSessionProcess($sessionId, 3, true, 1); // Process 1
-        usleep(100000);
-        $this->startSessionProcess($sessionId, 5, true);    // Process 2
 
-        $start = microtime(true);
-        // Waiting until TTL of process 1 ended and process 2 locked the session,
-        // because is not guaranteed which waiting process gets the next lock
-        sleep(1);
-        $sessionSuccessful = $this->startSessionProcess($sessionId, 0, false);
-        $end = microtime(true);
-        $elapsedTime = $end - $start;
+        $t1 = microtime(true);
 
-        $this->assertTrue($elapsedTime > 5);
-        $this->assertTrue($sessionSuccessful);
+        /* 1.  Start a background process, and wait until we are certain
+         *     the lock was attained. */
+        $nsec = 3;
+        $this->startSessionProcess($sessionId, $nsec, true, $nsec);
+        if ( ! $this->waitForSessionLockKey($sessionId, 1)) {
+            $this->assertFalse(true);
+            return;
+        }
+
+        /* 2.  Attempt to lock the same session.  This should force us to
+         *     wait until the first lock is released. */
+        $t2 = microtime(true);
+        $ok = $this->startSessionProcess($sessionId, 0, false);
+        $t3 = microtime(true);
+
+        /* 3.  Verify that we did in fact have to wait for this lock */
+        $this->assertTrue($ok);
+        $this->assertTrue($t3 - $t2 >= $nsec - ($t2 - $t1));
     }
 
     public function testSession_lockWaitTime()
@@ -6831,6 +6853,30 @@ class Redis_Test extends TestSuite
             return ($background || (count($output) == 1 && $output[0] == 'SUCCESS')) ? true : false;
         }
     }
+
+    /**
+     * @param string $session_id
+     * @param string $max_wait_sec
+     *
+     * Sometimes we want to block until a session lock has been detected
+     * This is better and faster than arbitrarily sleeping.  If we don't
+     * detect the session key within the specified maximum number of
+     * seconds, the function returns failure.
+     *
+     * @return bool
+     */
+    private function waitForSessionLockKey($session_id, $max_wait_sec) {
+        $now = microtime(true);
+        $key = $this->sessionPrefix . $session_id . '_LOCK';
+
+        do {
+            usleep(10000);
+            $exists = $this->redis->exists($key);
+        } while (!$exists && microtime(true) <= $now + $max_wait_sec);
+
+        return $exists || $this->redis->exists($key);
+    }
+
 
     /**
      * @param string $sessionId


### PR DESCRIPTION
Rework the session locking unit tests to be less reliant on arbitrary
sleep calls which can be very troublesome when running in Travis and
especially when running in Travis under Valgrind.

Additionally, skip multiple newly added Redis 6.2 commands that aren't
yet implemented in RedisCluster.