### PR TITLE
Refactor SLOWLOG command

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -2717,57 +2717,7 @@ PHP_METHOD(Redis, config) {
 
 /* {{{ proto boolean Redis::slowlog(string arg, [int option]) */
 PHP_METHOD(Redis, slowlog) {
-    zval *object;
-    RedisSock *redis_sock;
-    char *arg, *cmd;
-    int cmd_len;
-    size_t arg_len;
-    zend_long option = 0;
-    enum {SLOWLOG_GET, SLOWLOG_LEN, SLOWLOG_RESET} mode;
-
-    // Make sure we can get parameters
-    if(zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(),
-                                    "Os|l", &object, redis_ce, &arg, &arg_len,
-                                    &option) == FAILURE)
-    {
-        RETURN_FALSE;
-    }
-
-    /* Figure out what kind of slowlog command we're executing */
-    if(!strncasecmp(arg, "GET", 3)) {
-        mode = SLOWLOG_GET;
-    } else if(!strncasecmp(arg, "LEN", 3)) {
-        mode = SLOWLOG_LEN;
-    } else if(!strncasecmp(arg, "RESET", 5)) {
-        mode = SLOWLOG_RESET;
-    } else {
-        /* This command is not valid */
-        RETURN_FALSE;
-    }
-
-    /* Make sure we can grab our redis socket */
-    if ((redis_sock = redis_sock_get(object, 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    // Create our command.  For everything except SLOWLOG GET (with an arg) it's
-    // just two parts
-    if (mode == SLOWLOG_GET && ZEND_NUM_ARGS() == 2) {
-        cmd_len = REDIS_SPPRINTF(&cmd, "SLOWLOG", "sl", arg, arg_len, option);
-    } else {
-        cmd_len = REDIS_SPPRINTF(&cmd, "SLOWLOG", "s", arg, arg_len);
-    }
-
-    /* Kick off our command */
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
-    if (IS_ATOMIC(redis_sock)) {
-        if(redis_read_variant_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-                                    redis_sock, NULL, NULL) < 0)
-        {
-            RETURN_FALSE;
-        }
-    }
-    REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
+    REDIS_PROCESS_CMD(slowlog, redis_read_variant_reply);
 }
 
 /* {{{ proto Redis::wait(int num_slaves, int ms) }}} */

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -521,7 +521,33 @@ class Redis {
 
     public function slaveof(string $host = null, int $port = 6379): bool;
 
-    public function slowlog(string $mode, int $option = 0): mixed;
+    /**
+      Interact with Redis' slowlog functionality in variousu ways, depending
+      on the value of 'operations'.
+
+      @param string $operation  The operation you wish to perform.  This can
+                                be one of the following values:
+                                'get'   - Retreive the Redis slowlog as an array.
+                                'len'   - Retreive the length of the slowlog.
+                                'reset' - Remove all slowlog entries.
+      <code>
+      <?php
+      $redis->slowllog('get', -1);  // Retreive all slowlog entries.
+      $redis->slowlog('len');       // Retreive slowlog length.
+      $redis->slowlog('reset');     // Reset the slowlog.
+      ?>
+      </code>
+
+      @param int    $length     This optional argument can be passed when operation
+                                is 'get' and will specify how many elements to retreive.
+                                If omitted Redis will send up to a default number of
+                                entries, which is configurable.
+
+                                Note:  With Redis >= 7.0.0 you can send -1 to mean "all".
+
+      @return mixed
+     */
+    public function slowlog(string $operation, int $length = 0): mixed;
 
     public function sort(string $key, ?array $options = null): mixed;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a024c59eff58030ac224fc22cc4040b6e926a643 */
+ * Stub hash: 3ffe58fd2c74dcb474adf0b983f503d798c975d8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -392,7 +392,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMget, 0, 2, Red
 	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Redis, MAY_BE_BOOL|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, keyvals, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -787,8 +787,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_slaveof, 0, 0, _IS_B
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_slowlog, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, option, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO(0, operation, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_sort, 0, 1, IS_MIXED, 0)

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -132,6 +132,9 @@ int redis_intercard_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                         char *kw, char **cmd, int *cmd_len, short *slot,
                         void **ctx);
 
+int redis_slowlog_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                      char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_lcs_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                   char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a024c59eff58030ac224fc22cc4040b6e926a643 */
+ * Stub hash: 3ffe58fd2c74dcb474adf0b983f503d798c975d8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -664,8 +664,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_slaveof, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_slowlog, 0, 0, 1)
-	ZEND_ARG_INFO(0, mode)
-	ZEND_ARG_INFO(0, option)
+	ZEND_ARG_INFO(0, operation)
+	ZEND_ARG_INFO(0, length)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_sort arginfo_class_Redis_getEx

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2291,7 +2291,7 @@ class Redis_Test extends TestSuite
         $this->assertTrue(is_array($this->redis->slowlog('get', 10)));
         $this->assertTrue(is_int($this->redis->slowlog('len')));
         $this->assertTrue($this->redis->slowlog('reset'));
-        $this->assertFalse($this->redis->slowlog('notvalid'));
+        $this->assertFalse(@$this->redis->slowlog('notvalid'));
     }
 
     public function testWait() {


### PR DESCRIPTION
Refactor the slowlog command to use the new argument parsing API and also change it so we no longer manually handle atomic/non-atomic logic in the handler itself.