### PR TITLE
Fix fallthrough warnings and refactor adding a score

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -222,6 +222,7 @@ cluster_read_sock_resp(RedisSock *redis_sock, REDIS_REPLY_TYPE type,
                 r->str = estrndup(line_reply, len);
                 r->len = len;
             }
+            REDIS_FALLTHROUGH;
         case TYPE_ERR:
             return r;
         case TYPE_BULK:

--- a/common.h
+++ b/common.h
@@ -16,6 +16,16 @@
 #define PHPREDIS_GET_OBJECT(class_entry, o) (class_entry *)((char *)o - XtOffsetOf(class_entry, std))
 #define PHPREDIS_ZVAL_GET_OBJECT(class_entry, z) PHPREDIS_GET_OBJECT(class_entry, Z_OBJ_P(z))
 
+/* We'll fallthrough if we want to */
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+#if __has_attribute(__fallthrough__)
+#define REDIS_FALLTHROUGH __attribute__((__fallthrough__))
+#else
+#define REDIS_FALLTHROUGH do { } while (0)
+#endif
+
 /* NULL check so Eclipse doesn't go crazy */
 #ifndef NULL
 #define NULL   ((void *) 0)

--- a/library.c
+++ b/library.c
@@ -659,8 +659,7 @@ redis_sock_read(RedisSock *redis_sock, int *buf_len)
             if(memcmp(inbuf + 1, "-1", 2) == 0) {
                 return NULL;
             }
-            /* fall through */
-
+            REDIS_FALLTHROUGH;
         case '+':
         case ':':
             /* Single Line Reply */
@@ -669,6 +668,7 @@ redis_sock_read(RedisSock *redis_sock, int *buf_len)
                 *buf_len = len;
                 return estrndup(inbuf, *buf_len);
             }
+            REDIS_FALLTHROUGH;
         default:
             zend_throw_exception_ex(redis_exception_ce, 0,
                 "protocol error, got '%c' as reply type byte\n",


### PR DESCRIPTION
* Suppress implicit fallthrough warnings by using an attribute if we
  have it and a do { } while(0) if we don't.

* Move duplicated logic for appending a ZSET score to one utility
  function.