### PR TITLE
Refactor BITPOS and implement BIT/BYTE option.

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -41,7 +41,19 @@ class Redis {
 
     public function bitop(string $operation, string $deskey, string $srckey, string ...$other_keys): Redis|int|false;
 
-    public function bitpos(string $key, int $bit, int $start = 0, int $end = -1): Redis|int|false;
+    /**
+      Return the position of the first bit set to 0 or 1 in a string.
+
+      @see https://https://redis.io/commands/bitpos/
+
+      @param string $key   The key to check (must be a string)
+      @param bool   $bit   Whether to look for an unset (0) or set (1) bit.
+      @param int    $start Where in the string to start looking.
+      @param int    $end   Where in the string to stop looking.
+      @param bool   $bybit If true, Redis will treat $start and $end as BIT values and not bytes, so if start
+                           was 0 and end was 2, Redis would only search the first two bits.
+     */
+    public function bitpos(string $key, bool $bit, int $start = 0, int $end = -1, bool $bybit = false): Redis|int|false;
 
     public function blPop(string|array $key, string|float|int $timeout_or_key, mixed ...$extra_args): Redis|array|null|false;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b53146f6b329f404b4bfa9e5df9dde9c36b50440 */
+ * Stub hash: a8ddcde8e8af5201d72bfe8b463afc0c9dafb73d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -65,9 +65,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_bitpos, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, bit, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, bit, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bybit, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_blPop, 0, 2, Redis, MAY_BE_ARRAY|MAY_BE_NULL|MAY_BE_FALSE)

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -40,7 +40,19 @@ class RedisCluster {
 
     public function bitop(string $operation, string $deskey, string $srckey, string ...$otherkeys): RedisCluster|bool|int;
 
-    public function bitpos(string $key, int $bit, int $start = NULL, int $end = NULL): RedisCluster|bool|int;
+    /**
+      Return the position of the first bit set to 0 or 1 in a string.
+
+      @see https://https://redis.io/commands/bitpos/
+
+      @param string $key   The key to check (must be a string)
+      @param bool   $bit   Whether to look for an unset (0) or set (1) bit.
+      @param int    $start Where in the string to start looking.
+      @param int    $end   Where in the string to stop looking.
+      @param bool   $bybit If true, Redis will treat $start and $end as BIT values and not bytes, so if start
+                           was 0 and end was 2, Redis would only search the first two bits.
+     */
+    public function bitpos(string $key, bool $bit, int $start = 0, int $end = -1, bool $bybit = false): RedisCluster|int|false;
 
     public function blpop(string|array $key, string|float|int $timeout_or_key, mixed ...$extra_args): RedisCluster|array|null|false;
     public function brpop(string|array $key, string|float|int $timeout_or_key, mixed ...$extra_args): RedisCluster|array|null|false;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6b41f3c801e587509bc5c7cab302dc6c1e0f7d56 */
+ * Stub hash: ccb418a312ff22f03e2354de508ff8bd9e4d266e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -72,11 +72,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_bitop, 0,
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, otherkeys, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_bitpos, 0, 2, RedisCluster, MAY_BE_BOOL|MAY_BE_LONG)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_bitpos, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, bit, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "NULL")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "NULL")
+	ZEND_ARG_TYPE_INFO(0, bit, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_LONG, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bybit, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_blpop, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_NULL|MAY_BE_FALSE)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6b41f3c801e587509bc5c7cab302dc6c1e0f7d56 */
+ * Stub hash: ccb418a312ff22f03e2354de508ff8bd9e4d266e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -70,6 +70,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_bitpos, 0, 0, 2)
 	ZEND_ARG_INFO(0, bit)
 	ZEND_ARG_INFO(0, start)
 	ZEND_ARG_INFO(0, end)
+	ZEND_ARG_INFO(0, bybit)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_blpop, 0, 0, 2)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b53146f6b329f404b4bfa9e5df9dde9c36b50440 */
+ * Stub hash: a8ddcde8e8af5201d72bfe8b463afc0c9dafb73d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -63,6 +63,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_bitpos, 0, 0, 2)
 	ZEND_ARG_INFO(0, bit)
 	ZEND_ARG_INFO(0, start)
 	ZEND_ARG_INFO(0, end)
+	ZEND_ARG_INFO(0, bybit)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_blPop, 0, 0, 2)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -409,6 +409,14 @@ class Redis_Test extends TestSuite
 
         $this->redis->set('bpkey', "\x00\x00\x00");
         $this->assertEquals($this->redis->bitpos('bpkey', 1), -1);
+
+        if (!$this->minVersionCheck("7.0.0"))
+            return;
+
+        $this->redis->set('bpkey', "\xF");
+        $this->assertEquals(4, $this->redis->bitpos('bpkey', 1, 0, -1, true));
+        $this->assertEquals(-1,  $this->redis->bitpos('bpkey', 1, 1, -1));
+        $this->assertEquals(-1,  $this->redis->bitpos('bpkey', 1, 1, -1, false));
     }
 
     public function test1000() {


### PR DESCRIPTION
Update BITPOS to use the new argument parsing macros as well as implement Redis 7.0.0's BIT/BYTE modifier.

Additionally I changed `int $bit` to `bool $bit` as its a more appropriate datatype.

See #2068