### PR TITLE
Include redisSock's persistent_id in persistent connection pool persistent_id string

### DIFF
--- a/library.c
+++ b/library.c
@@ -881,6 +881,10 @@ redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...) {
     smart_str_append_ex(&str, redis_sock->host, 0);
     smart_str_appendc(&str, ':');
     smart_str_append_long(&str, (zend_long)redis_sock->port);
+    if (redis_sock->persistent_id) {
+        smart_str_appendc(&str, ':');
+        smart_str_append_ex(&str, redis_sock->persistent_id, 0);
+    }
 
     /* Short circuit if we don't have a pattern */
     if (fmt == NULL) {
@@ -890,15 +894,9 @@ redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...) {
 
     while (*fmt) {
         switch (*fmt) {
-            case 'i':
-                if (redis_sock->persistent_id) {
-                    smart_str_appendc(&str, ':');
-                    smart_str_append_ex(&str, redis_sock->persistent_id, 0);
-                }
-                break;
             case 'u':
-                smart_str_appendc(&str, ':');
                 if (redis_sock->user) {
+                    smart_str_appendc(&str, ':');
                     smart_str_append_ex(&str, redis_sock->user, 0);
                 }
                 break;


### PR DESCRIPTION
When use dbNumber 0 and not use select command after redis connect, pconnect return already selected db redisConn.
So use persistent_id for identified redisConn. But Not work. 
This issue was opened.  #1920
And not match in README.md description. https://github.com/phpredis/phpredis/blob/ff305349dba87ab857a8f28acbc3b22af5a271cc/README.md?plain=1#L291
All connection pool contained or not persistent_id return same persistent_id.
Of course it can be solved by using `redis.pconnect.pool_pattern`, Default option users will have a hard time understanding why an issue occurs.
This issue start at 5.0.0 version's commit. https://github.com/phpredis/phpredis/commit/8206b14749e2583895023312c2143116c2480a50

