### PR TITLE
TOUCH command

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -1043,19 +1043,24 @@ PHP_METHOD(Redis, mget)
     REDIS_PROCESS_RESPONSE(redis_sock_read_multibulk_reply);
 }
 
-/* {{{ proto boolean Redis::exists(string key)
+/* {{{ proto boolean Redis::exists(string $key, string ...$more_keys)
  */
-PHP_METHOD(Redis, exists)
-{
-    REDIS_PROCESS_CMD(exists, redis_long_response);
+PHP_METHOD(Redis, exists) {
+    REDIS_PROCESS_KW_CMD("EXISTS", redis_varkey_cmd, redis_long_response);
 }
 /* }}} */
 
+/* {{{ proto boolean Redis::touch(string $key, string ...$more_keys)
+ */
+PHP_METHOD(Redis, touch) {
+    REDIS_PROCESS_KW_CMD("TOUCH", redis_varkey_cmd, redis_long_response);
+}
+
+/* }}} */
 /* {{{ proto boolean Redis::del(string key)
  */
-PHP_METHOD(Redis, del)
-{
-    REDIS_PROCESS_CMD(del, redis_long_response);
+PHP_METHOD(Redis, del) {
+    REDIS_PROCESS_KW_CMD("DEL", redis_varkey_cmd, redis_long_response);
 }
 /* }}} */
 
@@ -1063,7 +1068,7 @@ PHP_METHOD(Redis, del)
  * {{{ proto long Redis::unlink(array $keys) */
 PHP_METHOD(Redis, unlink)
 {
-    REDIS_PROCESS_CMD(unlink, redis_long_response);
+    REDIS_PROCESS_KW_CMD("UNLINK", redis_varkey_cmd, redis_long_response);
 }
 
 PHP_REDIS_API void redis_set_watch(RedisSock *redis_sock)
@@ -1080,9 +1085,8 @@ PHP_REDIS_API int redis_watch_response(INTERNAL_FUNCTION_PARAMETERS,
 
 /* {{{ proto boolean Redis::watch(string key1, string key2...)
  */
-PHP_METHOD(Redis, watch)
-{
-    REDIS_PROCESS_CMD(watch, redis_watch_response);
+PHP_METHOD(Redis, watch) {
+    REDIS_PROCESS_KW_CMD("WATCH", redis_varkey_cmd, redis_watch_response);
 }
 /* }}} */
 
@@ -1440,7 +1444,7 @@ PHP_METHOD(Redis, sMisMember)
 
 /* {{{ proto array Redis::sInter(string key0, ... string keyN) */
 PHP_METHOD(Redis, sInter) {
-    REDIS_PROCESS_CMD(sinter, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_KW_CMD("SINTER", redis_varkey_cmd, redis_sock_read_multibulk_reply);
 }
 /* }}} */
 
@@ -1450,34 +1454,33 @@ PHP_METHOD(Redis, sintercard) {
 
 /* {{{ proto array Redis::sInterStore(string dst, string key0,...string keyN) */
 PHP_METHOD(Redis, sInterStore) {
-    REDIS_PROCESS_CMD(sinterstore, redis_long_response);
+    REDIS_PROCESS_KW_CMD("SINTERSTORE", redis_varkey_cmd, redis_long_response);
 }
 /* }}} */
 
 /* {{{ proto array Redis::sUnion(string key0, ... string keyN) */
 PHP_METHOD(Redis, sUnion) {
-    REDIS_PROCESS_CMD(sunion, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_KW_CMD("SUNION", redis_varkey_cmd, redis_sock_read_multibulk_reply);
 }
 /* }}} */
 
-/* {{{ proto array Redis::sUnionStore(string dst, string key0, ... keyN) */
+/* {{{ proto array Redis::sUnionStore(array|string $key, string ...$srckeys) */
 PHP_METHOD(Redis, sUnionStore) {
-    REDIS_PROCESS_CMD(sunionstore, redis_long_response);
+    REDIS_PROCESS_KW_CMD("SUNIONSTORE", redis_varkey_cmd, redis_long_response);
 }
 /* }}} */
 
 /* {{{ proto array Redis::sDiff(string key0, ... string keyN) */
 PHP_METHOD(Redis, sDiff) {
-    REDIS_PROCESS_CMD(sdiff, redis_sock_read_multibulk_reply);
+    REDIS_PROCESS_KW_CMD("SDIFF", redis_varkey_cmd, redis_sock_read_multibulk_reply);
 }
 /* }}} */
 
 /* {{{ proto array Redis::sDiffStore(string dst, string key0, ... keyN) */
 PHP_METHOD(Redis, sDiffStore) {
-    REDIS_PROCESS_CMD(sdiffstore, redis_long_response);
+    REDIS_PROCESS_KW_CMD("SDIFFSTORE", redis_varkey_cmd, redis_long_response);
 }
 /* }}} */
-
 
 /* {{{ proto array Redis::sort(string key, array options) */
 PHP_METHOD(Redis, sort) {

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -568,10 +568,24 @@ class Redis {
     public function slaveof(string $host = null, int $port = 6379): bool;
 
     /**
+     * Update one or more keys last modified metadata.
+     *
+     * @see https://redis.io/commands/touch/
+     *
+     * @param array|string $key    Either the first key or if passed as the only argument
+     *                             an array of keys.
+     * @param string $more_keys    One or more keys to send to the command.
+     *
+     * @return Redis|int|false     This command returns the number of keys that exist and
+     *                             had their last modified time reset
+     */
+    public function touch(array|string $key_or_array, string ...$more_keys): Redis|int|false;
+
+    /**
      * Interact with Redis' slowlog functionality in variousu ways, depending
      * on the value of 'operations'.
      *
-     * @see https://https://redis.io/commands/slowlog/
+     * @see https://redis.io/commands/slowlog/
      * @category administration
      *
      * @param string $operation  The operation you wish to perform.  This can

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 894a03b9e9db1e8ded0f016a00e7e7150dc26f31 */
+ * Stub hash: 7c2ec068711e216a4308a2c405c32204edf60d23 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -797,6 +797,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_slaveof, 0, 0, _IS_B
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "6379")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_touch, 0, 1, Redis, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_MASK(0, key_or_array, MAY_BE_ARRAY|MAY_BE_STRING, NULL)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, more_keys, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_slowlog, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, operation, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
@@ -1290,6 +1295,7 @@ ZEND_METHOD(Redis, setex);
 ZEND_METHOD(Redis, setnx);
 ZEND_METHOD(Redis, sismember);
 ZEND_METHOD(Redis, slaveof);
+ZEND_METHOD(Redis, touch);
 ZEND_METHOD(Redis, slowlog);
 ZEND_METHOD(Redis, sort);
 ZEND_METHOD(Redis, sort_ro);
@@ -1538,6 +1544,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, setnx, arginfo_class_Redis_setnx, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sismember, arginfo_class_Redis_sismember, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, slaveof, arginfo_class_Redis_slaveof, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, touch, arginfo_class_Redis_touch, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, slowlog, arginfo_class_Redis_slowlog, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sort, arginfo_class_Redis_sort, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sort_ro, arginfo_class_Redis_sort_ro, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -751,12 +751,18 @@ PHP_METHOD(RedisCluster, getset) {
 }
 /* }}} */
 
-/* {{{ proto int RedisCluster::exists(string key) */
+/* {{{ proto int RedisCluster::exists(string $key, string ...$more_keys) */
 PHP_METHOD(RedisCluster, exists) {
-    CLUSTER_PROCESS_CMD(exists, cluster_long_resp, 1);
+    CLUSTER_PROCESS_KW_CMD("EXISTS", redis_varkey_cmd, cluster_long_resp, 1);
 }
 /* }}} */
 
+/* {{{ proto int RedisCluster::exists(string $key, string ...$more_keys) */
+PHP_METHOD(RedisCluster, touch) {
+    CLUSTER_PROCESS_KW_CMD("TOUCH", redis_varkey_cmd, cluster_long_resp, 0);
+}
+
+/* }}} */
 /* {{{ proto array Redis::keys(string pattern) */
 PHP_METHOD(RedisCluster, keys) {
     redisCluster *c = GET_CONTEXT();
@@ -1007,19 +1013,19 @@ PHP_METHOD(RedisCluster, srem) {
 
 /* {{{ proto array RedisCluster::sunion(string key1, ... keyN) */
 PHP_METHOD(RedisCluster, sunion) {
-    CLUSTER_PROCESS_CMD(sunion, cluster_mbulk_resp, 0);
+    CLUSTER_PROCESS_KW_CMD("SUNION", redis_varkey_cmd, cluster_mbulk_resp, 0);
 }
 /* }}} */
 
 /* {{{ proto long RedisCluster::sunionstore(string dst, string k1, ... kN) */
 PHP_METHOD(RedisCluster, sunionstore) {
-    CLUSTER_PROCESS_CMD(sunionstore, cluster_long_resp, 0);
+    CLUSTER_PROCESS_KW_CMD("SUNIONSTORE", redis_varkey_cmd, cluster_long_resp, 0);
 }
 /* }}} */
 
 /* {{{ ptoto array RedisCluster::sinter(string k1, ... kN) */
 PHP_METHOD(RedisCluster, sinter) {
-    CLUSTER_PROCESS_CMD(sinter, cluster_mbulk_resp, 0);
+    CLUSTER_PROCESS_KW_CMD("SINTER", redis_varkey_cmd, cluster_mbulk_resp, 0);
 }
 
 /* {{{ proto RedisCluster::sintercard(array $keys, int $count = -1) */
@@ -1032,19 +1038,19 @@ PHP_METHOD(RedisCluster, sintercard) {
 
 /* {{{ ptoto long RedisCluster::sinterstore(string dst, string k1, ... kN) */
 PHP_METHOD(RedisCluster, sinterstore) {
-    CLUSTER_PROCESS_CMD(sinterstore, cluster_long_resp, 0);
+    CLUSTER_PROCESS_KW_CMD("SINTERSTORE", redis_varkey_cmd, cluster_long_resp, 0);
 }
 /* }}} */
 
 /* {{{ proto array RedisCluster::sdiff(string k1, ... kN) */
 PHP_METHOD(RedisCluster, sdiff) {
-    CLUSTER_PROCESS_CMD(sdiff, cluster_mbulk_resp, 1);
+    CLUSTER_PROCESS_KW_CMD("SDIFF", redis_varkey_cmd, cluster_mbulk_resp, 1);
 }
 /* }}} */
 
 /* {{{ proto long RedisCluster::sdiffstore(string dst, string k1, ... kN) */
 PHP_METHOD(RedisCluster, sdiffstore) {
-    CLUSTER_PROCESS_CMD(sdiffstore, cluster_long_resp, 0);
+    CLUSTER_PROCESS_KW_CMD("SDIFFSTORE", redis_varkey_cmd, cluster_long_resp, 0);
 }
 /* }}} */
 

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -111,6 +111,11 @@ class RedisCluster {
 
     public function exists(mixed $key, mixed ...$other_keys): RedisCluster|int|bool;
 
+    /**
+     * @see Redis::touch()
+     */
+    public function touch(mixed $key, mixed ...$other_keys): RedisCluster|int|bool;
+
     public function expire(string $key, int $timeout, ?string $mode = NULL): RedisCluster|bool;
 
     public function expireat(string $key, int $timestamp, ?string $mode = NULL): RedisCluster|bool;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9d2d6314c74dbf1e80662aa867b36c4a3ecfe8d */
+ * Stub hash: 895f61badfcc6198d72788d80d517144fc1e8daf */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -204,6 +204,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_exists, 0
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, other_keys, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_touch arginfo_class_RedisCluster_exists
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_expire, 0, 2, RedisCluster, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -993,6 +995,7 @@ ZEND_METHOD(RedisCluster, evalsha);
 ZEND_METHOD(RedisCluster, evalsha_ro);
 ZEND_METHOD(RedisCluster, exec);
 ZEND_METHOD(RedisCluster, exists);
+ZEND_METHOD(RedisCluster, touch);
 ZEND_METHOD(RedisCluster, expire);
 ZEND_METHOD(RedisCluster, expireat);
 ZEND_METHOD(RedisCluster, expiretime);
@@ -1201,6 +1204,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, evalsha_ro, arginfo_class_RedisCluster_evalsha_ro, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, exec, arginfo_class_RedisCluster_exec, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, exists, arginfo_class_RedisCluster_exists, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, touch, arginfo_class_RedisCluster_touch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expire, arginfo_class_RedisCluster_expire, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expireat, arginfo_class_RedisCluster_expireat, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiretime, arginfo_class_RedisCluster_expiretime, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9d2d6314c74dbf1e80662aa867b36c4a3ecfe8d */
+ * Stub hash: 895f61badfcc6198d72788d80d517144fc1e8daf */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -178,6 +178,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_exec arginfo_class_RedisCluster__masters
 
 #define arginfo_class_RedisCluster_exists arginfo_class_RedisCluster_del
+
+#define arginfo_class_RedisCluster_touch arginfo_class_RedisCluster_del
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_expire, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -844,6 +846,7 @@ ZEND_METHOD(RedisCluster, evalsha);
 ZEND_METHOD(RedisCluster, evalsha_ro);
 ZEND_METHOD(RedisCluster, exec);
 ZEND_METHOD(RedisCluster, exists);
+ZEND_METHOD(RedisCluster, touch);
 ZEND_METHOD(RedisCluster, expire);
 ZEND_METHOD(RedisCluster, expireat);
 ZEND_METHOD(RedisCluster, expiretime);
@@ -1052,6 +1055,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, evalsha_ro, arginfo_class_RedisCluster_evalsha_ro, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, exec, arginfo_class_RedisCluster_exec, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, exists, arginfo_class_RedisCluster_exists, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, touch, arginfo_class_RedisCluster_touch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expire, arginfo_class_RedisCluster_expire, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expireat, arginfo_class_RedisCluster_expireat, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiretime, arginfo_class_RedisCluster_expiretime, ZEND_ACC_PUBLIC)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4593,84 +4593,13 @@ int redis_migrate_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
-/* EXISTS */
-int redis_exists_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
+/* A generic passthru function for variadic key commands that take one or more
+ * keys.  This is essentially all of them except ones that STORE data. */
+int redis_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx)
 {
     return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "EXISTS", sizeof("EXISTS") - 1, 0, 0, cmd, cmd_len, slot);
-}
-
-/* DEL */
-int redis_del_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                  char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "DEL", sizeof("DEL")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* UNLINK */
-int redis_unlink_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "UNLINK", sizeof("UNLINK")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* WATCH */
-int redis_watch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "WATCH", sizeof("WATCH")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* SINTER */
-int redis_sinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "SINTER", sizeof("SINTER")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* SINTERSTORE */
-int redis_sinterstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "SINTERSTORE", sizeof("SINTERSTORE")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* SUNION */
-int redis_sunion_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "SUNION", sizeof("SUNION")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* SUNIONSTORE */
-int redis_sunionstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                          char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "SUNIONSTORE", sizeof("SUNIONSTORE")-1, 2, 0, cmd, cmd_len, slot);
-}
-
-/* SDIFF */
-int redis_sdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, "SDIFF",
-        sizeof("SDIFF")-1, 1, 0, cmd, cmd_len, slot);
-}
-
-/* SDIFFSTORE */
-int redis_sdiffstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                         char **cmd, int *cmd_len, short *slot, void **ctx)
-{
-    return gen_varkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-        "SDIFFSTORE", sizeof("SDIFFSTORE")-1, 1, 0, cmd, cmd_len, slot);
+                          kw, strlen(kw), 1, 0, cmd, cmd_len, slot);
 }
 
 static int

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -274,36 +274,6 @@ int redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     REDIS_REPLY_TYPE *rtype, char **cmd, int *cmd_len, short *slot,
     void **ctx);
 
-int redis_exists_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_del_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_unlink_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_watch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sinter_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sinterstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sunion_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sunionstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sdiff_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_sdiffstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char **cmd, int *cmd_len, short *slot, void **ctx);
-
 int redis_client_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
@@ -350,11 +320,15 @@ int redis_xreadgroup_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_xtrim_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                    char **cmd, int *cmd_len, short *slot, void **ctx);
+    char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_expire_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char *kw, char **cmd, int *cmd_len, short *slot,
-                     void **ctx);
+    char *kw, char **cmd, int *cmd_len, short *slot,
+    void **ctx);
+
+int redis_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+    char *kw, char **cmd, int *cmd_len, short *slot,
+    void **ctx);
 
 int redis_sentinel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 894a03b9e9db1e8ded0f016a00e7e7150dc26f31 */
+ * Stub hash: 7c2ec068711e216a4308a2c405c32204edf60d23 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -673,6 +673,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_slaveof, 0, 0, 0)
 	ZEND_ARG_INFO(0, port)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_touch, 0, 0, 1)
+	ZEND_ARG_INFO(0, key_or_array)
+	ZEND_ARG_VARIADIC_INFO(0, more_keys)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_slowlog, 0, 0, 1)
 	ZEND_ARG_INFO(0, operation)
 	ZEND_ARG_INFO(0, length)
@@ -1121,6 +1126,7 @@ ZEND_METHOD(Redis, setex);
 ZEND_METHOD(Redis, setnx);
 ZEND_METHOD(Redis, sismember);
 ZEND_METHOD(Redis, slaveof);
+ZEND_METHOD(Redis, touch);
 ZEND_METHOD(Redis, slowlog);
 ZEND_METHOD(Redis, sort);
 ZEND_METHOD(Redis, sort_ro);
@@ -1369,6 +1375,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, setnx, arginfo_class_Redis_setnx, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sismember, arginfo_class_Redis_sismember, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, slaveof, arginfo_class_Redis_slaveof, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, touch, arginfo_class_Redis_touch, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, slowlog, arginfo_class_Redis_slowlog, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sort, arginfo_class_Redis_sort, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, sort_ro, arginfo_class_Redis_sort_ro, ZEND_ACC_PUBLIC)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -894,8 +894,7 @@ class Redis_Test extends TestSuite
     }
 
 
-    public function testExists()
-    {
+    public function testExists() {
         /* Single key */
         $this->redis->del('key');
         $this->assertEquals(0, $this->redis->exists('key'));
@@ -915,6 +914,22 @@ class Redis_Test extends TestSuite
         /* Test passing an array as well as the keys variadic */
         $this->assertEquals(count($mkeys), $this->redis->exists($mkeys));
         $this->assertEquals(count($mkeys), call_user_func_array([$this->redis, 'exists'], $mkeys));
+    }
+
+    public function testTouch() {
+        if (!$this->minVersionCheck('3.2.1'))
+            $this->markTestSkipped();
+
+        $this->redis->del('notakey');
+
+        $this->assertTrue($this->redis->mset(['{idle}1' => 'beep', '{idle}2' => 'boop']));
+        usleep(1100000);
+        $this->assertTrue($this->redis->object('idletime', '{idle}1') >= 1);
+        $this->assertTrue($this->redis->object('idletime', '{idle}2') >= 1);
+
+        $this->assertEquals(2, $this->redis->touch('{idle}1', '{idle}2', '{idle}notakey'));
+        $this->assertTrue($this->redis->object('idletime', '{idle}1') == 0);
+        $this->assertTrue($this->redis->object('idletime', '{idle}2') == 0);
     }
 
     public function testKeys()


### PR DESCRIPTION
Implement the TOUCH command and refactor several of our "variadic key" commands, which were previously all using their own specific handlers.

While refactoring the code, I changed `EXISTS` to require one key (it had previously been set to require zero keys).

Additonally, it looks like we had a disparity in two commands which should be idential to PhpRedis:  SINTERSTORE and SUNIONSTORE. Previously, SINTERSTORE required only one argument but SUNIONSTORE 2.

I simply changed SUNIONSTORE to also only require a single argument, since that argument could be an array.

```php
$redis->sInterStore(['dst', 'src1', 'src2']);
$redis->sUnionStore(['dst', 'src1', 'src2']);
```