### PR TITLE
Added support for remapping the cluster's keyspace on a failover

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -45,11 +45,11 @@
 #define CMD_SOCK(c) (c->cmd_sock)
 #define CMD_STREAM(c) (c->cmd_sock->stream)
 
-/* Compare redirection slot information with what we have */
-#define CLUSTER_REDIR_CMP(c) \
-    (SLOT_SOCK(c,c->redir_slot)->port != c->redir_port || \
-    ZSTR_LEN(SLOT_SOCK(c,c->redir_slot)->host) != c->redir_host_len || \
-    memcmp(ZSTR_VAL(SLOT_SOCK(c,c->redir_slot)->host),c->redir_host,c->redir_host_len))
+/* Compare redirection slot information with the passed node */
+#define CLUSTER_REDIR_CMP(c, sock) \
+    (sock->port != c->redir_port || \
+    ZSTR_LEN(sock->host) != c->redir_host_len || \
+    memcmp(ZSTR_VAL(sock->host),c->redir_host,c->redir_host_len))
 
 /* Clear out our "last error" */
 #define CLUSTER_CLEAR_ERROR(c) do { \


### PR DESCRIPTION
When using phpredis with RedisCluster, and a failover takes place on the cluster, the old primary does not get removed from the masters cache.
It means that if a user attempts to ping the masters after a failover, an exception will be thrown.
```
foreach ($obj_cluster->_masters() as $arr_master) {
    $obj_cluster->ping($arr_master);
}
 
Array PHP Fatal error:  Uncaught RedisClusterException: Unable to send command at the specified node in /home/ec2-user/clusterTest2/test.php:31
Stack trace:
#0 /home/ec2-user/clusterTest2/test.php(31): RedisCluster->ping(Array)
#1 {main}
  thrown in /home/ec2-user/clusterTest2/test.php on line 31
```

This PR adds support for remapping the cluster's keyspace when a failover occurs: 
In the current implementation, when we get a MOVED error, we check to see if the redirected address belongs to an existing primary, and if it doesn't, we create a new node and add it to the cluster's primaries. It will end up with a stale primary on the _masters array.
In this fix, I added a check to detect a failover: if the redirected node was a replica of the master that is currently pointing to this slot, then a failover had occurred. In the case of a failover, the cluster's topology has changed, and we will call cluster_map_keyspace() to reinitialize the cluster's nodes cache.

I ran the following test scenario: 
1. Created a cluster with 2 shards = [[primary=6379], [primary=6378,replica=6377]]
2. Created a RedisCluster instance:
```
foreach ($obj_cluster->_masters() as $arr_master) {
    print_r($arr_master);
```
  
Output:
```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)
Array
(
    [0] => 127.0.0.1
    [1] => 6378
)
```

3. Killed primary 6378 & executed failover takeover on replica 6377, so replica 6377 became the new primary of this shard
4.  Ran GET command with a slot of the failed primary (to get the MOVED error)
5.  Tested the _masters array: after the old primary (6378) was killed, the masters array was updated with the new promoted primary (6377), but the old primary hasn’t been removed. 
```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)

Array
(
    [0] => 127.0.0.1
    [1] => 6377
)

Array
(
    [0] => 127.0.0.1
    [1] => 6378
)
```

 With the changes I suggest in this PR the _masters array is updated correctly after the failover:
 ```
Array
(
    [0] => 127.0.0.1
    [1] => 6379
)

Array
(
    [0] => 127.0.0.1
    [1] => 6377
)
```



