### PR TITLE
Add additional arguments for XADD from Redis 6.2.0 missed by #1894

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,12 @@
 /.vscode
 /docs/.cache
 .cquery
+*.dep
 *.deps
 *.libs
 *.o
+*.so
+*.la
 *.lo
 Makefile*
 configure*

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -3640,11 +3640,14 @@ class Redis {
      *                           end of the stream.  It can also be a value in the form <ms>-* which will
      *                           generate an ID that appends to the end ot entries with the same <ms> value
      *                           (if any exist).
-     * @param int    $maxlen     If specified Redis will append the new message but trim any number of the
-     *                           oldest messages in the stream until the length is <= $maxlen.
-     * @param bool   $approx     Used in conjunction with `$maxlen`, this flag tells Redis to trim the stream
-     *                           but in a more efficient way, meaning the trimming may not be exactly to
-     *                           `$maxlen` values.
+     * @param string $threshold This can either be a maximum length, or a minimum id.
+     *                          MAXLEN - An integer describing the maximum desired length of the stream after the command.
+     *                          MINID  - An ID that will become the new minimum ID in the stream, as Redis will trim all
+     *                                   messages older than this ID.
+     * @param bool   $approx    Whether redis is allowed to do an approximate trimming of the stream.  This is
+     *                          more efficient for Redis given how streams are stored internally.
+     * @param bool   $minid     When set to `true`, users should pass a minimum ID to the `$threshold` argument.
+     * @param int    $limit     An optional upper bound on how many entries to trim during the command.
      * @param bool   $nomkstream If passed as `TRUE`, the stream must exist for Redis to append the message.
      *
      * @see https://redis.io/commands/xadd
@@ -3652,7 +3655,7 @@ class Redis {
      * @example $redis->xAdd('ds9-season-1', '1-1', ['title' => 'Emissary Part 1']);
      * @example $redis->xAdd('ds9-season-1', '1-2', ['title' => 'A Man Alone']);
      */
-    public function xadd(string $key, string $id, array $values, int $maxlen = 0, bool $approx = false, bool $nomkstream = false): Redis|string|false;
+    public function xadd(string $key, string $id, array $values, int $threshold = 0, bool $approx = false, bool $minid = false, int $limit = -1, bool $nomkstream = false): Redis|string|false;
 
     /**
      * This command allows a consumer to claim pending messages that have been idle for a specified period of time.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: 93d21b26e8c0c5c1550ca5eb13464a076aae2be6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -588,17 +588,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_object, 0, 2, Re
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_open, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, host, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "6379")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, persistent_id, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, retry_interval, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, read_timeout, IS_DOUBLE, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, context, IS_ARRAY, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_open arginfo_class_Redis_connect
 
-#define arginfo_class_Redis_pconnect arginfo_class_Redis_open
+#define arginfo_class_Redis_pconnect arginfo_class_Redis_connect
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_persist, 0, 1, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -633,7 +625,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_pipeline, 0, 0, Redis, MAY_BE_BOOL)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_popen arginfo_class_Redis_open
+#define arginfo_class_Redis_popen arginfo_class_Redis_connect
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_psetex, 0, 3, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -908,8 +900,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xadd, 0, 3, Redi
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxlen, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, threshold, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, approx, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, minid, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nomkstream, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -1155,12 +1149,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_zunion arginfo_class_Redis_zinter
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zunionstore, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, dst, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, weights, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, aggregate, IS_STRING, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_zunionstore arginfo_class_Redis_zinterstore
 
 
 ZEND_METHOD(Redis, __construct);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -5306,9 +5306,6 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         redis_cmd_append_sstr_zval(&cmdstr, value, redis_sock);
     } ZEND_HASH_FOREACH_END();
 
-    // TODO remove this
-    printf("%s\n", cmdstr.c);
-
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;
     return SUCCESS;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -5263,7 +5263,7 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     if (threshold < 0) {
         php_error_docref(NULL, E_WARNING,
-            "Invalid MAXLEN/MINID argument or approximate flag");
+            "Invalid threshold argument flag");
     }
 
     /* Calculate argc for XADD.  It's a bit complex because we've got

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -5229,27 +5229,31 @@ redis_copy_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
-/* XADD */
+// XADD key [NOMKSTREAM] [MAXLEN|MINID [=|~] threshold [LIMIT count]] *|id field value [field value ...]
 int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                    char **cmd, int *cmd_len, short *slot, void **ctx)
 {
     smart_string cmdstr = {0};
     zend_string *arrkey;
     zval *z_fields, *value;
-    zend_long maxlen = 0;
-    zend_bool approx = 0, nomkstream = 0;
+    zend_long threshold = 0, limit = -1;
+    zend_bool approx = 0, minid = 0, nomkstream = 0;
     zend_ulong idx;
     HashTable *ht_fields;
     int fcount, argc;
-    char *key, *id;
-    size_t keylen, idlen;
+    zend_string *key, *id;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssa|lbb", &key, &keylen,
-                              &id, &idlen, &z_fields, &maxlen, &approx,
-                              &nomkstream) == FAILURE)
-    {
-        return FAILURE;
-    }
+    ZEND_PARSE_PARAMETERS_START(3, 8)
+        Z_PARAM_STR(key)
+        Z_PARAM_STR(id)
+        Z_PARAM_ARRAY(z_fields)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(threshold)
+        Z_PARAM_BOOL(approx)
+        Z_PARAM_BOOL(minid)
+        Z_PARAM_LONG(limit)
+        Z_PARAM_BOOL(nomkstream)
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
     /* At least one field and string are required */
     ht_fields = Z_ARRVAL_P(z_fields);
@@ -5257,38 +5261,53 @@ int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         return FAILURE;
     }
 
-    if (maxlen < 0 || (maxlen == 0 && approx != 0)) {
+    if (threshold < 0) {
         php_error_docref(NULL, E_WARNING,
-            "Warning:  Invalid MAXLEN argument or approximate flag");
+            "Invalid MAXLEN/MINID argument or approximate flag");
     }
 
-
     /* Calculate argc for XADD.  It's a bit complex because we've got
-     * an optional MAXLEN argument which can either take the form MAXLEN N
-     * or MAXLEN ~ N */
-    argc = 2 + nomkstream + (fcount * 2) + (maxlen > 0 ? (approx ? 3 : 2) : 0);
+     * an optional threshold (MAXLEN/MINID) which can either take the 
+     * form OPTION N or OPTION ~ N, with the optional LIMIT N */
+    argc = 2 + nomkstream + (fcount * 2) + (threshold > 0 ? 2 + (approx && limit > -1 ? 3 : approx) : 0);
 
     /* XADD key ID field string [field string ...] */
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "XADD");
-    redis_cmd_append_sstr_key(&cmdstr, key, keylen, redis_sock, slot);
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
 
     if (nomkstream) {
         REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "NOMKSTREAM");
     }
 
-    /* Now append our MAXLEN bits if we've got them */
-    if (maxlen > 0) {
-        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "MAXLEN");
+    /* Now append our MAXLEN/MINID bits if we've got them */
+    if (threshold > 0) {
+        if (minid) {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "MINID");
+        } else {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "MAXLEN");
+        }
+
         REDIS_CMD_APPEND_SSTR_OPT_STATIC(&cmdstr, approx, "~");
-        redis_cmd_append_sstr_long(&cmdstr, maxlen);
+        redis_cmd_append_sstr_long(&cmdstr, threshold);
+
+        if (limit > -1 && approx) {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "LIMIT");
+            redis_cmd_append_sstr_long(&cmdstr, limit);
+        } else if (limit > -1) {
+            php_error_docref(NULL, E_WARNING, 
+                "Cannot use LIMIT without an approximate match, ignoring");
+        }
     }
 
     /* Now append ID and field(s) */
-    redis_cmd_append_sstr(&cmdstr, id, idlen);
+    redis_cmd_append_sstr_zstr(&cmdstr, id);
     ZEND_HASH_FOREACH_KEY_VAL(ht_fields, idx, arrkey, value) {
         redis_cmd_append_sstr_arrkey(&cmdstr, arrkey, idx);
         redis_cmd_append_sstr_zval(&cmdstr, value, redis_sock);
     } ZEND_HASH_FOREACH_END();
+
+    // TODO remove this
+    printf("%s\n", cmdstr.c);
 
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: 93d21b26e8c0c5c1550ca5eb13464a076aae2be6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -790,8 +790,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xadd, 0, 0, 3)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, id)
 	ZEND_ARG_INFO(0, values)
-	ZEND_ARG_INFO(0, maxlen)
+	ZEND_ARG_INFO(0, threshold)
 	ZEND_ARG_INFO(0, approx)
+	ZEND_ARG_INFO(0, minid)
+	ZEND_ARG_INFO(0, limit)
 	ZEND_ARG_INFO(0, nomkstream)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
The redis `XADD` command as specified by https://redis.io/commands/xadd/ supports additional parameters that allows for trimming in the same command as adding.

It was covered in this issue https://github.com/phpredis/phpredis/issues/1894, and more specifically this PR https://github.com/phpredis/phpredis/pull/2172 addressing another issue https://github.com/phpredis/phpredis/issues/1961 which in turn requested the same arguments for the XTRIM command when the feature was released in redis 6.2.0.

I've been wanting to use these features in my own code, but found them lacking, and with no inherent explanation on their omission i did my best following the existing implementation of them in XTRIM.

