### PR TITLE
Obtain a read only session if session lock fails

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -701,9 +701,7 @@ PS_READ_FUNC(redis)
     cmd_len = REDIS_SPPRINTF(&cmd, "GET", "S", pool->lock_status.session_key);
 
     if (lock_acquire(redis_sock, &pool->lock_status) != SUCCESS) {
-        php_error_docref(NULL, E_WARNING, "Failed to acquire session lock");
-        efree(cmd);
-        return FAILURE;
+        php_error_docref(NULL, E_WARNING, "Failed to acquire session lock, session will be read only");
     }
 
     if (redis_sock_write(redis_sock, cmd, cmd_len) < 0) {


### PR DESCRIPTION
If a session lock fails to obtain, use a read only version of the session. This causes less backwards compatible issues and was introduced between the 5.3.7 and 6.0.0 releases.

New note added to suggest the session is read only

Fixes #2382

Introduced here 
https://github.com/phpredis/phpredis/commit/687a0b405051adada1ff460a3863d0f85cd6e98a#diff-d7896829bc47f45d33720c352a4b8aabd4dca447b6db9e2d4205be5b44ba5d9eR714