### PR TITLE
Add 'BIT'/'BYTE' modifier to BITCOUNT + tests

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -42,7 +42,7 @@ class Redis {
     public function bgrewriteaof(): bool;
 
     /** @return int|Redis */
-    public function bitcount(string $key, int $start = 0, int $end = -1);
+    public function bitcount(string $key, int $start = 0, int $end = -1, bool $bybit = false);
 
     /**
      * @return int|Redis

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d3ef188b058066309394ffaaf00489572d7b629 */
+ * Stub hash: b9da355c27e6fb1b776164d40a521703e31713b5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -53,6 +53,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_bitcount, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bybit, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_bitop, 0, 3, IS_LONG, 0)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2267,15 +2267,21 @@ int redis_bitcount_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     size_t key_len;
     zend_long start = 0, end = -1;
+    zend_bool isbit = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|ll", &key, &key_len,
-                             &start, &end) == FAILURE)
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|llb", &key, &key_len,
+                             &start, &end, &isbit) == FAILURE)
     {
         return FAILURE;
     }
 
-    *cmd_len = REDIS_CMD_SPPRINTF(cmd, "BITCOUNT", "kdd", key, key_len,
-                                 (int)start, (int)end);
+    if (isbit) {
+        *cmd_len = REDIS_CMD_SPPRINTF(cmd, "BITCOUNT", "kdds", key, key_len,
+                                     (int)start, (int)end, "BIT", 3);
+    } else {
+        *cmd_len = REDIS_CMD_SPPRINTF(cmd, "BITCOUNT", "kdd", key, key_len,
+                                     (int)start, (int)end);
+    }
 
     return SUCCESS;
 }

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d3ef188b058066309394ffaaf00489572d7b629 */
+ * Stub hash: b9da355c27e6fb1b776164d40a521703e31713b5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -48,6 +48,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_bitcount, 0, 0, 1)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, start)
 	ZEND_ARG_INFO(0, end)
+	ZEND_ARG_INFO(0, bybit)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_bitop, 0, 0, 3)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -206,6 +206,30 @@ class Redis_Test extends TestSuite
         $this->assertFalse($this->redis->pubsub("numsub", "not-an-array"));
     }
 
+    /* These test cases were generated randomly.  We're just trying to test
+       that PhpRedis handles all combination of arguments correctly. */
+    public function testBitcount() {
+        /* key */
+        $this->redis->set('bitcountkey', hex2bin('bd906b854ca76cae'));
+        $this->assertEquals(33, $this->redis->bitcount('bitcountkey'));
+
+        /* key, start */
+        $this->redis->set('bitcountkey', hex2bin('400aac171382a29bebaab554f178'));
+        $this->assertEquals(4, $this->redis->bitcount('bitcountkey', 13));
+
+        /* key, start, end */
+        $this->redis->set('bitcountkey', hex2bin('b1f32405'));
+        $this->assertEquals(2, $this->redis->bitcount('bitcountkey', 3, 3));
+
+        /* key, start, end BYTE */
+        $this->redis->set('bitcountkey', hex2bin('10eb8939e68bfdb640260f0629f3'));
+        $this->assertEquals(1, $this->redis->bitcount('bitcountkey', 8, 8, false));
+
+        /* key, start, end, BIT */
+        $this->redis->set('bitcountkey', hex2bin('cd0e4c80f9e4590d888a10'));
+        $this->assertEquals(5, $this->redis->bitcount('bitcountkey', 0, 9, true));
+    }
+
     public function testBitsets() {
 
         $this->redis->del('key');


### PR DESCRIPTION
BITCOUNT can take a third optional argument ('BIT', or 'BYTE').

Additionally add a specific test for BITCOUNT that tests all of the legal ways it can be called in PhpRedis.