### PR TITLE
Relax TTL test and run a smaller cluster in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             redis-server --port $PORT --cluster-enabled yes --cluster-config-file $PORT.conf --daemonize yes --aclfile tests/users.acl
             echo 127.0.0.1:$PORT >> tests/nodes/nodemap
           done
-          echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7011) --cluster-replicas 3 --user phpredis -a phpredis
+          echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7006) --cluster-replicas 1 --user phpredis -a phpredis
       - name: Start redis sentinel
         run: |
           wget raw.githubusercontent.com/redis/redis/6.2/sentinel.conf

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1924,10 +1924,8 @@ class Redis_Test extends TestSuite
     public function testttl() {
         $this->redis->set('x', 'y');
         $this->redis->expire('x', 5);
-        for($i = 5; $i > 0; $i--) {
-            $this->assertEquals($i, $this->redis->ttl('x'));
-            sleep(1);
-        }
+        $ttl = $this->redis->ttl('x');
+        $this->assertTrue($ttl > 0 && $ttl <= 5);
 
         // A key with no TTL
         $this->redis->del('x'); $this->redis->set('x', 'bar');


### PR DESCRIPTION
Wild guess that perhaps resource exhaustion is causing our flaky `testTime` cluster test.