### PR TITLE
Update Redis Sentinel documentation to reflect changes to constructor in 6.0 release

### DIFF
--- a/sentinel.md
+++ b/sentinel.md
@@ -21,12 +21,42 @@ Redis Sentinel also provides other collateral tasks such as monitoring, notifica
 ##### *Example*
 
 ~~~php
-$sentinel = new RedisSentinel('127.0.0.1'); // default parameters
-$sentinel = new RedisSentinel('127.0.0.1', 26379, 2.5); // 2.5 sec timeout.
-$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, 'sentinel'); // persistent connection with id 'sentinel'
-$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, ''); // also persistent connection with id ''
-$sentinel = new RedisSentinel('127.0.0.1', 26379, 1, null, 100); // 1 sec timeout, 100ms delay between reconnection attempts.
-$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, NULL, 0, 0, "secret"); // connect sentinel with password authentication
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+]); // default parameters
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+  'port' => 26379,
+  'connectTimeout' => 2.5,
+]); // 2.5 sec timeout.
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+  'port' => 26379,
+  'connectTimeout' => 2.5,
+  'persistent' => 'sentinel',
+]); // persistent connection with id 'sentinel'
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+  'port' => 26379,
+  'connectTimeout' => 2.5,
+  'persistent' => '',
+]); // also persistent connection with id ''
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+  'port' => 26379,
+  'connectTimeout' => 1,
+  'persistent' => null,
+  'retryInterval' => 100,
+]); // 1 sec timeout, 100ms delay between reconnection attempts.
+$sentinel = new RedisSentinel([
+  'host' => '127.0.0.1',
+  'port' => 26379,
+  'connectTimeout' => 0,
+  'persistent' => null,
+  'retryInterval' => 0,
+  'readTimeout' => 0,
+  'auth' => 'secret',
+]); // connect sentinel with password authentication
 ~~~
 
 ### Usage

--- a/sentinel.md
+++ b/sentinel.md
@@ -18,7 +18,7 @@ Redis Sentinel also provides other collateral tasks such as monitoring, notifica
 *read_timeout*: Float, value in seconds (optional, default is 0 meaning unlimited)  
 *auth*:String, or an Array with one or two elements, used to authenticate with the redis-sentinel. (optional, default is NULL meaning NOAUTH)
 
-##### *Example*
+##### *Examples for version 6.0 or later*
 
 ~~~php
 $sentinel = new RedisSentinel([
@@ -57,6 +57,17 @@ $sentinel = new RedisSentinel([
   'readTimeout' => 0,
   'auth' => 'secret',
 ]); // connect sentinel with password authentication
+~~~
+
+##### *Examples for versions older than 6.0*
+
+~~~php
+$sentinel = new RedisSentinel('127.0.0.1'); // default parameters
+$sentinel = new RedisSentinel('127.0.0.1', 26379, 2.5); // 2.5 sec timeout.
+$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, 'sentinel'); // persistent connection with id 'sentinel'
+$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, ''); // also persistent connection with id ''
+$sentinel = new RedisSentinel('127.0.0.1', 26379, 1, null, 100); // 1 sec timeout, 100ms delay between reconnection attempts.
+$sentinel = new RedisSentinel('127.0.0.1', 26379, 0, NULL, 0, 0, "secret"); // connect sentinel with password authentication
 ~~~
 
 ### Usage


### PR DESCRIPTION
Updates the Redis Sentinel documentation examples to reflect the constructor changes in the 6.0 release: https://github.com/phpredis/phpredis/commit/ebb2386e52c9ddd8a45e3cd67f12d77be894e1d7