### PR TITLE
Separate compression and create utility methods

### DIFF
--- a/library.h
+++ b/library.h
@@ -121,6 +121,11 @@ redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len);
 PHP_REDIS_API int
 redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret);
 
+PHP_REDIS_API int
+redis_compress(RedisSock *redis_sock, char **dst, size_t *dstlen, char *buf, size_t len);
+PHP_REDIS_API int
+redis_uncompress(RedisSock *redis_sock, char **dst, size_t *dstlen, const char *src, size_t len);
+
 PHP_REDIS_API int redis_pack(RedisSock *redis_sock, zval *z, char **val, size_t *val_len);
 PHP_REDIS_API int redis_unpack(RedisSock *redis_sock, const char *val, int val_len, zval *z_ret);
 

--- a/php_redis.h
+++ b/php_redis.h
@@ -165,8 +165,14 @@ PHP_METHOD(Redis, role);
 PHP_METHOD(Redis, getLastError);
 PHP_METHOD(Redis, clearLastError);
 PHP_METHOD(Redis, _prefix);
+PHP_METHOD(Redis, _pack);
+PHP_METHOD(Redis, _unpack);
+
 PHP_METHOD(Redis, _serialize);
 PHP_METHOD(Redis, _unserialize);
+
+PHP_METHOD(Redis, _compress);
+PHP_METHOD(Redis, _uncompress);
 
 PHP_METHOD(Redis, mset);
 PHP_METHOD(Redis, msetnx);

--- a/redis.c
+++ b/redis.c
@@ -286,6 +286,10 @@ static zend_function_entry redis_functions[] = {
      PHP_ME(Redis, _prefix, arginfo_key, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _serialize, arginfo_value, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, _unserialize, arginfo_value, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, _pack, arginfo_value, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, _unpack, arginfo_value, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, _compress, arginfo_value, ZEND_ACC_PUBLIC)
+     PHP_ME(Redis, _uncompress, arginfo_value, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, acl, arginfo_acl, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, append, arginfo_key_value, ZEND_ACC_PUBLIC)
      PHP_ME(Redis, auth, arginfo_auth, ZEND_ACC_PUBLIC)
@@ -3292,6 +3296,51 @@ PHP_METHOD(Redis, _unserialize) {
 
     redis_unserialize_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
         redis_exception_ce);
+}
+
+PHP_METHOD(Redis, _compress) {
+    RedisSock *redis_sock;
+
+    // Grab socket
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    redis_compress_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
+}
+
+PHP_METHOD(Redis, _uncompress) {
+    RedisSock *redis_sock;
+
+    // Grab socket
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    redis_uncompress_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
+        redis_exception_ce);
+}
+
+PHP_METHOD(Redis, _pack) {
+    RedisSock *redis_sock;
+
+    // Grab socket
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    redis_pack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
+}
+
+PHP_METHOD(Redis, _unpack) {
+    RedisSock *redis_sock;
+
+    // Grab socket
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    redis_unpack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
 }
 
 /* {{{ proto Redis::getLastError() */

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -110,6 +110,10 @@ zend_function_entry redis_cluster_functions[] = {
     PHP_ME(RedisCluster, _redir, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, _serialize, arginfo_value, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, _unserialize, arginfo_value, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, _compress, arginfo_value, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, _uncompress, arginfo_value, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, _pack, arginfo_value, ZEND_ACC_PUBLIC)
+    PHP_ME(RedisCluster, _unpack, arginfo_value, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, acl, arginfo_acl_cl, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, append, arginfo_key_value, ZEND_ACC_PUBLIC)
     PHP_ME(RedisCluster, bgrewriteaof, arginfo_key_or_address, ZEND_ACC_PUBLIC)
@@ -1969,6 +1973,27 @@ PHP_METHOD(RedisCluster, _unserialize) {
         c->flags, redis_cluster_exception_ce);
 }
 /* }}} */
+
+PHP_METHOD(RedisCluster, _compress) {
+    redisCluster *c = GET_CONTEXT();
+    redis_compress_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags);
+}
+
+PHP_METHOD(RedisCluster, _uncompress) {
+    redisCluster *c = GET_CONTEXT();
+    redis_uncompress_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags,
+                             redis_cluster_exception_ce);
+}
+
+PHP_METHOD(RedisCluster, _pack) {
+    redisCluster *c = GET_CONTEXT();
+    redis_pack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags);
+}
+
+PHP_METHOD(RedisCluster, _unpack) {
+    redisCluster *c = GET_CONTEXT();
+    redis_unpack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags);
+}
 
 /* {{{ proto array RedisCluster::_masters() */
 PHP_METHOD(RedisCluster, _masters) {

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -13,7 +13,7 @@
     redis_##name##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, &cmd, \
                        &cmd_len, &slot)
 
-/* Append information required to handle MULTI commands to the tail of our MULTI 
+/* Append information required to handle MULTI commands to the tail of our MULTI
  * linked list. */
 #define CLUSTER_ENQUEUE_RESPONSE(c, slot, cb, ctx) \
     clusterFoldItem *_item; \
@@ -69,8 +69,8 @@
         CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_func, ctx); \
         RETURN_ZVAL(getThis(), 1, 0); \
     } \
-    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx); 
-        
+    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
+
 /* More generic processing, where only the keyword differs */
 #define CLUSTER_PROCESS_KW_CMD(kw, cmdfunc, resp_func, readcmd) \
     redisCluster *c = GET_CONTEXT(); \
@@ -89,7 +89,7 @@
         CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_func, ctx); \
         RETURN_ZVAL(getThis(), 1, 0); \
     } \
-    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx); 
+    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
 
 /* Create cluster context */
 zend_object *create_cluster_context(zend_class_entry *class_type);
@@ -293,6 +293,10 @@ PHP_METHOD(RedisCluster, setoption);
 PHP_METHOD(RedisCluster, _prefix);
 PHP_METHOD(RedisCluster, _serialize);
 PHP_METHOD(RedisCluster, _unserialize);
+PHP_METHOD(RedisCluster, _compress);
+PHP_METHOD(RedisCluster, _uncompress);
+PHP_METHOD(RedisCluster, _pack);
+PHP_METHOD(RedisCluster, _unpack);
 PHP_METHOD(RedisCluster, _masters);
 PHP_METHOD(RedisCluster, _redir);
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4510,4 +4510,67 @@ void redis_unserialize_handler(INTERNAL_FUNCTION_PARAMETERS,
     RETURN_ZVAL(&z_ret, 0, 0);
 }
 
+void redis_compress_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
+    zend_string *zstr;
+    size_t len;
+    char *buf;
+    int cmp_free;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &zstr) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    cmp_free = redis_compress(redis_sock, &buf, &len, ZSTR_VAL(zstr), ZSTR_LEN(zstr));
+    RETVAL_STRINGL(buf, len);
+    if (cmp_free) efree(buf);
+}
+
+void redis_uncompress_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                              zend_class_entry *ex)
+{
+    zend_string *zstr;
+    size_t len;
+    char *buf;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &zstr) == FAILURE) {
+        RETURN_FALSE;
+    } else if (ZSTR_LEN(zstr) == 0 || redis_sock->compression == REDIS_COMPRESSION_NONE) {
+        RETURN_STR_COPY(zstr);
+    }
+
+    if (!redis_uncompress(redis_sock, &buf, &len, ZSTR_VAL(zstr), ZSTR_LEN(zstr))) {
+        zend_throw_exception(ex, "Invalid compressed data or uncompression error", 0);
+        RETURN_FALSE;
+    }
+
+    RETVAL_STRINGL(buf, len);
+    efree(buf);
+}
+
+void redis_pack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
+    int valfree;
+    size_t len;
+    char *val;
+    zval *zv;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zv) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    valfree = redis_pack(redis_sock, zv, &val, &len);
+    RETVAL_STRINGL(val, len);
+    if (valfree) efree(val);
+}
+
+void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
+    zend_string *str;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &str) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if (redis_unpack(redis_sock, ZSTR_VAL(str), ZSTR_LEN(str), return_value) == 0) {
+        RETURN_STR_COPY(str);
+    }
+}
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -52,7 +52,7 @@ int redis_kv_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_key_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);     
+    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_key_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
@@ -96,11 +96,11 @@ typedef int (*zrange_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                          char *,char**,int*,int*,short*,void**);
 
 int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot, 
+    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot,
     void **ctx);
 
 int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot, 
+    char *kw, char **cmd, int *cmd_len, int *withscores, short *slot,
     void **ctx);
 
 int redis_zdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
@@ -143,7 +143,7 @@ int redis_georadiusbymember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_s
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
 /* Commands which need a unique construction mechanism.  This is either because
- * they don't share a signature with any other command, or because there is 
+ * they don't share a signature with any other command, or because there is
  * specific processing we do (e.g. verifying subarguments) that make them
  * unique */
 
@@ -174,7 +174,7 @@ int redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_hstrlen_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
-int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, 
+int redis_bitop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
@@ -313,21 +313,28 @@ int redis_sentinel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_sentinel_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
-/* Commands that don't communicate with Redis at all (such as getOption, 
+/* Commands that don't communicate with Redis at all (such as getOption,
  * setOption, _prefix, _serialize, etc).  These can be handled in one place
- * with the method of grabbing our RedisSock* object in different ways 
+ * with the method of grabbing our RedisSock* object in different ways
  * depending if this is a Redis object or a RedisCluster object. */
 
-void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS, 
+void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, redisCluster *c);
-void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS, 
+void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, redisCluster *c);
-void redis_prefix_handler(INTERNAL_FUNCTION_PARAMETERS, 
+void redis_prefix_handler(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock);
-void redis_serialize_handler(INTERNAL_FUNCTION_PARAMETERS, 
+void redis_serialize_handler(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock);
-void redis_unserialize_handler(INTERNAL_FUNCTION_PARAMETERS, 
+void redis_unserialize_handler(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zend_class_entry *ex);
+void redis_compress_handler(INTERNAL_FUNCTION_PARAMETERS,
+    RedisSock *redis_sock);
+void redis_uncompress_handler(INTERNAL_FUNCTION_PARAMETERS,
+    RedisSock *redis_sock, zend_class_entry *ex);
+
+void redis_pack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
+void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 
 #endif
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -39,6 +39,18 @@ class TestSuite
     public function getPort() { return $this->i_port; }
     public function getAuth() { return $this->auth; }
 
+    public static function getAvailableCompression() {
+        $result[] = Redis::COMPRESSION_NONE;
+        if (defined('Redis::COMPRESSION_LZF'))
+            $result[] = Redis::COMPRESSION_LZF;
+        if (defined('Redis::COMPRESSION_LZ4'))
+            $result[] = Redis::COMPRESSION_LZ4;
+        if (defined('Redis::COMPRESSION_ZSTD'))
+            $result[] = Redis::COMPRESSION_ZSTD;
+
+        return $result;
+    }
+
     /**
      * Returns the fully qualified host path,
      * which may be used directly for php.ini parameters like session.save_path


### PR DESCRIPTION
This commit splits compression and serialization into two distinct parts
and adds some utility functions so the user can compress/uncompress
or pack/unpack data explicily.

See #1939