### PR TITLE
Refactor INFO and SCRIPT commands.

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -1572,32 +1572,7 @@ PHP_METHOD(Redis, pttl) {
 
 /* {{{ proto array Redis::info() */
 PHP_METHOD(Redis, info) {
-    smart_string cmdstr = {0};
-    RedisSock *redis_sock;
-    zend_string *section;
-    zval *args = NULL;
-    int i, argc = 0;
-
-    ZEND_PARSE_PARAMETERS_START(0, -1)
-        Z_PARAM_VARIADIC('+', args, argc)
-    ZEND_PARSE_PARAMETERS_END();
-
-    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL)
-        RETURN_FALSE;
-
-    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "INFO");
-    for (i = 0; i < argc; i++) {
-        section = zval_get_string(&args[i]);
-        redis_cmd_append_sstr_zstr(&cmdstr, section);
-        zend_string_release(section);
-    }
-
-    REDIS_PROCESS_REQUEST(redis_sock, cmdstr.c, cmdstr.len);
-    if (IS_ATOMIC(redis_sock)) {
-        redis_info_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL,
-            NULL);
-    }
-    REDIS_PROCESS_RESPONSE(redis_info_response);
+    REDIS_PROCESS_CMD(info, redis_info_response);
 }
 /* }}} */
 
@@ -2504,7 +2479,7 @@ PHP_METHOD(Redis, evalsha_ro) {
 
 /* {{{ public function script($args...): mixed }}} */
 PHP_METHOD(Redis, script) {
-    REDIS_PROCESS_KW_CMD("SCRIPT", redis_vararg_cmd, redis_read_variant_reply);
+    REDIS_PROCESS_CMD(script, redis_read_variant_reply);
 }
 
 /* {{{ proto DUMP key */

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1815,16 +1815,17 @@ int redis_key_str_arr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 }
 
 /* Generic function that takes one or more non-serialized arguments */
-int redis_vararg_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                     char *kw, char **cmd, int *cmd_len, short *slot,
-                     void **ctx)
+static int
+gen_vararg_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+               uint32_t min_argc, char *kw, char **cmd, int *cmd_len,
+               short *slot, void **ctx)
 {
     smart_string cmdstr = {0};
     zval *argv = NULL;
     zend_string *arg;
     int argc = 0;
 
-    ZEND_PARSE_PARAMETERS_START(1, -1)
+    ZEND_PARSE_PARAMETERS_START(min_argc, -1)
         Z_PARAM_VARIADIC('*', argv, argc)
     ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
@@ -2067,6 +2068,20 @@ int redis_mpop_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw
     *cmd_len = cmdstr.len;
 
     return SUCCESS;
+}
+
+int redis_info_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                   char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    return gen_vararg_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, 0,
+                          "INFO", cmd, cmd_len, slot, ctx);
+}
+
+int redis_script_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                   char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    return gen_vararg_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, 1,
+                          "SCRIPT", cmd, cmd_len, slot, ctx);
 }
 
 /* Generic handling of every blocking pop command (BLPOP, BZPOP[MIN/MAX], etc */

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -185,6 +185,12 @@ int redis_geosearchstore_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock
  * specific processing we do (e.g. verifying subarguments) that make them
  * unique */
 
+int redis_info_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+    char **cmd, int *cmd_len, short *slot, void **ctx);
+
+int redis_script_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+    char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_acl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
@@ -340,9 +346,6 @@ int redis_expire_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_varkey_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-    char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
-
-int redis_vararg_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *kw, char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_sentinel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,


### PR DESCRIPTION
Use `gen_varkey_cmd` for INFO and SCRIPT.