### PR TITLE
Add missing directed node command to docs and refactor stubs.

### DIFF
--- a/cluster.markdown
+++ b/cluster.markdown
@@ -145,22 +145,28 @@ foreach ($obj_cluster->_masters() as $arr_master) {
 
 In the case of all commands which need to be directed at a node, the calling convention is identical to the Redis call, except that they require an additional (first) argument in order to deliver the command.  Following is a list of each of these commands:
 
-1.  SAVE
-2.  BGSAVE
-3.  FLUSHDB
-4.  FLUSHALL
-5.  DBSIZE
-6.  BGREWRITEAOF
-7.  LASTSAVE
-8.  INFO
-9.  CLIENT
-10.  CLUSTER
-11.  CONFIG
-12.  PUBSUB
-13.  SLOWLOG
-14.  RANDOMKEY
-15.  PING
-16.  SCAN
+1. ACL
+1. BGREWRITEAOF
+1. BGSAVE
+1. CLIENT
+1. CLUSTER
+1. CONFIG
+1. DBSIZE
+1. ECHO
+1. FLUSHALL
+1. FLUSHDB
+1. INFO
+1. LASTSAVE
+1. PING
+1. PUBSUB
+1. RANDOMKEY
+1. RAWCOMMAND
+1. ROLE
+1. SAVE
+1. SCAN
+1. SCRIPT
+1. SLOWLOG
+1. TIME
 
 ## Session Handler
 You can use the cluster functionality of phpredis to store PHP session information in a Redis cluster as you can with a non cluster-enabled Redis instance.

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -61,15 +61,15 @@ class RedisCluster {
 
     public function clearlasterror(): bool;
 
-    public function client(string|array $node, string $subcommand, ?string $arg = NULL): array|string|bool;
+    public function client(string|array $key_or_address, string $subcommand, ?string $arg = NULL): array|string|bool;
 
     public function close(): bool;
 
-    public function cluster(string|array $node, string $command, mixed ...$extra_args): mixed;
+    public function cluster(string|array $key_or_address, string $command, mixed ...$extra_args): mixed;
 
     public function command(mixed ...$extra_args): mixed;
 
-    public function config(string|array $node, string $subcommand, mixed ...$extra_args): mixed;
+    public function config(string|array $key_or_address, string $subcommand, mixed ...$extra_args): mixed;
 
     public function dbsize(string|array $key_or_address): RedisCluster|int;
 
@@ -85,7 +85,7 @@ class RedisCluster {
 
     public function dump(string $key): RedisCluster|string|false;
 
-    public function echo(string|array $node, string $msg): RedisCluster|string|false;
+    public function echo(string|array $key_or_address, string $msg): RedisCluster|string|false;
 
     public function eval(string $script, array $args = [], int $num_keys = 0): mixed;
 
@@ -103,9 +103,9 @@ class RedisCluster {
 
     public function pexpiretime(string $key): RedisCluster|int|false;
 
-    public function flushall(string|array $node, bool $async = false): RedisCluster|bool;
+    public function flushall(string|array $key_or_address, bool $async = false): RedisCluster|bool;
 
-    public function flushdb(string|array $node, bool $async = false): RedisCluster|bool;
+    public function flushdb(string|array $key_or_address, bool $async = false): RedisCluster|bool;
 
     public function geoadd(string $key, float $lng, float $lat, string $member, mixed ...$other_triples): RedisCluster|int;
 
@@ -175,11 +175,11 @@ class RedisCluster {
 
     public function incrbyfloat(string $key, float $value): RedisCluster|float|false;
 
-    public function info(string|array $node, ?string $section = null): RedisCluster|array|false;
+    public function info(string|array $key_or_address, ?string $section = null): RedisCluster|array|false;
 
     public function keys(string $pattern): RedisCluster|array|false;
 
-    public function lastsave(string|array $node): RedisCluster|int|false;
+    public function lastsave(string|array $key_or_address): RedisCluster|int|false;
 
     public function lget(string $key, int $index): RedisCluster|string|bool;
 
@@ -268,7 +268,7 @@ class RedisCluster {
 
     public function save(string|array $key_or_address): RedisCluster|bool;
 
-    public function scan(?int &$iterator, mixed $node, ?string $pattern = null, int $count = 0): bool|array;
+    public function scan(?int &$iterator, string|array $key_or_address, ?string $pattern = null, int $count = 0): bool|array;
 
     public function scard(string $key): RedisCluster|int|false;
 

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 280323a9e3fc028641ad1d8bcba2514dfa90fac9 */
+ * Stub hash: c6326ac0f4a1dc7b6fe920a7358010f1a570832a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -122,7 +122,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_clearlasterro
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_RedisCluster_client, 0, 2, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_BOOL)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, subcommand, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg, IS_STRING, 1, "NULL")
 ZEND_END_ARG_INFO()
@@ -130,7 +130,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_close arginfo_class_RedisCluster_clearlasterror
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_cluster, 0, 2, IS_MIXED, 0)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, command, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -140,7 +140,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_command, 0, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_config, 0, 2, IS_MIXED, 0)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, subcommand, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, extra_args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -176,7 +176,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_dump, 0, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_echo, 0, 2, RedisCluster, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, msg, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -217,7 +217,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_pexpiretime arginfo_class_RedisCluster_expiretime
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_flushall, 0, 1, RedisCluster, MAY_BE_BOOL)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, async, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -381,7 +381,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_incrbyflo
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_info, 0, 1, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, section, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -390,7 +390,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_keys, 0, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_lastsave, 0, 1, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_MASK(0, node, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_lget, 0, 2, RedisCluster, MAY_BE_STRING|MAY_BE_BOOL)
@@ -591,7 +591,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_RedisCluster_scan, 0, 2, MAY_BE_BOOL|MAY_BE_ARRAY)
 	ZEND_ARG_TYPE_INFO(1, iterator, IS_LONG, 1)
-	ZEND_ARG_TYPE_INFO(0, node, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, key_or_address, MAY_BE_STRING|MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 280323a9e3fc028641ad1d8bcba2514dfa90fac9 */
+ * Stub hash: c6326ac0f4a1dc7b6fe920a7358010f1a570832a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -110,7 +110,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_clearlasterror arginfo_class_RedisCluster__masters
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_client, 0, 0, 2)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, subcommand)
 	ZEND_ARG_INFO(0, arg)
 ZEND_END_ARG_INFO()
@@ -118,7 +118,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_close arginfo_class_RedisCluster__masters
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_cluster, 0, 0, 2)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, command)
 	ZEND_ARG_VARIADIC_INFO(0, extra_args)
 ZEND_END_ARG_INFO()
@@ -128,7 +128,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_command, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_config, 0, 0, 2)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, subcommand)
 	ZEND_ARG_VARIADIC_INFO(0, extra_args)
 ZEND_END_ARG_INFO()
@@ -154,7 +154,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_dump arginfo_class_RedisCluster__prefix
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_echo, 0, 0, 2)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, msg)
 ZEND_END_ARG_INFO()
 
@@ -189,7 +189,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_pexpiretime arginfo_class_RedisCluster__prefix
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_flushall, 0, 0, 1)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, async)
 ZEND_END_ARG_INFO()
 
@@ -323,7 +323,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_incrbyfloat arginfo_class_RedisCluster_append
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_info, 0, 0, 1)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, section)
 ZEND_END_ARG_INFO()
 
@@ -331,9 +331,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_keys, 0, 0, 1)
 	ZEND_ARG_INFO(0, pattern)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_lastsave, 0, 0, 1)
-	ZEND_ARG_INFO(0, node)
-ZEND_END_ARG_INFO()
+#define arginfo_class_RedisCluster_lastsave arginfo_class_RedisCluster_bgrewriteaof
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_lget, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -499,7 +497,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_scan, 0, 0, 2)
 	ZEND_ARG_INFO(1, iterator)
-	ZEND_ARG_INFO(0, node)
+	ZEND_ARG_INFO(0, key_or_address)
 	ZEND_ARG_INFO(0, pattern)
 	ZEND_ARG_INFO(0, count)
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
* Add every "directed node" command we could find to the relevant section in cluster.markdown.

* Refactor the stubs so every node argument is named the same thing ($key_or_address) and has the same data type (string|array).

Fixes #1840