### PR TITLE
Variadic CONFIG GET/SET

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -559,17 +559,19 @@ _**Description**_: Get or Set the Redis server configuration parameters.
 
 ##### *Prototype*
 ~~~php
-$redis->config($operation, ?string $key = NULL, ?string $value = NULL): mixed;
+$redis->config(string $operation, string|array|null $key = NULL, ?string $value = NULL): mixed;
 ~~~
 
 ##### *Return value*
-*Associative array* for `GET`, key -> value  
-*bool* for `SET`, and `RESETSTAT`
+*Associative array* for `GET`, key(s) -> value(s)  
+*bool* for `SET`, `RESETSTAT`, and `REWRITE`
 
 ##### *Examples*
 ~~~php
 $redis->config("GET", "*max-*-entries*");
+$redis->config("SET", ['timeout', 'loglevel']);
 $redis->config("SET", "dir", "/var/run/redis/dumps/");
+$redis->config("SET", ['timeout' => 128, 'loglevel' => 'warning']);
 $redis->config('RESETSTAT');
 ~~~
 

--- a/library.c
+++ b/library.c
@@ -1151,6 +1151,15 @@ PHP_REDIS_API int redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *r
     return SUCCESS;
 }
 
+PHP_REDIS_API int
+redis_config_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
+    FailableResultCallback cb = ctx;
+
+    ZEND_ASSERT(cb == redis_boolean_response || cb == redis_mbulk_reply_zipped_raw);
+
+    return cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, ctx);
+}
+
 PHP_REDIS_API int redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
     char *response;
     int response_len;

--- a/library.h
+++ b/library.h
@@ -67,6 +67,7 @@ PHP_REDIS_API int redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, Redis
 PHP_REDIS_API int redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+PHP_REDIS_API int redis_config_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API void redis_parse_info_response(char *response, zval *z_ret);
 PHP_REDIS_API void redis_parse_client_list_response(char *response, zval *z_ret);
 PHP_REDIS_API int redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -2707,45 +2707,10 @@ PHP_METHOD(Redis, setOption)
 /* }}} */
 
 /* {{{ proto boolean Redis::config(string op, string key [, mixed value]) */
-PHP_METHOD(Redis, config)
-{
-    zend_string *op, *key = NULL, *val = NULL;
-    FailableResultCallback cb;
-    RedisSock *redis_sock;
-    zval *object;
-    int cmd_len;
-    char *cmd;
-
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "OS|SS", &object,
-                                     redis_ce, &op, &key, &val) == FAILURE)
-    {
-        RETURN_FALSE;
-    }
-
-    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if (zend_string_equals_literal_ci(op, "GET") && key != NULL) {
-        cmd_len = REDIS_SPPRINTF(&cmd, "CONFIG", "SS", op, key);
-        cb = redis_mbulk_reply_zipped_raw;
-    } else if (zend_string_equals_literal_ci(op, "RESETSTAT") ||
-               zend_string_equals_literal_ci(op, "REWRITE"))
-    {
-        cmd_len = REDIS_SPPRINTF(&cmd, "CONFIG", "s", ZSTR_VAL(op), ZSTR_LEN(op));
-        cb = redis_boolean_response;
-    } else if (zend_string_equals_literal_ci(op, "SET") && key != NULL && val != NULL) {
-        cmd_len = REDIS_SPPRINTF(&cmd, "CONFIG", "SSS", op, key, val);
-        cb = redis_boolean_response;
-    } else {
-        RETURN_FALSE;
-    }
-
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len)
-    if (IS_ATOMIC(redis_sock)) {
-        cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, NULL);
-    }
-    REDIS_PROCESS_RESPONSE(redis_boolean_response);
+/* {{{ proto public function config(string $op, string ...$args) }}} */
+// CONFIG SET/GET
+PHP_METHOD(Redis, config) {
+    REDIS_PROCESS_CMD(config, redis_config_response);
 }
 /* }}} */
 

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -81,7 +81,29 @@ class Redis {
 
     public function command(string $opt = null, string|array $arg): mixed;
 
-    public function config(string $operation, ?string $key = NULL, mixed $value = null): mixed;
+    /**
+      Execute the Redis CONFIG command in a variety of ways.  What the command does in particular depends
+      on the `$operation` qualifier.
+
+      Operations that PhpRedis supports are: RESETSTAT, REWRITE, GET, and SET.
+
+      @param string            $operation      The CONFIG subcommand to execute
+      @param array|string|null $key_or_setting Can either be a setting string for the GET/SET operation or
+                                               an array of settings or settings and values.
+                                               Note:  Redis 7.0.0 is required to send an array of settings.
+      @param ?string           $value          The setting value when the operation is SET.
+
+      <code>
+      <?php
+      $redis->config('GET', 'timeout');
+      $redis->config('GET', ['timeout', 'databases']);
+
+      $redis->config('SET', 'timeout', 30);
+      $redis->config('SET', ['timeout' => 30, 'loglevel' => 'warning']);
+      ?>
+      </code>
+     */
+    public function config(string $operation, array|string|null $key_or_settings = NULL, ?string $value = NULL): mixed;
 
     public function connect(string $host, int $port = 6379, float $timeout = 0, string $persistent_id = null, int $retry_interval = 0, float $read_timeout = 0, array $context = null): bool;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bd81918bd558ec53399e7f64647c39f288f3413e */
+ * Stub hash: a024c59eff58030ac224fc22cc4040b6e926a643 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -127,8 +127,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_config, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, operation, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, key, IS_STRING, 1, "NULL")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "null")
+	ZEND_ARG_TYPE_MASK(0, key_or_settings, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_NULL, "NULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 1, "NULL")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_connect, 0, 1, _IS_BOOL, 0)

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -110,6 +110,9 @@ int redis_zrangebyscore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, int *withscores, short *slot,
     void **ctx);
 
+int redis_config_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+    char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_zrandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bd81918bd558ec53399e7f64647c39f288f3413e */
+ * Stub hash: a024c59eff58030ac224fc22cc4040b6e926a643 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -117,7 +117,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_config, 0, 0, 1)
 	ZEND_ARG_INFO(0, operation)
-	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, key_or_settings)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Redis 7.0.0 allows for getting and setting multiple config values as an atomic operation.  In order to support this while maintaining backward compatibility, the CONFIG command is reworked to also accept an array of values or keys and values.

See: #2068