### PR TITLE
Return false or NULL on empty lpos response

### DIFF
--- a/library.c
+++ b/library.c
@@ -1378,6 +1378,7 @@ redis_lpos_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z
     int i, numElems;
     size_t len;
     zval z_ret;
+    long lval;
 
     if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf), &len) < 0) {
         goto failure;
@@ -1387,7 +1388,14 @@ redis_lpos_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z
         if (*inbuf != TYPE_INT && *inbuf != TYPE_BULK) {
             goto failure;
         }
-        ZVAL_LONG(&z_ret, atol(inbuf + 1));
+        lval = atol(inbuf + 1);
+        if (lval > -1) {
+            ZVAL_LONG(&z_ret, lval);
+        } else if (redis_sock->null_mbulk_as_null) {
+            ZVAL_NULL(&z_ret);
+        } else {
+            ZVAL_FALSE(&z_ret);
+        }
     } else if (ctx == PHPREDIS_CTX_PTR) {
         if (*inbuf != TYPE_MULTIBULK) {
             goto failure;

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -241,7 +241,7 @@ class Redis {
 
     public function lPop(string $key, int $count = 0): bool|string|array;
 
-    public function lPos(string $key, mixed $value, array $options = null): bool|int|array;
+    public function lPos(string $key, mixed $value, array $options = null): null|bool|int|array;
 
     /**
      * @param mixed $elements

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9da355c27e6fb1b776164d40a521703e31713b5 */
+ * Stub hash: 2b1fc18e5c464c551df8572363972769b2ec1096 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -417,7 +417,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_lPop, 0, 1, MAY_BE_B
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_lPos, 0, 2, MAY_BE_BOOL|MAY_BE_LONG|MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_lPos, 0, 2, MAY_BE_NULL|MAY_BE_BOOL|MAY_BE_LONG|MAY_BE_ARRAY)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9da355c27e6fb1b776164d40a521703e31713b5 */
+ * Stub hash: 2b1fc18e5c464c551df8572363972769b2ec1096 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1050,7 +1050,7 @@ class Redis_Test extends TestSuite
         $this->assertEquals([0], $this->redis->lPos('key', 'val1', ['count' => 2, 'maxlen' => 1]));
         $this->assertEquals([], $this->redis->lPos('key', 'val2', ['count' => 1]));
 
-        foreach ([[false, false], [true, NULL], [false, false]] as $optpack) {
+        foreach ([[true, NULL], [false, false]] as $optpack) {
             list ($setting, $expected) = $optpack;
             $this->redis->setOption(Redis::OPT_NULL_MULTIBULK_AS_NULL, $setting);
             $this->assertEquals($expected, $this->redis->lPos('key', 'val2'));

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1049,7 +1049,12 @@ class Redis_Test extends TestSuite
         $this->assertEquals([0, 1], $this->redis->lPos('key', 'val1', ['count' => 2]));
         $this->assertEquals([0], $this->redis->lPos('key', 'val1', ['count' => 2, 'maxlen' => 1]));
         $this->assertEquals([], $this->redis->lPos('key', 'val2', ['count' => 1]));
-        $this->assertEquals(-1, $this->redis->lPos('key', 'val2'));
+
+        foreach ([[false, false], [true, NULL], [false, false]] as $optpack) {
+            list ($setting, $expected) = $optpack;
+            $this->redis->setOption(Redis::OPT_NULL_MULTIBULK_AS_NULL, $setting);
+            $this->assertEquals($expected, $this->redis->lPos('key', 'val2'));
+        }
     }
 
     // ltrim, lsize, lpop


### PR DESCRIPTION
To be consistent with other PhpRedis methods, we should return either false or NULL when LPOS returns no results, depening on NULL_MBULK_AS_NULL setting.