### PR TITLE
raise minimal supported version to 7.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -187,7 +187,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.2.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
Because various issues with generated legacy arginfo

ex: missing in 7.0 and 7.1
- zend_string_init_interned
- zend_declare_class_constant_ex

IMHO it make sense to drop support for old EOL versions.