### PR TITLE
The VALUE argument type for hSetNx must be the same as for hSet

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1802,7 +1802,7 @@ class Redis {
      * $redis->hsetnx('player:1', 'lock', 'enabled');
      * $redis->hsetnx('player:1', 'lock', 'enabled');
      */
-    public function hSetNx(string $key, string $field, string $value): Redis|bool;
+    public function hSetNx(string $key, string $field, mixed $value): Redis|bool;
 
     /**
      * Get the string length of a hash field

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: f98761a9bf8bfd22f34609b4d7c0c26f69248668 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -440,7 +440,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hSetNx, 0, 3, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hStrLen, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cf0ecc2f5a43c6ede68d537a76faa23cb912d96 */
+ * Stub hash: f98761a9bf8bfd22f34609b4d7c0c26f69248668 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)


### PR DESCRIPTION
After update to phpredis 6.0 I got an error when uses `$redis->hSetNx` with integer $value argument. But at the same time `hSet` is works

```php 
public function hSet(string $key, string $member, mixed $value): \Redis|false|int;

public function hSetNx(string $key, string $field, string $value): \Redis|bool
```

After fix

```php 
public function hSet(string $key, string $member, mixed $value): \Redis|false|int;

public function hSetNx(string $key, string $field, mixed $value): \Redis|bool
```