### PR TITLE
Relax OBJECT idletime tests to avoid false failures.

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3060,7 +3060,7 @@ class Redis_Test extends TestSuite
         $this->redis->set('key', 'value');
         $this->assertTrue($this->redis->object('encoding', 'key') === $str_small_encoding);
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
-        $this->assertTrue($this->redis->object('idletime', 'key') === 0);
+        $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 
         $this->redis->del('key');
         $this->redis->lpush('key', 'value');
@@ -3071,20 +3071,20 @@ class Redis_Test extends TestSuite
         $this->assertTrue($str_encoding === "ziplist" || $str_encoding === 'quicklist');
 
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
-        $this->assertTrue($this->redis->object('idletime', 'key') === 0);
+        $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 
         $this->redis->del('key');
         $this->redis->sadd('key', 'value');
         $this->assertTrue($this->redis->object('encoding', 'key') === "hashtable");
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
-        $this->assertTrue($this->redis->object('idletime', 'key') === 0);
+        $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 
         $this->redis->del('key');
         $this->redis->sadd('key', 42);
         $this->redis->sadd('key', 1729);
         $this->assertTrue($this->redis->object('encoding', 'key') === "intset");
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
-        $this->assertTrue($this->redis->object('idletime', 'key') === 0);
+        $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 
         $this->redis->del('key');
         $this->redis->lpush('key', str_repeat('A', pow(10,6))); // 1M elements, too big for a ziplist.
@@ -3093,7 +3093,7 @@ class Redis_Test extends TestSuite
         $this->assertTrue($str_encoding === "linkedlist" || $str_encoding == "quicklist");
 
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
-        $this->assertTrue($this->redis->object('idletime', 'key') === 0);
+        $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
     }
 
     public function testMultiExec() {


### PR DESCRIPTION
Instead of testing that `OBJECT IDLETIME` returns exactly zero after updating a key in our tests, just make sure PhpRedis returns us some numeric value.

We can't really test for a specific number of elapsed seconds in CI as the VMs may be randomly preempted at times beyond our control, causing the tests to "fail" even though there was no actual failure.