### PR TITLE
Add back a default switch case for setoption handler

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -5566,7 +5566,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 RETURN_TRUE;
             }
             break;
-        EMPTY_SWITCH_DEFAULT_CASE()
+        default:
+            php_error_docref(NULL, E_WARNING, "Unknown option '" ZEND_LONG_FMT "'", option);
+            break;
     }
     RETURN_FALSE;
 }

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6985,6 +6985,11 @@ class Redis_Test extends TestSuite
         $this->assertEquals('bar', $this->redis->get('key2'));
     }
 
+    /* Make sure we handle a bad option value gracefully */
+    public function testBadOptionValue() {
+        $this->assertFalse(@$this->redis->setOption(pow(2, 32), false));
+    }
+
     public  function testSession_regenerateSessionId_noLock_noDestroy() {
         $this->setSessionHandler();
         $sessionId = $this->generateSessionId();


### PR DESCRIPTION
We can't use `EMPTY_SWITCH_DEFAULT_CASE` here as the underlying macro will actually panic, as it calls `ZEND_UNREACHABLE` under the hood.