### PR TITLE
XGROUP DELCONSUMER and ENTRIESREAD

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -660,7 +660,44 @@ class Redis {
 
     public function xdel(string $key, array $ids): Redis|int|false;
 
-    public function xgroup(string $operation, string $key = null, string $arg1 = null, string $arg2 = null, bool $arg3 = false): mixed;
+    /**
+     * XGROUP
+     *
+     * Perform various operation on consumer groups for a particular Redis STREAM.
+     * What the command does is primarily based on which operation is passed.
+     *
+     * @see https://redis.io/commands/xgroup/
+     *
+     * @param string $operation      The subcommand you intend to execute.  Valid options are as follows
+     *                               'HELP'          - Redis will return information about the command
+     *                                                 Requires: none
+     *                               'CREATE'        - Create a consumer group.
+     *                                                 Requires:  Key, group, consumer.
+     *                               'SETID'         - Set the ID of an existing consumer group for the stream.
+     *                                                 Requires:  Key, group, id.
+     *                               'CREATECONSUMER - Create a new consumer group for the stream.  You must
+     *                                                 also pass key, group, and the consumer name you wish to
+     *                                                 create.
+     *                                                 Requires:  Key, group, consumer.
+     *                               'DELCONSUMER'   - Delete a consumer from group attached to the stream.
+     *                                                 Requires:  Key, group, consumer.
+     *                               'DESTROY'       - Delete a consumer group from a stream.
+     *                                                  Requires:  Key, group.
+     * @param string $key            The STREAM we're operating on.
+     * @param string $group          The consumer group wse want to create/modify/delete.
+     * @param string $id_or_consumer The STREAM id (e.g. '$') or consumer group.  See the operation section
+     *                               for information about which to send.
+     * @param bool   $mkstream       This flag may be sent in combination with the 'CREATE' operation, and
+     *                               cause Redis to also create the STREAM if it doesn't currently exist.
+     *
+     * @param bool   $entriesread    Allows you to set Redis's 'entries-read' STREAM value.  This argument is
+     *                               only relevant to the 'CREATE' and 'SETID' operations.
+     *                               Note:  Requires Redis >= 7.0.0.
+     *
+     * @return mixed                 This command return various results depending on the operation performed.
+     */
+    public function xgroup(string $operation, string $key = null, string $group = null, string $id_or_consumer = null,
+                           bool $mkstream = false, int $entries_read = -2): mixed;
 
     public function xinfo(string $operation, ?string $arg1 = null, ?string $arg2 = null, int $count = -1): mixed;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 73bbd79b67c155a90acfa2b5ca1be49effdaf8ba */
+ * Stub hash: c04531e86379ab5c0de12e8e82868b7c7f024068 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -909,9 +909,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_xgroup, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, operation, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, key, IS_STRING, 0, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg1, IS_STRING, 0, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg2, IS_STRING, 0, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg3, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, group, IS_STRING, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, id_or_consumer, IS_STRING, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mkstream, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, entries_read, IS_LONG, 0, "-2")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_xinfo, 0, 1, IS_MIXED, 0)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 73bbd79b67c155a90acfa2b5ca1be49effdaf8ba */
+ * Stub hash: c04531e86379ab5c0de12e8e82868b7c7f024068 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -769,9 +769,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xgroup, 0, 0, 1)
 	ZEND_ARG_INFO(0, operation)
 	ZEND_ARG_INFO(0, key)
-	ZEND_ARG_INFO(0, arg1)
-	ZEND_ARG_INFO(0, arg2)
-	ZEND_ARG_INFO(0, arg3)
+	ZEND_ARG_INFO(0, group)
+	ZEND_ARG_INFO(0, id_or_consumer)
+	ZEND_ARG_INFO(0, mkstream)
+	ZEND_ARG_INFO(0, entries_read)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xinfo, 0, 0, 1)


### PR DESCRIPTION
Refactor XGROUP and implement the new DELCONSUMER (Redis 6.2.0) and ENTRIESREAD (Redis 7.0.0) options.  Additionally, add a proper phpdoc block to the stub file.

See #2068