### PR TITLE
Fix flaky test and OBJECT in a pipeline.

### DIFF
--- a/library.c
+++ b/library.c
@@ -1519,9 +1519,9 @@ redis_object_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval 
     ZEND_ASSERT(ctx == PHPREDIS_CTX_PTR || ctx == PHPREDIS_CTX_PTR + 1);
 
     if (ctx == PHPREDIS_CTX_PTR) {
-        return redis_long_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, NULL);
+        return redis_long_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, NULL);
     } else {
-        return redis_string_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, NULL);
+        return redis_string_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, z_tab, NULL);
     }
 }
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -983,13 +983,18 @@ class Redis_Test extends TestSuite
         $this->redis->del('notakey');
 
         $this->assertTrue($this->redis->mset(['{idle}1' => 'beep', '{idle}2' => 'boop']));
-        usleep(1100000);
-        $this->assertTrue($this->redis->object('idletime', '{idle}1') >= 1);
-        $this->assertTrue($this->redis->object('idletime', '{idle}2') >= 1);
+        usleep(2100000);
+        $this->assertTrue($this->redis->object('idletime', '{idle}1') >= 2);
+        $this->assertTrue($this->redis->object('idletime', '{idle}2') >= 2);
 
         $this->assertEquals(2, $this->redis->touch('{idle}1', '{idle}2', '{idle}notakey'));
-        $this->assertTrue($this->redis->object('idletime', '{idle}1') == 0);
-        $this->assertTrue($this->redis->object('idletime', '{idle}2') == 0);
+        $idle1 = $this->redis->object('idletime', '{idle}1');
+        $idle2 = $this->redis->object('idletime', '{idle}2');
+
+        /* We're not testing if idle is 0 because CPU scheduling on GitHub CI
+         * potatoes can cause that to erroneously fail. */
+        $this->assertTrue($idle1 < 2);
+        $this->assertTrue($idle2 < 2);
     }
 
     public function testKeys()


### PR DESCRIPTION
* We weren't properly passing `z_tab` through to the underlying OBJECT handler, which was causing PhpRedis to crash if you tried to execute the OBJECT command in a pipeline.

* Rework the `testTouch` unit test to try and avoid erroneous failures due to CI instance CPU scheduling.