### PR TITLE
Allow negative timeout/read_timeout and fix doc

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -200,10 +200,10 @@ _**Description**_: Connects to a Redis instance.
 
 *host*: string. can be a host, or the path to a unix domain socket. Starting from version 5.0.0 it is possible to specify schema 
 *port*: int, optional  
-*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
+*timeout*: float, value in seconds (optional, default is 0 meaning it will use default_socket_timeout)  
 *reserved*: should be NULL if retry_interval is specified  
 *retry_interval*: int, value in milliseconds (optional)  
-*read_timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
+*read_timeout*: float, value in seconds (optional, default is 0 meaning it will use default_socket_timeout)
 
 ##### *Return value*
 
@@ -246,10 +246,10 @@ persistent equivalents.
 
 *host*: string. can be a host, or the path to a unix domain socket. Starting from version 5.0.0 it is possible to specify schema 
 *port*: int, optional  
-*timeout*: float, value in seconds (optional, default is 0 meaning unlimited)  
+*timeout*: float, value in seconds (optional, default is 0 meaning it will use default_socket_timeout)  
 *persistent_id*: string. identity for the requested persistent connection  
 *retry_interval*: int, value in milliseconds (optional)  
-*read_timeout*: float, value in seconds (optional, default is 0 meaning unlimited)
+*read_timeout*: float, value in seconds (optional, default is 0 meaning it will use default_socket_timeout)
 
 ##### *Return value*
 

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2842,12 +2842,12 @@ cluster_validate_args(double timeout, double read_timeout, HashTable *seeds,
 {
     zend_string **retval;
 
-    if (timeout < 0L || timeout > INT_MAX) {
+    if (timeout > INT_MAX) {
         if (errstr) *errstr = "Invalid timeout";
         return NULL;
     }
 
-    if (read_timeout < 0L || read_timeout > INT_MAX) {
+    if (read_timeout > INT_MAX) {
         if (errstr) *errstr = "Invalid read timeout";
         return NULL;
     }

--- a/redis.c
+++ b/redis.c
@@ -1063,12 +1063,12 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
         persistent_id = NULL;
     }
 
-    if (timeout < 0L || timeout > INT_MAX) {
+    if (timeout > INT_MAX) {
         REDIS_THROW_EXCEPTION("Invalid connect timeout", 0);
         return FAILURE;
     }
 
-    if (read_timeout < 0L || read_timeout > INT_MAX) {
+    if (read_timeout > INT_MAX) {
         REDIS_THROW_EXCEPTION("Invalid read timeout", 0);
         return FAILURE;
     }

--- a/redis_sentinel.c
+++ b/redis_sentinel.c
@@ -70,12 +70,12 @@ PHP_METHOD(RedisSentinel, __construct)
         RETURN_FALSE;
     }
 
-    if (timeout < 0L || timeout > INT_MAX) {
+    if (timeout > INT_MAX) {
         REDIS_THROW_EXCEPTION("Invalid connect timeout", 0);
         RETURN_FALSE;
     }
 
-    if (read_timeout < 0L || read_timeout > INT_MAX) {
+    if (read_timeout > INT_MAX) {
         REDIS_THROW_EXCEPTION("Invalid read timeout", 0);
         RETURN_FALSE;
     }


### PR DESCRIPTION
Negative timeout means wait forever (unlimited) in php stream, previously we allow to set `OPT_READ_TIMEOUT` to -1 but we did not allow to do the same in `connect()`, I think it's unreasonable.

And doc is wrong for me, after taking a quick look at the source code, I think zero timeout means php stream will use default_socket_timeout, not unlimited, usually it's 60s.

Maybe there are some reasons I don't know, correct me if am wrong...