### PR TITLE
Refactor SELECT command.

### DIFF
--- a/library.c
+++ b/library.c
@@ -1530,6 +1530,17 @@ redis_lpos_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z
 }
 
 PHP_REDIS_API int
+redis_select_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab,
+                      void *ctx)
+{
+    if (redis_boolean_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, NULL) < 0)
+        return FAILURE;
+
+    redis_sock->dbNumber = (long)(uintptr_t)ctx;
+    return SUCCESS;
+}
+
+PHP_REDIS_API int
 redis_boolean_response_impl(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                             zval *z_tab, void *ctx,
                             SuccessCallback success_callback)

--- a/library.h
+++ b/library.h
@@ -195,6 +195,7 @@ PHP_REDIS_API int redis_read_lpos_response(zval *zdst, RedisSock *redis_sock, ch
 
 PHP_REDIS_API int redis_client_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_command_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+PHP_REDIS_API int redis_select_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 
 /* Helper methods to get configuration values from a HashTable. */
 

--- a/redis.c
+++ b/redis.c
@@ -1631,32 +1631,7 @@ PHP_METHOD(Redis, info) {
 
 /* {{{ proto bool Redis::select(long dbNumber) */
 PHP_METHOD(Redis, select) {
-
-    zval *object;
-    RedisSock *redis_sock;
-
-    char *cmd;
-    int cmd_len;
-    zend_long dbNumber;
-
-    if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol",
-                                     &object, redis_ce, &dbNumber) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if (dbNumber < 0 || (redis_sock = redis_sock_get(object, 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    redis_sock->dbNumber = dbNumber;
-    cmd_len = REDIS_SPPRINTF(&cmd, "SELECT", "d", dbNumber);
-
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
-    if (IS_ATOMIC(redis_sock)) {
-        redis_boolean_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
-            NULL, NULL);
-    }
-    REDIS_PROCESS_RESPONSE(redis_boolean_response);
+    REDIS_PROCESS_CMD(select, redis_select_response);
 }
 /* }}} */
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3664,6 +3664,24 @@ redis_hrandfield_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
+int redis_select_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    zend_long db = 0;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_LONG(db)
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
+
+    if (db < 0 || db > INT_MAX)
+        return FAILURE;
+
+    *ctx = (void*)(uintptr_t)db;
+    *cmd_len = REDIS_CMD_SPPRINTF(cmd, "SELECT", "d", db);
+
+    return SUCCESS;
+}
+
 /* SRANDMEMBER */
 int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                           char **cmd, int *cmd_len, short *slot, void **ctx,

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -266,6 +266,9 @@ int redis_hsetnx_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_srandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx, short *have_count);
 
+int redis_select_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_zincrby_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 


### PR DESCRIPTION
* Use our common command handler logic for SELECT.

* Shift updating `redis_sock->dbNumber` from the command itself to the reply handler, so we aren't erroneously pointing to a non-existent database before the command succeeds.