### PR TITLE
Remove experimental for PHP 8.1 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
         include:
           - php: '8.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
         include:
-          - php: '8.1'
+          - php: '8.2'
             experimental: true
     steps:
       - name: Checkout


### PR DESCRIPTION
Given that PHP 8.1 will be released within 2 weeks I think it's good to fail instead of skip.

