### PR TITLE
Throw when passing an empty array to `mget()` instead or returning false

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2385,8 +2385,10 @@ int redis_mget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         Z_PARAM_ARRAY_HT(keys)
     ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
-    if (zend_hash_num_elements(keys) == 0)
+    if (zend_hash_num_elements(keys) == 0) {
+        zend_throw_exception(NULL, "Expected array of at least one element", 0);
         return FAILURE;
+    }
 
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, zend_hash_num_elements(keys), "MGET");
 


### PR DESCRIPTION
Fix #1810, related to https://github.com/symfony/symfony/pull/52700 and https://github.com/symfony/symfony/issues/52668

![image](https://github.com/phpredis/phpredis/assets/2144837/f0454f18-ae1f-4d55-a45d-1fc5ea73a2fe)

The stub doesn't allow `false` to be returned, however that's what happen when calling `mget` with an empty array. I propose to throw an exception about it when this happen. This allow to keep the current `mget` return type.