### PR TITLE
Fix LZF decompression logic.

### DIFF
--- a/library.c
+++ b/library.c
@@ -3032,7 +3032,7 @@ redis_uncompress(RedisSock *redis_sock, char **dst, size_t *dstlen, const char *
             {
                 char *data = NULL;
                 uint32_t res;
-                int i = 2;
+                int i;
 
                 if (len == 0)
                     break;

--- a/library.c
+++ b/library.c
@@ -3030,27 +3030,22 @@ redis_uncompress(RedisSock *redis_sock, char **dst, size_t *dstlen, const char *
         case REDIS_COMPRESSION_LZF:
 #ifdef HAVE_REDIS_LZF
             {
-                char *data;
-                int i;
+                char *data = NULL;
                 uint32_t res;
+                int i = 2;
 
                 if (len == 0)
                     break;
 
-                /* start from two-times bigger buffer and
-                 * increase it exponentially  if needed */
+                /* Grow our buffer until we succeed or get a non E2BIG error */
                 errno = E2BIG;
                 for (i = 2; errno == E2BIG; i *= 2) {
-                    data = emalloc(i * len);
-                    if ((res = lzf_decompress(src, len, data, i * len)) == 0) {
-                        /* errno != E2BIG will brake for loop */
-                        efree(data);
-                        continue;
+                    data = erealloc(data, len * i);
+                    if ((res = lzf_decompress(src, len, data, len * i)) > 0) {
+                        *dst = data;
+                        *dstlen = res;
+                        return 1;
                     }
-
-                    *dst = data;
-                    *dstlen = res;
-                    return 1;
                 }
 
                 efree(data);

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -4730,6 +4730,14 @@ class Redis_Test extends TestSuite
         if (!defined('Redis::COMPRESSION_LZF')) {
             $this->markTestSkipped();
         }
+
+        /* Don't crash on improperly compressed LZF data */
+        $payload = 'not-actually-lzf-compressed';
+        $this->redis->set('badlzf', $payload);
+        $this->redis->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
+        $this->assertEquals($payload, $this->redis->get('badlzf'));
+        $this->redis->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_NONE);
+
         $this->checkCompression(Redis::COMPRESSION_LZF, 0);
     }
 


### PR DESCRIPTION
Rework how we decompress LZF data.  Previously it was possible to
encounter a double-free, if the error was not E2BIG.