### PR TITLE
Rework ZRANGE argument handling.

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -4108,9 +4108,9 @@ class Redis {
      * @category zset
      *
      * @example $redis->zRange('zset', 0, -1);
-     * @example $redis->zRange('zset', '-inf', 'inf', ['byscore' => true]);
+     * @example $redis->zRange('zset', '-inf', 'inf', ['byscore']);
      */
-    public function zRange(string $key, mixed $start, mixed $end, array|bool|null $options = null): Redis|array|false;
+    public function zRange(string $key, string|int $start, string|int $end, array|bool|null $options = null): Redis|array|false;
 
     /**
      * Retrieve a range of elements from a sorted set by legographical range.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2d2bd3a96ba44622f4157ee2e06695ffb87a4949 */
+ * Stub hash: b0d5c56084a89230807e6ba582d2fab536d2e897 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -1028,8 +1028,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zRange, 0, 3, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, start, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, end, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, start, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_TYPE_MASK(0, end, MAY_BE_STRING|MAY_BE_LONG, NULL)
 	ZEND_ARG_TYPE_MASK(0, options, MAY_BE_ARRAY|MAY_BE_BOOL|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -759,7 +759,7 @@ int redis_zrange_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                      char *kw, char **cmd, int *cmd_len, short *slot,
                      void **ctx)
 {
-    zval *zoptions = NULL, *zstart, *zend;
+    zval *zoptions = NULL, *zstart = NULL, *zend = NULL;
     zend_string *dst = NULL, *src = NULL;
     zend_long start = 0, end = 0;
     smart_string cmdstr = {0};

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2d2bd3a96ba44622f4157ee2e06695ffb87a4949 */
+ * Stub hash: b0d5c56084a89230807e6ba582d2fab536d2e897 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)


### PR DESCRIPTION
Rework argument parsing for `ZRANGE` so we can pass either a string or an integer so everything will work even when using strict types.

Additionally update our docs to use the correct mechanism for adding the `BYSCORE` option.

Fixes #2291