### PR TITLE
Find our callback by pattern with PSUBSCRIBE

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1580,7 +1580,7 @@ int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     ZEND_HASH_FOREACH_VAL(ht_chan, z_chan) {
         redis_cmd_append_sstr_key_zval(&cmdstr, z_chan, redis_sock, slot ? &s2 : NULL);
 
-        if (shardslot != REDIS_CLUSTER_SLOTS && s2 != shardslot) {
+        if (slot && (shardslot != REDIS_CLUSTER_SLOTS && s2 != shardslot)) {
             php_error_docref(NULL, E_WARNING, "All shard channels needs to belong to a single slot");
             smart_string_free(&cmdstr);
             efree(sctx);


### PR DESCRIPTION
* Use the pattern Redis provides us not the channel, if this is a wildcard based `PSUBSCRIBE` payload.

* Don't test whether our slots match in `SSUBSCRIBE` when not in cluster mode.

Fixes #2395