### PR TITLE
Refactor network IO tracking.

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -59,12 +59,11 @@
 /* Protected sending of data down the wire to a RedisSock->stream */
 #define CLUSTER_SEND_PAYLOAD(sock, buf, len) \
     (sock && !redis_sock_server_open(sock) && sock->stream && !redis_check_eof(sock, 0, 1) && \
-     php_stream_write(sock->stream, buf, len)==len)
+     redis_sock_write_raw(sock, buf, len) == len)
 
 /* Macro to read our reply type character */
 #define CLUSTER_VALIDATE_REPLY_TYPE(sock, type) \
-    (redis_check_eof(sock, 1, 1) == 0 && \
-     (php_stream_getc(sock->stream) == type))
+    (redis_check_eof(sock, 1, 1) == 0 && redis_sock_getc(sock) == type)
 
 /* Reset our last single line reply buffer and length */
 #define CLUSTER_CLEAR_REPLY(c) \

--- a/common.h
+++ b/common.h
@@ -324,6 +324,7 @@ typedef struct {
     int                 tcp_keepalive;
     int                 sentinel;
     size_t              txBytes;
+    size_t              rxBytes;
 } RedisSock;
 /* }}} */
 

--- a/library.c
+++ b/library.c
@@ -3274,9 +3274,8 @@ PHP_REDIS_API int
 redis_sock_write(RedisSock *redis_sock, char *cmd, size_t sz)
 {
     if (redis_check_eof(redis_sock, 0, 0) == 0 &&
-        php_stream_write(redis_sock->stream, cmd, sz) == sz)
+        redis_sock_write_raw(redis_sock, cmd, sz) == sz)
     {
-        redis_sock->txBytes += sz;
         return sz;
     }
 

--- a/redis.c
+++ b/redis.c
@@ -2861,10 +2861,24 @@ PHP_METHOD(Redis, getDBNum) {
 PHP_METHOD(Redis, getTransferredBytes) {
     RedisSock *redis_sock;
 
-    if ((redis_sock = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU)) == NULL) {
-        RETURN_FALSE;
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_THROWS();
     }
-    RETURN_LONG(redis_sock->txBytes);
+
+    array_init_size(return_value, 2);
+    add_next_index_long(return_value, redis_sock->txBytes);
+    add_next_index_long(return_value, redis_sock->rxBytes);
+}
+
+PHP_METHOD(Redis, clearTransferredBytes) {
+    RedisSock *redis_sock;
+
+    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
+        RETURN_THROWS();
+    }
+
+    redis_sock->txBytes = 0;
+    redis_sock->rxBytes = 0;
 }
 
 /* {{{ proto Redis::getTimeout */

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1571,7 +1571,19 @@ class Redis {
      */
     public function getTimeout(): float|false;
 
-    public function getTransferredBytes(): int|false;
+    /**
+     * Get the number of bytes sent and received on the socket.
+     *
+     * @return array An array in the form [$sent_bytes, $received_bytes]
+     */
+    public function getTransferredBytes(): array;
+
+    /**
+     * Reset the number of bytes sent and received on the socket.
+     *
+     * @return void
+     */
+    public function clearTransferredBytes(): void;
 
     /**
      * Remove one or more fields from a hash.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 27f05179a82a7b33198a3a707134d9da5597ab1c */
+ * Stub hash: 2f941423f250241850fc678282e0656ecfb44018 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -361,7 +361,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getTimeout, 0, 0, MAY_BE_DOUBLE|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getTransferredBytes, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getTransferredBytes, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_clearTransferredBytes, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hDel, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
@@ -1217,6 +1220,7 @@ ZEND_METHOD(Redis, getReadTimeout);
 ZEND_METHOD(Redis, getset);
 ZEND_METHOD(Redis, getTimeout);
 ZEND_METHOD(Redis, getTransferredBytes);
+ZEND_METHOD(Redis, clearTransferredBytes);
 ZEND_METHOD(Redis, hDel);
 ZEND_METHOD(Redis, hExists);
 ZEND_METHOD(Redis, hGet);
@@ -1465,6 +1469,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, getset, arginfo_class_Redis_getset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getTimeout, arginfo_class_Redis_getTimeout, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getTransferredBytes, arginfo_class_Redis_getTransferredBytes, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, clearTransferredBytes, arginfo_class_Redis_clearTransferredBytes, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hDel, arginfo_class_Redis_hDel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hExists, arginfo_class_Redis_hExists, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hGet, arginfo_class_Redis_hGet, ZEND_ACC_PUBLIC)

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -395,7 +395,12 @@ class RedisCluster {
     /**
      * @see Redis::gettransferredbytes
      */
-    public function gettransferredbytes(): int|false;
+    public function gettransferredbytes(): array|false;
+
+    /**
+     * @see Redis::cleartransferredbytes
+     */
+    public function cleartransferredbytes(): void;
 
     /**
      * @see Redis::hdel

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f4e2b11cf48fc70db77a52e79443536ad850d06f */
+ * Stub hash: 9a900fefb0ccb36638768a9d08909c68fff26c10 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -308,7 +308,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_getset, 0
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_RedisCluster_gettransferredbytes, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
+#define arginfo_class_RedisCluster_gettransferredbytes arginfo_class_RedisCluster_exec
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_cleartransferredbytes, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hdel, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
@@ -1030,6 +1032,7 @@ ZEND_METHOD(RedisCluster, getrange);
 ZEND_METHOD(RedisCluster, lcs);
 ZEND_METHOD(RedisCluster, getset);
 ZEND_METHOD(RedisCluster, gettransferredbytes);
+ZEND_METHOD(RedisCluster, cleartransferredbytes);
 ZEND_METHOD(RedisCluster, hdel);
 ZEND_METHOD(RedisCluster, hexists);
 ZEND_METHOD(RedisCluster, hget);
@@ -1240,6 +1243,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, lcs, arginfo_class_RedisCluster_lcs, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getset, arginfo_class_RedisCluster_getset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, gettransferredbytes, arginfo_class_RedisCluster_gettransferredbytes, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, cleartransferredbytes, arginfo_class_RedisCluster_cleartransferredbytes, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hdel, arginfo_class_RedisCluster_hdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hexists, arginfo_class_RedisCluster_hexists, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hget, arginfo_class_RedisCluster_hget, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f4e2b11cf48fc70db77a52e79443536ad850d06f */
+ * Stub hash: 9a900fefb0ccb36638768a9d08909c68fff26c10 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -275,6 +275,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster_getset arginfo_class_RedisCluster_append
 
 #define arginfo_class_RedisCluster_gettransferredbytes arginfo_class_RedisCluster__masters
+
+#define arginfo_class_RedisCluster_cleartransferredbytes arginfo_class_RedisCluster__masters
 
 #define arginfo_class_RedisCluster_hdel arginfo_class_RedisCluster_geohash
 
@@ -881,6 +883,7 @@ ZEND_METHOD(RedisCluster, getrange);
 ZEND_METHOD(RedisCluster, lcs);
 ZEND_METHOD(RedisCluster, getset);
 ZEND_METHOD(RedisCluster, gettransferredbytes);
+ZEND_METHOD(RedisCluster, cleartransferredbytes);
 ZEND_METHOD(RedisCluster, hdel);
 ZEND_METHOD(RedisCluster, hexists);
 ZEND_METHOD(RedisCluster, hget);
@@ -1091,6 +1094,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, lcs, arginfo_class_RedisCluster_lcs, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getset, arginfo_class_RedisCluster_getset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, gettransferredbytes, arginfo_class_RedisCluster_gettransferredbytes, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, cleartransferredbytes, arginfo_class_RedisCluster_cleartransferredbytes, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hdel, arginfo_class_RedisCluster_hdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hexists, arginfo_class_RedisCluster_hexists, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hget, arginfo_class_RedisCluster_hget, ZEND_ACC_PUBLIC)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 27f05179a82a7b33198a3a707134d9da5597ab1c */
+ * Stub hash: 2f941423f250241850fc678282e0656ecfb44018 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -331,6 +331,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Redis_getTimeout arginfo_class_Redis___destruct
 
 #define arginfo_class_Redis_getTransferredBytes arginfo_class_Redis___destruct
+
+#define arginfo_class_Redis_clearTransferredBytes arginfo_class_Redis___destruct
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hDel, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -1058,6 +1060,7 @@ ZEND_METHOD(Redis, getReadTimeout);
 ZEND_METHOD(Redis, getset);
 ZEND_METHOD(Redis, getTimeout);
 ZEND_METHOD(Redis, getTransferredBytes);
+ZEND_METHOD(Redis, clearTransferredBytes);
 ZEND_METHOD(Redis, hDel);
 ZEND_METHOD(Redis, hExists);
 ZEND_METHOD(Redis, hGet);
@@ -1306,6 +1309,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, getset, arginfo_class_Redis_getset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getTimeout, arginfo_class_Redis_getTimeout, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getTransferredBytes, arginfo_class_Redis_getTransferredBytes, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, clearTransferredBytes, arginfo_class_Redis_clearTransferredBytes, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hDel, arginfo_class_Redis_hDel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hExists, arginfo_class_Redis_hExists, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hGet, arginfo_class_Redis_hGet, ZEND_ACC_PUBLIC)

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -758,15 +758,6 @@ class Redis_Cluster_Test extends Redis_Test {
         ini_set('redis.pconnect.pooling_enabled', $prev_value);
     }
 
-    public function testTransferredBytes() {
-        $this->assertTrue($this->redis->ping(''));
-        $this->assertEquals(strlen("*1\r\n$4\r\nPING\r\n"), $this->redis->getTransferredBytes());
-        $this->assertEquals(['cluster_enabled' => 1], $this->redis->info('', 'cluster'));
-        $this->assertEquals(strlen("*2\r\n$4\r\nINFO\r\n$7\r\ncluster\r\n"), $this->redis->getTransferredBytes());
-        $this->assertEquals([true, true], $this->redis->multi()->ping('')->ping('')->exec());
-        $this->assertEquals(strlen("*1\r\n$5\r\nMULTI\r\n*1\r\n$4\r\nEXEC\r\n") + 2 * strlen("*2\r\n$4\r\nPING\r\n"), $this->redis->getTransferredBytes());
-    }
-
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
* Create inline wrappers of the low-level php_stream_* functions that also keep track of the number of bytes written/read.

* Change the logic to aggregate network traffic until the user explicitly "resets" it.  I think this will be a more common use-case (running many commands and then seeing overall network IO).

See #2106