### PR TITLE
Experimental support to detect unconsumed data

### DIFF
--- a/common.h
+++ b/common.h
@@ -134,6 +134,17 @@ typedef enum {
 #define MULTI    1
 #define PIPELINE 2
 
+#define PHPREDIS_DEBUG_LOGGING 0
+
+#if PHPREDIS_DEBUG_LOGGING == 1
+#define redisDbgFmt(fmt, ...) \
+    php_printf("%s:%d:%s(): " fmt "\n", __FILE__, __LINE__, __func__, __VA_ARGS__)
+#define redisDbgStr(str) phpredisDebugFmt("%s", str)
+#else
+#define redisDbgFmt(fmt, ...) ((void)0)
+#define redisDbgStr(str) ((void)0)
+#endif
+
 #define IS_ATOMIC(redis_sock) (redis_sock->mode == ATOMIC)
 #define IS_MULTI(redis_sock) (redis_sock->mode & MULTI)
 #define IS_PIPELINE(redis_sock) (redis_sock->mode & PIPELINE)

--- a/library.c
+++ b/library.c
@@ -2266,16 +2266,14 @@ redis_sock_check_liveness(RedisSock *redis_sock)
     smart_string cmd = {0};
     size_t len;
 
+    /* Short circuit if PHP detects the stream isn't live */
+    if (redis_stream_liveness_check(redis_sock->stream) != SUCCESS)
+        goto failure;
+
     /* Short circuit if we detect the stream is "dirty", can't or are
        configured not to try and fix it */
     if (redis_stream_detect_dirty(redis_sock->stream) != SUCCESS)
         goto failure;
-
-    /* Short circuit if we detect the stream has gone bad or if the user has
-     * configured persistent connection "YOLO mode". */
-    if (redis_stream_liveness_check(redis_sock->stream) != SUCCESS) {
-        goto failure;
-    }
 
     redis_sock->status = REDIS_SOCK_STATUS_CONNECTED;
     if (!INI_INT("redis.pconnect.echo_check_liveness")) {

--- a/redis.c
+++ b/redis.c
@@ -104,6 +104,8 @@ PHP_INI_BEGIN()
     PHP_INI_ENTRY("redis.pconnect.pooling_enabled", "1", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.pconnect.connection_limit", "0", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.pconnect.echo_check_liveness", "1", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.pconnect.pool_detect_dirty", "0", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.pconnect.pool_poll_timeout", "0", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.pconnect.pool_pattern", "", PHP_INI_ALL, NULL)
 
     /* redis session */


### PR DESCRIPTION
This commit is an attempt at detecting unconsumed data on a socket when
we pull it from the connection pool.

Two new INI settings are introduced related to the changes:

redis.pconnect.pool_detect_dirty:

Value Explanation
----- ----------------------------------------------------------------
    0 Don't execute new logic at all.
    1 Abort and close the socket if we find unconsumed bytes in the
      read buffer.
    2 Seek to the end of our read buffer if we find unconsumed bytes
      and then poll the socket FD to detect if we're still readable
      in which case we fail and close the socket.

redis.pconnect.pool_poll_timeout:

The poll timeout to employ when checking if the socket is readable.
This value is in milliseconds and can be zero.