### PR TITLE
exec: initialize z_ret before returning

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -1982,6 +1982,8 @@ PHP_METHOD(Redis, exec)
         RETURN_FALSE;
     }
 
+    ZVAL_NULL(&z_ret);
+
     if (IS_MULTI(redis_sock)) {
         if (IS_PIPELINE(redis_sock)) {
             PIPELINE_ENQUEUE_COMMAND(RESP_EXEC_CMD, sizeof(RESP_EXEC_CMD) - 1);
@@ -1991,7 +1993,6 @@ PHP_METHOD(Redis, exec)
         }
         SOCKET_WRITE_COMMAND(redis_sock, RESP_EXEC_CMD, sizeof(RESP_EXEC_CMD) - 1)
 
-        ZVAL_NULL(&z_ret);
         ret = redis_sock_read_multibulk_multi_reply(
             INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &z_ret);
         free_reply_callbacks(redis_sock);


### PR DESCRIPTION
In case no multi or pipeline is active, just calling `->exec()` segfaults.

Fixes #2390