### PR TITLE
Newer versions of Redis shouldn't need a long delay

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5675,10 +5675,10 @@ class Redis_Test extends TestSuite
         // Time out after 1 second.
         $this->redis->config('SET', 'timeout', '1');
 
-        // Wait for the timeout. With Redis 2.4, we have to wait up to 10 s
-        // for the server to close the connection, regardless of the timeout
-        // setting.
-        sleep(11);
+        // Wait for the connection to time out.  On very old versions
+        // of Redis we need to wait much longer (TODO:  Investigate
+        // which version exactly)
+        sleep($this->minVersionCheck('3.0.0') ? 2 : 11);
 
         // Make sure we're still using the same DB.
         $this->assertEquals($value, $this->redis->get($key));


### PR DESCRIPTION
We had some ancient logic sleeping for 11 seconds even though the connection is set to timeout in 1s.  We should figure out if this is actually still needed at all, but as a shorter-term fix just reduce the wait time for any non-ancient version of Redis (picked 3.0.0 arbitrarily)