### PR TITLE
Don't allow reconnect on read response

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1161,7 +1161,7 @@ static int cluster_check_response(redisCluster *c, REDIS_REPLY_TYPE *reply_type)
     CLUSTER_CLEAR_ERROR(c);
     CLUSTER_CLEAR_REPLY(c);
 
-    if (-1 == redis_check_eof(c->cmd_sock, 1) ||
+    if (-1 == redis_check_eof(c->cmd_sock, 1, 1) ||
        EOF == (*reply_type = php_stream_getc(c->cmd_sock->stream)))
     {
         return -1;

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -62,12 +62,12 @@
 
 /* Protected sending of data down the wire to a RedisSock->stream */
 #define CLUSTER_SEND_PAYLOAD(sock, buf, len) \
-    (sock && !redis_sock_server_open(sock) && sock->stream && !redis_check_eof(sock, 1 ) && \
+    (sock && !redis_sock_server_open(sock) && sock->stream && !redis_check_eof(sock, 0, 1) && \
      php_stream_write(sock->stream, buf, len)==len)
 
 /* Macro to read our reply type character */
 #define CLUSTER_VALIDATE_REPLY_TYPE(sock, type) \
-    (redis_check_eof(sock, 1) == 0 && \
+    (redis_check_eof(sock, 1, 1) == 0 && \
      (php_stream_getc(sock->stream) == type))
 
 /* Reset our last single line reply buffer and length */

--- a/library.h
+++ b/library.h
@@ -111,7 +111,7 @@ PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
     RedisSock *redis_sock, zval *z_tab, void *ctx);
 
 PHP_REDIS_API int redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz);
-PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, int no_throw);
+PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, zend_bool no_retry, zend_bool no_throw);
 PHP_REDIS_API RedisSock *redis_sock_get(zval *id, int nothrow);
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len);


### PR DESCRIPTION
It doesn't make sense to reconnect while reading response