### PR TITLE
Added support for remapping the cluster's keyspace on a failover

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1080,6 +1080,7 @@ PHP_REDIS_API int cluster_map_keyspace(redisCluster *c) {
     RedisSock *seed;
     clusterReply *slots = NULL;
     int mapped = 0;
+    
     // Iterate over seeds until we can get slots
     ZEND_HASH_FOREACH_PTR(c->seeds, seed) {
         // Attempt to connect to this seed node
@@ -1108,6 +1109,7 @@ PHP_REDIS_API int cluster_map_keyspace(redisCluster *c) {
         CLUSTER_THROW_EXCEPTION("Couldn't map cluster keyspace using any provided seed", 0);
         return FAILURE;
     }
+
     return SUCCESS;
 }
 
@@ -1274,6 +1276,7 @@ static int cluster_dist_write(redisCluster *c, const char *cmd, size_t sz,
                 c->cmd_sock = redis_sock;
                 efree(nodes);
                 return 0;
+            }
         }
     }
 

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1433,7 +1433,6 @@ static void cluster_update_slot(redisCluster *c) {
 
             /* Now point our slot at the node */
             c->master[c->redir_slot] = node;
-            
         }
     } else {
         /* Check to see if the ip and port are mapped */
@@ -1537,7 +1536,7 @@ PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
                                          int cmd_len)
 {
-    int resp, timedout = 0, remaped = 0;
+    int resp, timedout = 0;
     long msstart;
 
     if (!SLOT(c, slot)) {

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1080,7 +1080,7 @@ PHP_REDIS_API int cluster_map_keyspace(redisCluster *c) {
     RedisSock *seed;
     clusterReply *slots = NULL;
     int mapped = 0;
-    
+
     // Iterate over seeds until we can get slots
     ZEND_HASH_FOREACH_PTR(c->seeds, seed) {
         // Attempt to connect to this seed node
@@ -1276,6 +1276,7 @@ static int cluster_dist_write(redisCluster *c, const char *cmd, size_t sz,
                 c->cmd_sock = redis_sock;
                 efree(nodes);
                 return 0;
+
             }
         }
     }
@@ -1402,7 +1403,7 @@ static void cluster_update_slot(redisCluster *c) {
 
         /* Check to see if we have this new node mapped */
         node = cluster_find_node(c, c->redir_host, c->redir_port);
-        
+
         if (node) {
             /* Just point to this slot */
             c->master[c->redir_slot] = node;
@@ -1433,7 +1434,6 @@ static void cluster_update_slot(redisCluster *c) {
 
             /* Now point our slot at the node */
             c->master[c->redir_slot] = node;
-            
         }
     } else {
         /* Check to see if the ip and port are mapped */
@@ -1537,7 +1537,7 @@ PHP_REDIS_API int cluster_send_slot(redisCluster *c, short slot, char *cmd,
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char *cmd,
                                          int cmd_len)
 {
-    int resp, timedout = 0, remaped = 0;
+    int resp, timedout = 0;
     long msstart;
 
     if (!SLOT(c, slot)) {

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -45,11 +45,11 @@
 #define CMD_SOCK(c) (c->cmd_sock)
 #define CMD_STREAM(c) (c->cmd_sock->stream)
 
-/* Compare redirection slot information with what we have */
-#define CLUSTER_REDIR_CMP(c) \
-    (SLOT_SOCK(c,c->redir_slot)->port != c->redir_port || \
-    ZSTR_LEN(SLOT_SOCK(c,c->redir_slot)->host) != c->redir_host_len || \
-    memcmp(ZSTR_VAL(SLOT_SOCK(c,c->redir_slot)->host),c->redir_host,c->redir_host_len))
+/* Compare redirection slot information with the passed node */
+#define CLUSTER_REDIR_CMP(c, sock) \
+    (sock->port != c->redir_port || \
+    ZSTR_LEN(sock->host) != c->redir_host_len || \
+    memcmp(ZSTR_VAL(sock->host),c->redir_host,c->redir_host_len))
 
 /* Clear out our "last error" */
 #define CLUSTER_CLEAR_ERROR(c) do { \


### PR DESCRIPTION
When using phpredis with RedisCluster, and a failover takes place on the cluster, the old primary does not get removed from the masters cache.
It means that if a user attempts to ping the masters after a failover, an exception will be thrown.
```
foreach ($obj_cluster->_masters() as $arr_master) {
    $obj_cluster->ping($arr_master);
}
 
Array PHP Fatal error:  Uncaught RedisClusterException: Unable to send command at the specified node in /home/ec2-user/clusterTest2/test.php:31
Stack trace:
#0 /home/ec2-user/clusterTest2/test.php(31): RedisCluster->ping(Array)
#1 {main}
  thrown in /home/ec2-user/clusterTest2/test.php on line 31
```

This PR adds support for remapping the cluster's keyspace when a failover occurs: 
In the current implementation, when we get a MOVED error, we check to see if the redirected address belongs to an existing primary, and if it doesn't, we create a new node and add it to the cluster's primaries. It will end up with a stale primary on the _masters array.
In this fix, I added a check to detect a failover: if the redirected node was a replica of the master that is currently pointing to this slot, then a failover had occurred. In the case of a failover, the cluster's topology has changed, and we will call cluster_map_keyspace() to reinitialize the cluster's nodes cache.

I ran the following test scenario: 
1. Created a cluster with 2 shards = [[primary=6379], [primary=6378,replica=6377]]
2. Created a RedisCluster instance:
```
foreach ($obj_cluster->_masters() as $arr_master) {
    print_r($arr_master);
```
  
Output:
```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)
Array
(
    [0] => 127.0.0.1
    [1] => 6378
)
```

3. Killed primary 6378 & executed failover takeover on replica 6377, so replica 6377 became the new primary of this shard
4.  Ran GET command with a slot of the failed primary (to get the MOVED error)
5.  Tested the _masters array: after the old primary (6378) was killed, the masters array was updated with the new promoted primary (6377), but the old primary hasn’t been removed. 
```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)

Array
(
    [0] => 127.0.0.1
    [1] => 6377
)

Array
(
    [0] => 127.0.0.1
    [1] => 6378
)
```

 With the changes I suggest in this PR the _masters array is updated correctly after the failover:
 ```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)

Array
(
    [0] => 127.0.0.1
    [1] => 6377
)
```



