### PR TITLE
Small refactor of some methods

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1820,6 +1820,18 @@ cluster_zdiff_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
 }
 
 PHP_REDIS_API void
+cluster_zadd_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
+    ZEND_ASSERT(ctx == NULL || ctx == PHPREDIS_CTX_PTR);
+
+    if (ctx == NULL) {
+        cluster_long_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
+    } else {
+        cluster_dbl_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
+    }
+}
+
+
+PHP_REDIS_API void
 cluster_zrandmember_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
     if (ctx == NULL) {
         cluster_bulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -418,6 +418,8 @@ PHP_REDIS_API void cluster_hrandfield_resp(INTERNAL_FUNCTION_PARAMETERS, redisCl
     void *ctx);
 PHP_REDIS_API void cluster_zdiff_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
+PHP_REDIS_API void cluster_zadd_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    void *ctx);
 PHP_REDIS_API void cluster_zrandmember_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
 PHP_REDIS_API void cluster_srandmember_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,

--- a/library.c
+++ b/library.c
@@ -1427,6 +1427,18 @@ redis_parse_client_list_response(char *response, zval *z_ret)
 }
 
 PHP_REDIS_API int
+redis_zadd_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx)
+{
+    FailableResultCallback cb;
+
+    ZEND_ASSERT(ctx == NULL || ctx == PHPREDIS_CTX_PTR);
+
+    cb = ctx ? redis_bulk_double_response : redis_long_response;
+
+    return cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, NULL);
+}
+
+PHP_REDIS_API int
 redis_zrandmember_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx)
 {
     if (ctx == NULL) {

--- a/library.h
+++ b/library.h
@@ -183,6 +183,7 @@ PHP_REDIS_API int redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAMETERS, Red
 PHP_REDIS_API int redis_read_variant_reply_strings(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_client_list_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 
+PHP_REDIS_API int redis_zadd_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_zrandmember_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_zdiff_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_set_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -1583,7 +1583,7 @@ PHP_METHOD(Redis, brpoplpush) {
 
 /* {{{ proto long Redis::zAdd(string key, int score, string value) */
 PHP_METHOD(Redis, zAdd) {
-    REDIS_PROCESS_CMD(zadd, redis_long_response);
+    REDIS_PROCESS_CMD(zadd, redis_zadd_response);
 }
 /* }}} */
 

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1214,7 +1214,7 @@ class Redis {
 
     /**
      * Functions is an API for managing code to be executed on the server.
-     * 
+     *
      * @param string $operation         The subcommand you intend to execute.  Valid options are as follows
      *                                  'LOAD'      - Create a new library with the given library name and code.
      *                                  'DELETE'    - Delete the given library.
@@ -4004,7 +4004,7 @@ class Redis {
      * @example $redis->zadd('zs', 1, 'first', 2, 'second', 3, 'third');
      * @example $redis->zAdd('zs', ['XX'], 8, 'second', 99, 'new-element');
      */
-    public function zAdd(string $key, array|float $score_or_options, mixed ...$more_scores_and_mems): Redis|int|false;
+    public function zAdd(string $key, array|float $score_or_options, mixed ...$more_scores_and_mems): Redis|int|float|false;
 
     /**
      * Return the number of elements in a sorted set.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 600a10da9438d33050be825dff3683399737cc5e */
+ * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "null")
@@ -1000,7 +1000,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xtrim, 0, 2, Red
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zAdd, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zAdd, 0, 2, Redis, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, score_or_options, MAY_BE_ARRAY|MAY_BE_DOUBLE, NULL)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, more_scores_and_mems, IS_MIXED, 0)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1084,7 +1084,7 @@ PHP_METHOD(RedisCluster, zmscore) {
 
 /* {{{ proto long RedisCluster::zadd(string key,double score,string mem, ...) */
 PHP_METHOD(RedisCluster, zadd) {
-    CLUSTER_PROCESS_CMD(zadd, cluster_long_resp, 0);
+    CLUSTER_PROCESS_CMD(zadd, cluster_zadd_resp, 0);
 }
 /* }}} */
 

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -1035,7 +1035,7 @@ class RedisCluster {
     /**
      * @see Redis::zadd
      */
-    public function zadd(string $key, array|float $score_or_options, mixed ...$more_scores_and_mems): RedisCluster|int|false;
+    public function zadd(string $key, array|float $score_or_options, mixed ...$more_scores_and_mems): RedisCluster|int|float|false;
 
     /**
      * @see Redis::zcard

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eabecbc2e536faca2a9fcba3c99ad0aeba9721b4 */
+ * Stub hash: 32b24ce215ff4f2299dd838fab7cbc36b81b65eb */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -891,7 +891,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_xtrim, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zadd, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zadd, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_MASK(0, score_or_options, MAY_BE_ARRAY|MAY_BE_DOUBLE, NULL)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, more_scores_and_mems, IS_MIXED, 0)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eabecbc2e536faca2a9fcba3c99ad0aeba9721b4 */
+ * Stub hash: 32b24ce215ff4f2299dd838fab7cbc36b81b65eb */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 600a10da9438d33050be825dff3683399737cc5e */
+ * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2567,6 +2567,15 @@ class Redis_Test extends TestSuite
         $this->assertTrue(['val0', 'val1'] === $this->redis->zRange($zsetName, 0, -1));
     }
 
+    public function testZaddIncr() {
+        $this->redis->del('zset');
+
+        $this->assertEquals(10.0, $this->redis->zAdd('zset', ['incr'], 10, 'value'));
+        $this->assertEquals(20.0, $this->redis->zAdd('zset', ['incr'], 10, 'value'));
+
+        $this->assertFalse($this->redis->zAdd('zset', ['incr'], 10, 'value', 20, 'value2'));
+    }
+
     public function testZX() {
         $this->redis->del('key');
 


### PR DESCRIPTION
* Use our `redis_cmd_append_sstr_key_*` and `redis_cmd_append_sstr_zval` wrappers, which handle key prefixing and serialization transparently.

* Rework ZADD so it can handle the bulk double response from the `INCR` options.