### PR TITLE
fix: RedisCluster::publish returns a cluster_long_resp

### DIFF
--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -704,7 +704,7 @@ class RedisCluster {
     /**
      * @see Redis::publish
      */
-    public function publish(string $channel, string $message): RedisCluster|bool;
+    public function publish(string $channel, string $message): RedisCluster|bool|int;
 
     /**
      * @see Redis::pubsub

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8038ea72ccc7fd8384d0eba4209702b20d77bd */
+ * Stub hash: d832720b86414896922f919bcd559fe82426c7a6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -576,7 +576,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_pttl arginfo_class_RedisCluster_expiretime
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_publish, 0, 2, RedisCluster, MAY_BE_BOOL)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_publish, 0, 2, RedisCluster, MAY_BE_BOOL|MAY_BE_LONG)
 	ZEND_ARG_TYPE_INFO(0, channel, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8038ea72ccc7fd8384d0eba4209702b20d77bd */
+ * Stub hash: d832720b86414896922f919bcd559fe82426c7a6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)


### PR DESCRIPTION
Hi :wave:

While updating our test suites for phpredis v6, I stumbled upon the following error:
```
Fatal error: RedisCluster::publish(): Return value must be of type RedisCluster|bool, int returned in Unknown on line 0
```

I haven't looked deeply into it, but I think that may be sufficient.