### PR TITLE
Fix #1952 Incorrect PHP method info on the RedisCluster time method

### DIFF
--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -247,7 +247,7 @@ zend_function_entry redis_cluster_functions[] = {
     PHP_ME(RedisCluster, subscribe, arginfo_subscribe, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, sunion, arginfo_nkeys, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, sunionstore, arginfo_dst_nkeys, ZEND_ACC_PUBLIC)
-    PHP_ME(RedisCluster, time, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, time, key_or_address, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, ttl, arginfo_key, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, type, arginfo_key, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, unsubscribe, arginfo_unsubscribe, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -247,7 +247,7 @@ zend_function_entry redis_cluster_functions[] = {
     PHP_ME(RedisCluster, subscribe, arginfo_subscribe, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, sunion, arginfo_nkeys, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, sunionstore, arginfo_dst_nkeys, ZEND_ACC_PUBLIC)
-    PHP_ME(RedisCluster, time, key_or_address, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, time, arginfo_key_or_address, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, ttl, arginfo_key, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, type, arginfo_key, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, unsubscribe, arginfo_unsubscribe, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
Fixes [#1952](https://github.com/phpredis/phpredis/issues/1952) 