### PR TITLE
Implement new ZSET commands for cluster

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -414,6 +414,10 @@ PHP_REDIS_API void cluster_lpos_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
     void *ctx);
 PHP_REDIS_API void cluster_hrandfield_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
+PHP_REDIS_API void cluster_zdiff_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    void *ctx);
+PHP_REDIS_API void cluster_zrandmember_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    void *ctx);
 PHP_REDIS_API void cluster_set_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
 PHP_REDIS_API void cluster_geosearch_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
@@ -459,6 +463,8 @@ PHP_REDIS_API void cluster_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API void cluster_mbulk_zipstr_resp(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c, void *ctx);
 PHP_REDIS_API void cluster_mbulk_zipdbl_resp(INTERNAL_FUNCTION_PARAMETERS,
+    redisCluster *c, void *ctx);
+PHP_REDIS_API void cluster_mbulk_dbl_resp(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c, void *ctx);
 PHP_REDIS_API void cluster_mbulk_assoc_resp(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c, void *ctx);
@@ -512,6 +518,8 @@ int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
 int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
     long long count, void *ctx);
 int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
     long long count, void *ctx);
 int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
     long long count, void *ctx);

--- a/library.c
+++ b/library.c
@@ -1108,6 +1108,17 @@ int redis_cmd_append_sstr_key_zstr(smart_string *dst, zend_string *key, RedisSoc
     return redis_cmd_append_sstr_key(dst, ZSTR_VAL(key), ZSTR_LEN(key), redis_sock, slot);
 }
 
+int redis_cmd_append_sstr_key_zval(smart_string *dst, zval *zv, RedisSock *redis_sock, short *slot) {
+    zend_string *key;
+    int res;
+
+    key = zval_get_string(zv);
+    res = redis_cmd_append_sstr_key_zstr(dst, key, redis_sock, slot);
+    zend_string_release(key);
+
+    return res;
+}
+
 /* Append an array key to a redis smart string command.  This function
  * handles the boilerplate conditionals around string or integer keys */
 int redis_cmd_append_sstr_arrkey(smart_string *cmd, zend_string *kstr, zend_ulong idx)

--- a/library.h
+++ b/library.h
@@ -51,6 +51,7 @@ int redis_cmd_append_sstr_zstr(smart_string *str, zend_string *zstr);
 int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock);
 int redis_cmd_append_sstr_key(smart_string *str, char *key, size_t len, RedisSock *redis_sock, short *slot);
 int redis_cmd_append_sstr_key_zstr(smart_string *str, zend_string *key, RedisSock *redis_sock, short *slot);
+int redis_cmd_append_sstr_key_zval(smart_string *dst, zval *zv, RedisSock *redis_sock, short *slot);
 int redis_cmd_append_sstr_arrkey(smart_string *cmd, zend_string *kstr, zend_ulong idx);
 
 PHP_REDIS_API int redis_spprintf(RedisSock *redis_sock, short *slot, char **ret, char *kw, char *fmt, ...);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1108,6 +1108,10 @@ PHP_METHOD(RedisCluster, zscore) {
 }
 /* }}} */
 
+PHP_METHOD(RedisCluster, zmscore) {
+    CLUSTER_PROCESS_KW_CMD("ZMSCORE", redis_key_varval_cmd, cluster_mbulk_dbl_resp, 1);
+}
+
 /* {{{ proto long RedisCluster::zadd(string key,double score,string mem, ...) */
 PHP_METHOD(RedisCluster, zadd) {
     CLUSTER_PROCESS_CMD(zadd, cluster_long_resp, 0);
@@ -1494,6 +1498,28 @@ PHP_METHOD(RedisCluster, zunionstore) {
 }
 /* }}} */
 
+PHP_METHOD(RedisCluster, zdiff) {
+    CLUSTER_PROCESS_CMD(zdiff, cluster_zdiff_resp, 1);
+}
+
+PHP_METHOD(RedisCluster, zdiffstore) {
+    CLUSTER_PROCESS_CMD(zdiffstore, cluster_long_resp, 0);
+}
+
+PHP_METHOD(RedisCluster, zinter) {
+    CLUSTER_PROCESS_KW_CMD("ZUNION", redis_zinterunion_cmd, cluster_zdiff_resp, 1);
+}
+
+PHP_METHOD(RedisCluster, zunion) {
+    CLUSTER_PROCESS_KW_CMD("ZINTER", redis_zinterunion_cmd, cluster_zdiff_resp, 1);
+}
+
+/* {{{ proto array RedisCluster::zrandmember(string key, array options) */
+PHP_METHOD(RedisCluster, zrandmember) {
+    CLUSTER_PROCESS_CMD(zrandmember, cluster_zrandmember_resp, 1);
+}
+
+/* }}} */
 /* {{{ proto RedisCluster::zinterstore(string dst, array keys, [array weights,
  *                                     string agg]) */
 PHP_METHOD(RedisCluster, zinterstore) {

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -1089,6 +1089,11 @@ class RedisCluster {
                                 array|bool|null $options = null): RedisCluster|int|false;
 
     /**
+     * @see https://redis.io/commands/zRandMember
+     */
+    public function zrandmember(string $key, array $options = null): RedisCluster|string|array;
+
+    /**
      * @see Redis::zrangebylex
      */
     public function zrangebylex(string $key, string $min, string $max, int $offset = -1, int $count = -1): RedisCluster|array|false;
@@ -1154,9 +1159,34 @@ class RedisCluster {
     public function zscore(string $key, mixed $member): RedisCluster|float|false;
 
     /**
+     * @see https://redis.io/commands/zMscore
+     */
+    public function zmscore(string $key, mixed $member, mixed ...$other_members): Redis|array|false;
+
+    /**
      * @see Redis::zunionstore
      */
     public function zunionstore(string $dst, array $keys, ?array $weights = NULL, ?string $aggregate = NULL): RedisCluster|int|false;
+
+    /**
+     * @see https://redis.io/commands/zinter
+     */
+    public function zinter(array $keys, ?array $weights = null, ?array $options = null): RedisCluster|array|false;
+
+    /**
+     * @see https://redis.io/commands/zdiffstore
+     */
+    public function zdiffstore(string $dst, array $keys): RedisCluster|int|false;
+
+    /**
+     * @see https://redis.io/commands/zunion
+     */
+    public function zunion(array $keys, ?array $weights = null, ?array $options = null): RedisCluster|array|false;
+
+    /**
+     * @see https://redis.io/commands/zdiff
+     */
+    public function zdiff(array $keys, array $options = null): RedisCluster|array|false;
 }
 
 class RedisClusterException extends RuntimeException {}

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e6c2d8efa4150e1cb198470d8106e693661c1e4f */
+ * Stub hash: eabecbc2e536faca2a9fcba3c99ad0aeba9721b4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -948,6 +948,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zrangesto
 	ZEND_ARG_TYPE_MASK(0, options, MAY_BE_ARRAY|MAY_BE_BOOL|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_RedisCluster_zrandmember arginfo_class_RedisCluster_hrandfield
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zrangebylex, 0, 3, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, min, IS_STRING, 0)
@@ -1005,11 +1007,35 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zscore, 0
 	ZEND_ARG_TYPE_INFO(0, member, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zmscore, 0, 2, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, member, IS_MIXED, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, other_members, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zunionstore, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, dst, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, weights, IS_ARRAY, 1, "NULL")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, aggregate, IS_STRING, 1, "NULL")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zinter, 0, 1, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, weights, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zdiffstore, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, dst, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_zunion arginfo_class_RedisCluster_zinter
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zdiff, 0, 1, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
 ZEND_END_ARG_INFO()
 
 
@@ -1215,6 +1241,7 @@ ZEND_METHOD(RedisCluster, zpopmax);
 ZEND_METHOD(RedisCluster, zpopmin);
 ZEND_METHOD(RedisCluster, zrange);
 ZEND_METHOD(RedisCluster, zrangestore);
+ZEND_METHOD(RedisCluster, zrandmember);
 ZEND_METHOD(RedisCluster, zrangebylex);
 ZEND_METHOD(RedisCluster, zrangebyscore);
 ZEND_METHOD(RedisCluster, zrank);
@@ -1228,7 +1255,12 @@ ZEND_METHOD(RedisCluster, zrevrangebyscore);
 ZEND_METHOD(RedisCluster, zrevrank);
 ZEND_METHOD(RedisCluster, zscan);
 ZEND_METHOD(RedisCluster, zscore);
+ZEND_METHOD(RedisCluster, zmscore);
 ZEND_METHOD(RedisCluster, zunionstore);
+ZEND_METHOD(RedisCluster, zinter);
+ZEND_METHOD(RedisCluster, zdiffstore);
+ZEND_METHOD(RedisCluster, zunion);
+ZEND_METHOD(RedisCluster, zdiff);
 
 
 static const zend_function_entry class_RedisCluster_methods[] = {
@@ -1434,6 +1466,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zpopmin, arginfo_class_RedisCluster_zpopmin, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrange, arginfo_class_RedisCluster_zrange, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangestore, arginfo_class_RedisCluster_zrangestore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zrandmember, arginfo_class_RedisCluster_zrandmember, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangebylex, arginfo_class_RedisCluster_zrangebylex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangebyscore, arginfo_class_RedisCluster_zrangebyscore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrank, arginfo_class_RedisCluster_zrank, ZEND_ACC_PUBLIC)
@@ -1447,7 +1480,12 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zrevrank, arginfo_class_RedisCluster_zrevrank, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zscan, arginfo_class_RedisCluster_zscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zscore, arginfo_class_RedisCluster_zscore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zmscore, arginfo_class_RedisCluster_zmscore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zunionstore, arginfo_class_RedisCluster_zunionstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zinter, arginfo_class_RedisCluster_zinter, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zdiffstore, arginfo_class_RedisCluster_zdiffstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zunion, arginfo_class_RedisCluster_zunion, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zdiff, arginfo_class_RedisCluster_zdiff, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e6c2d8efa4150e1cb198470d8106e693661c1e4f */
+ * Stub hash: eabecbc2e536faca2a9fcba3c99ad0aeba9721b4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -817,6 +817,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zrangestore, 0, 0, 4)
 	ZEND_ARG_INFO(0, options)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_RedisCluster_zrandmember arginfo_class_RedisCluster_hrandfield
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zrangebylex, 0, 0, 3)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, min)
@@ -854,7 +856,27 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_zscore arginfo_class_RedisCluster_hexists
 
+#define arginfo_class_RedisCluster_zmscore arginfo_class_RedisCluster_geohash
+
 #define arginfo_class_RedisCluster_zunionstore arginfo_class_RedisCluster_zinterstore
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zinter, 0, 0, 1)
+	ZEND_ARG_INFO(0, keys)
+	ZEND_ARG_INFO(0, weights)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zdiffstore, 0, 0, 2)
+	ZEND_ARG_INFO(0, dst)
+	ZEND_ARG_INFO(0, keys)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_zunion arginfo_class_RedisCluster_zinter
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zdiff, 0, 0, 1)
+	ZEND_ARG_INFO(0, keys)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
 
 
 ZEND_METHOD(RedisCluster, __construct);
@@ -1059,6 +1081,7 @@ ZEND_METHOD(RedisCluster, zpopmax);
 ZEND_METHOD(RedisCluster, zpopmin);
 ZEND_METHOD(RedisCluster, zrange);
 ZEND_METHOD(RedisCluster, zrangestore);
+ZEND_METHOD(RedisCluster, zrandmember);
 ZEND_METHOD(RedisCluster, zrangebylex);
 ZEND_METHOD(RedisCluster, zrangebyscore);
 ZEND_METHOD(RedisCluster, zrank);
@@ -1072,7 +1095,12 @@ ZEND_METHOD(RedisCluster, zrevrangebyscore);
 ZEND_METHOD(RedisCluster, zrevrank);
 ZEND_METHOD(RedisCluster, zscan);
 ZEND_METHOD(RedisCluster, zscore);
+ZEND_METHOD(RedisCluster, zmscore);
 ZEND_METHOD(RedisCluster, zunionstore);
+ZEND_METHOD(RedisCluster, zinter);
+ZEND_METHOD(RedisCluster, zdiffstore);
+ZEND_METHOD(RedisCluster, zunion);
+ZEND_METHOD(RedisCluster, zdiff);
 
 
 static const zend_function_entry class_RedisCluster_methods[] = {
@@ -1278,6 +1306,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zpopmin, arginfo_class_RedisCluster_zpopmin, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrange, arginfo_class_RedisCluster_zrange, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangestore, arginfo_class_RedisCluster_zrangestore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zrandmember, arginfo_class_RedisCluster_zrandmember, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangebylex, arginfo_class_RedisCluster_zrangebylex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrangebyscore, arginfo_class_RedisCluster_zrangebyscore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zrank, arginfo_class_RedisCluster_zrank, ZEND_ACC_PUBLIC)
@@ -1291,7 +1320,12 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zrevrank, arginfo_class_RedisCluster_zrevrank, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zscan, arginfo_class_RedisCluster_zscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zscore, arginfo_class_RedisCluster_zscore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zmscore, arginfo_class_RedisCluster_zmscore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zunionstore, arginfo_class_RedisCluster_zunionstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zinter, arginfo_class_RedisCluster_zinter, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zdiffstore, arginfo_class_RedisCluster_zdiffstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zunion, arginfo_class_RedisCluster_zunion, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, zdiff, arginfo_class_RedisCluster_zdiff, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -51,12 +51,7 @@ class Redis_Cluster_Test extends Redis_Test {
     public function testInvalidAuthArgs() { return $this->markTestSkipped(); }
     public function testScanErrors() { return $this->markTestSkipped(); }
 
-    public function testzDiff() { return $this->markTestSkipped(); }
-    public function testzInter() { return $this->markTestSkipped(); }
-    public function testzUnion() { return $this->markTestSkipped(); }
-    public function testzDiffStore() { return $this->markTestSkipped(); }
-    public function testzMscore() { return $this->marktestSkipped(); }
-    public function testZRandMember() { return $this->marktestSkipped(); }
+    /* These 'directed node' commands work differently in RedisCluster */
     public function testConfig() { return $this->markTestSkipped(); }
     public function testFlushDB() { return $this->markTestSkipped(); }
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2708,7 +2708,7 @@ class Redis_Test extends TestSuite
 
         // test weighted zUnion
         $this->redis->del('{zset}Z');
-        $this->assertTrue(4 === $this->redis->zUnionStore('{zset}Z', ['{zset}1', '{zset}2'], [1, 1]));
+        $this->assertEquals(4, $this->redis->zUnionStore('{zset}Z', ['{zset}1', '{zset}2'], [1, 1]));
         $this->assertTrue(['val0', 'val1', 'val2', 'val3'] === $this->redis->zRange('{zset}Z', 0, -1));
 
         $this->redis->zRemRangeByScore('{zset}Z', 0, 10);
@@ -2998,12 +2998,12 @@ class Redis_Test extends TestSuite
             return;
         }
 
-        $this->redis->del('key');
+        $this->redis->del('{zkey}src');
         foreach (range('a', 'c') as $c) {
-            $this->redis->zAdd('key', 1, $c);
+            $this->redis->zAdd('{zkey}src', 1, $c);
         }
-        $this->assertEquals(3, $this->redis->zDiffStore('key2', ['key']));
-        $this->assertEquals(['a', 'b', 'c'], $this->redis->zRange('key2', 0, -1));
+        $this->assertEquals(3, $this->redis->zDiffStore('{zkey}dst', ['{zkey}src']));
+        $this->assertEquals(['a', 'b', 'c'], $this->redis->zRange('{zkey}dst', 0, -1));
     }
 
     public function testzMscore()


### PR DESCRIPTION
* Implement `ZDIFF`, `ZINTER`, `ZUNION`, `ZMSCORE`, and `ZRANDMEMBER` for `RedisCluster`.
* Refactor `ZUNIONSTORE` command and switch to using our centralized zset option parsing handler.

See #1894