### PR TITLE
fix testObject for redis 7.2

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3318,16 +3318,18 @@ class Redis_Test extends TestSuite
         $this->redis->lpush('key', 'value');
 
         /* Newer versions of redis are going to encode lists as 'quicklists',
-         * so 'quicklist' or 'ziplist' is valid here */
+         * redis >= 7.2 as 'listpack'
+         * so 'quicklist' or 'ziplist' or 'listpack' are valid here */
         $str_encoding = $this->redis->object('encoding', 'key');
-        $this->assertTrue($str_encoding === "ziplist" || $str_encoding === 'quicklist');
+        $this->assertTrue($str_encoding === "ziplist" || $str_encoding === 'quicklist' || $str_encoding === 'listpack', $str_encoding);
 
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
         $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 
         $this->redis->del('key');
         $this->redis->sadd('key', 'value');
-        $this->assertTrue($this->redis->object('encoding', 'key') === "hashtable");
+        $str_encoding = $this->redis->object('encoding', 'key');
+        $this->assertTrue($str_encoding === "hashtable" || $str_encoding === 'listpack', $str_encoding);
         $this->assertTrue($this->redis->object('refcount', 'key') === 1);
         $this->assertTrue(is_numeric($this->redis->object('idletime', 'key')));
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -102,13 +102,13 @@ class TestSuite
         return false;
     }
 
-    protected function assertTrue($bool) {
+    protected function assertTrue($bool, $msg='') {
         if($bool)
             return true;
 
         $bt = debug_backtrace(false);
-        self::$errors []= sprintf("Assertion failed: %s:%d (%s)\n",
-            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"]);
+        self::$errors []= sprintf("Assertion failed: %s:%d (%s) %s\n",
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"], $msg);
 
         return false;
     }


### PR DESCRIPTION
See #2334 

I also add a new `$msg` option to assertTrue to be able to add some debug info about the failure
