### PR TITLE
Use Get-ChildItem instead of a hardcoded path for php_relay.dll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,7 @@ jobs:
         run: |
           md binaries
           copy LICENSE binaries
-          if (Test-Path "x64\Release") {
-            Set-Variable -Name "prefix" -Value "x64\Release"
-          } else {
-            Set-Variable -Name "prefix" -Value "x64\Release_TS"
-          }
-          copy $prefix\php_redis.dll binaries
+          Get-ChildItem -Recurse -Filter "php_redis.dll" | ForEach-Object {Copy-Item -Path $_.FullName -Destination "binaries"}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
@yatsukhnenko the future is now.  This line of code was generated by chatGPT

![Screenshot 2022-12-10 at 2 39 27 PM](https://user-images.githubusercontent.com/468149/206878334-68cedacd-a2ce-4a5f-8424-013fc57c40a1.png)

mind=blown