### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,7 +597,7 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- Remove unused macroses
+- Remove unused macros
   [831d6118](https://github.com/phpredis/phpredis/commit/831d6118)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 
@@ -1495,7 +1495,7 @@ serializers, soft deprecation of non-Redis commands.
 
 ## [4.3.0] - 2019-03-13 ([GitHub](https://github.com/phpredis/phpredis/releases/tag/4.3.0), [PECL](https://pecl.php.net/package/redis/4.3.0))
 
-This is probably the last release with PHP 5 suport!!!
+This is probably the last release with PHP 5 support!!!
 
 ### Added
 
@@ -1566,7 +1566,7 @@ The main feature of this release is new Streams API implemented by
 ### Changed
 
 - Optimize close method [2a1ef961](https://www.github.com/phpredis/phpredis/commit/2a1ef961) ([yulonghu](https://github.com/yulonghu))
-- Use a ZSET insted of SET for EVAL tests [2e412373](https://www.github.com/phpredis/phpredis/commit/2e412373) ([Michael Grunder](https://github.com/michael-grunder))
+- Use a ZSET instead of SET for EVAL tests [2e412373](https://www.github.com/phpredis/phpredis/commit/2e412373) ([Michael Grunder](https://github.com/michael-grunder))
 - Modify session testing logic [bfd27471](https://www.github.com/phpredis/phpredis/commit/bfd27471) ([Michael Grunder](https://github.com/michael-grunder))
 - Documentation improvements ([@michael-grunder](https://github.com/michael-grunder), [@elcheco](https://github.com/elcheco), [@lucascourot](https://github.com/lucascourot), [@nolimitdev](https://github.com/nolimitdev),
   [Michael Grunder](https://github.com/michael-grunder))
@@ -1618,7 +1618,7 @@ The main feature of this release is new Streams API implemented by
 - Add tcp_keepalive option to redis sock [68c58513](https://www.github.com/phpredis/phpredis/commit/68c58513), [5101172a](https://www.github.com/phpredis/phpredis/commit/5101172a), [010336d5](https://www.github.com/phpredis/phpredis/commit/010336d5),
   [51e48729](https://www.github.com/phpredis/phpredis/commit/51e48729) ([@git-hulk](https://github.com/git-hulk), [Michael Grunder](https://github.com/michael-grunder))
 - More robust GEORADIUS COUNT validation [f7edee5d](https://www.github.com/phpredis/phpredis/commit/f7edee5d) ([Michael Grunder](https://github.com/michael-grunder))
-- Allow to use empty string as persistant_id [ec4fd1bd](https://www.github.com/phpredis/phpredis/commit/ec4fd1bd) ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
+- Allow to use empty string as persistent_id [ec4fd1bd](https://www.github.com/phpredis/phpredis/commit/ec4fd1bd) ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 - Documentation improvements ([Michael Grunder](https://github.com/michael-grunder), [@TomA-R](https://github.com/TomA-R))
 
 ### Fixed
@@ -1641,7 +1641,7 @@ This is interim release which contains only bug fixes.
 - Fix segfault when extending Redis class in PHP 5 [d23eff](https://www.github.com/phpredis/phpredis/commit/d23eff) ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 - Fix RedisCluster constructor with PHP 7 strict scalar type [5c21d7](https://www.github.com/phpredis/phpredis/commit/5c21d7)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
-- Allow to use empty string as persistant_id [344de5](https://www.github.com/phpredis/phpredis/commit/344de5) ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
+- Allow to use empty string as persistent_id [344de5](https://www.github.com/phpredis/phpredis/commit/344de5) ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 - Fix cluster_init_seeds. [db1347](https://www.github.com/phpredis/phpredis/commit/db1347) ([@adlagares](https://github.com/adlagares))
 - Fix z_seeds may be a reference [42581a](https://www.github.com/phpredis/phpredis/commit/42581a) ([@janic716](https://github.com/janic716))
 - PHP >=7.3 uses zend_string for php_url elements [b566fb](https://www.github.com/phpredis/phpredis/commit/b566fb) ([@fmk](https://github.com/fmk))
@@ -1701,9 +1701,9 @@ to the api, listed below.
 
 This release contains two big improvements:
 
-1. Adding a new printf like command construction function with additionaly
+1. Adding a new printf like command construction function with additionally
    format specifiers specific to phpredis.
-2. Implementation of custom objects for Redis and RedisArray wich eliminates
+2. Implementation of custom objects for Redis and RedisArray which eliminates
    double hash lookup.
 
 Also many small improvements and bug fixes were made.
@@ -1783,7 +1783,7 @@ the php 5 and 7 codebase into a single branch.
 - wrong size. ([@remicollet](https://github.com/remicollet))
 -
 - Added php session unit test ([@yatsukhnenko](https://github.com/weltling))
-- Added explicit module dependancy for igbinary ([@remicollet](https://github.com/remicollet))
+- Added explicit module dependency for igbinary ([@remicollet](https://github.com/remicollet))
 - Added phpinfo serialization information ([@remicollet](https://github.com/remicollet))
 
 ---
@@ -1886,7 +1886,7 @@ than 7.
 - Fixed memory leak in discard function [17b1f427](https://www.github.com/phpredis/phpredis/commit/17b1f427)
 - Sanity check for igbinary unserialization
   [3266b222](https://www.github.com/phpredis/phpredis/commit/3266b222), [528297a](https://www.github.com/phpredis/phpredis/commit/528297a) ([Maurus Cuelenaere](https://github.com/mcuelenaere)).
-- Fix segfault occuring from unclosed socket connection for Redis Cluster
+- Fix segfault occurring from unclosed socket connection for Redis Cluster
   [04196aee](https://www.github.com/phpredis/phpredis/commit/04196aee) ([CatKang](https://github.com/CatKang))
 - Case insensitive zRangeByScore options
 - Fixed dreaded size_t vs long long compiler warning

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ _**Description**_: Sends a string to Redis, which replies with the same string
 1. [Backoff algorithms](#backoff-algorithms)
 
 ### Maximum retries
-You can set and get the maximum retries upon connection issues using the `OPT_MAX_RETRIES` option. Note that this is the number of _retries_, meaning if you set this option to _n_, there will be a maximum _n+1_ attemps overall. Defaults to 10.
+You can set and get the maximum retries upon connection issues using the `OPT_MAX_RETRIES` option. Note that this is the number of _retries_, meaning if you set this option to _n_, there will be a maximum _n+1_ attempts overall. Defaults to 10.
 
 ##### *Example*
 
@@ -511,7 +511,7 @@ $redis->setOption(Redis::OPT_BACKOFF_CAP, 750); // backoff time capped at 750ms
 _**Description**_: Execute the Redis ACL command.
 
 ##### *Parameters*
-_variable_:  Minumum of one argument for `Redis` and two for `RedisCluster`.
+_variable_:  Minimum of one argument for `Redis` and two for `RedisCluster`.
 
 ##### *Example*
 ~~~php

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -450,7 +450,7 @@ void cluster_dist_add_val(redisCluster *c, clusterKeyVal *kv, zval *z_val
     // Serialize our value
     val_free = redis_pack(c->flags, z_val, &val, &val_len);
 
-    // Attach it to the provied keyval entry
+    // Attach it to the provided keyval entry
     kv->val = val;
     kv->val_len = val_len;
     kv->val_free = val_free;
@@ -468,7 +468,7 @@ void cluster_multi_add(clusterMultiCmd *mc, char *data, int data_len) {
     redis_cmd_append_sstr(&(mc->args), data, data_len);
 }
 
-/* Finalize a clusterMutliCmd by constructing the whole thing */
+/* Finalize a clusterMultiCmd by constructing the whole thing */
 void cluster_multi_fini(clusterMultiCmd *mc) {
     mc->cmd.len = 0;
     redis_cmd_init_sstr(&(mc->cmd), mc->argc, mc->kw, mc->kw_len);
@@ -709,7 +709,7 @@ static int cluster_map_slots(redisCluster *c, clusterReply *r) {
             master = cluster_node_create(c, host, hlen, port, low, 0);
             zend_hash_str_update_ptr(c->nodes, key, klen, master);
 
-            // Attach slaves first time we encounter a given master in order to avoid regitering the slaves multiple times
+            // Attach slaves first time we encounter a given master in order to avoid registering the slaves multiple times
             for (j = 3; j< r2->elements; j++) {
                 r3 = r2->element[j];
                 if (!VALIDATE_SLOTS_INNER(r3)) {
@@ -1151,7 +1151,7 @@ static int cluster_set_redirection(redisCluster* c, char *msg, int moved)
  * redirection, parsing out slot host and port so the caller can take
  * appropriate action.
  *
- * In the case of a non MOVED/ASK error, we wlll set our cluster error
+ * In the case of a non MOVED/ASK error, we will set our cluster error
  * condition so GetLastError can be queried by the client.
  *
  * This function will return -1 on a critical error (e.g. parse/communication

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -116,7 +116,7 @@
     mc->args.len = 0; \
     mc->argc     = 0; \
 
-/* Initialzie a clusterMultiCmd with a keyword and length */
+/* Initialize a clusterMultiCmd with a keyword and length */
 #define CLUSTER_MULTI_INIT(mc, keyword, keyword_len) \
     mc.kw     = keyword; \
     mc.kw_len = keyword_len; \

--- a/docs/Redis.html
+++ b/docs/Redis.html
@@ -654,7 +654,7 @@ modifies how the command will execute.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_pexpiretime">pexpiretime</a>(string $key)
         
-                                            <p><p>Get the expriation timestamp of a given Redis key but in milliseconds.</p></p>                </div>
+                                            <p><p>Get the expiration timestamp of a given Redis key but in milliseconds.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -714,7 +714,7 @@ modifies how the command will execute.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_geopos">geopos</a>(string $key, string $member, string ...$other_members)
         
-                                            <p><p>Return the longitude and lattitude for one or more members of a geospacially encoded sorted set.</p></p>                </div>
+                                            <p><p>Return the longitude and latitude for one or more members of a geospacially encoded sorted set.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1128,7 +1128,7 @@ a new set.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_incr">incr</a>(string $key, int $by = 1)
         
-                                            <p><p>Increment a key's value, optionally by a specifc amount.</p></p>                </div>
+                                            <p><p>Increment a key's value, optionally by a specific amount.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -1203,7 +1203,7 @@ to that section.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_lLen">lLen</a>(string $key)
         
-                                            <p><p>Retrieve the lenght of a list.</p></p>                </div>
+                                            <p><p>Retrieve the length of a list.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -2180,7 +2180,7 @@ Redis blocking for a long period of time.</p></p>                </div>
                     <a href="#method_wait">wait</a>(int $numreplicas, int $timeout)
         
                                             <p><p>Block the client up to the provided timeout until a certain number of replicas have confirmed
-recieving them.</p></p>                </div>
+receiving them.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -2313,7 +2313,7 @@ acknowledged with XACK.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_xrevrange">xrevrange</a>(string $key, string $end, string $start, int $count = -1)
         
-                                            <p><p>Get a range of entries from a STREAM ke in reverse cronological order.</p></p>                </div>
+                                            <p><p>Get a range of entries from a STREAM key in reverse chronological order.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
                     <div class="row">
@@ -2373,7 +2373,7 @@ acknowledged with XACK.</p></p>                </div>
                 <div class="col-md-8">
                     <a href="#method_zLexCount">zLexCount</a>(string $key, string $min, string $max)
         
-                                            <p><p>Count the number of elements in a sorted set whos members fall within the provided
+                                            <p><p>Count the number of elements in a sorted set whose members fall within the provided
 lexographical range.</p></p>                </div>
                 <div class="col-md-2"></div>
             </div>
@@ -3805,7 +3805,7 @@ to Redis &gt;= 6.0.0 to send a floating point timeout.</p></td>
         <div class="method-description">
                             <p><p>POP the maximum scoring element off of one or more sorted sets, blocking up to a specified
 timeout if no elements are available.</p></p>                <p><p>Following are examples of the two main ways to call this method.</p>
-<p><strong>NOTE</strong>:  We reccomend calling this function with an array and a timeout as the other strategy
+<p><strong>NOTE</strong>:  We recommend calling this function with an array and a timeout as the other strategy
 may be deprecated in future versions of PhpRedis</p></p>        
         </div>
         <div class="tags">
@@ -5850,7 +5850,7 @@ $redis-&gt;expiretime(&#039;mykey&#039;);</pre></td>
             
 
         <div class="method-description">
-                            <p><p>Get the expriation timestamp of a given Redis key but in milliseconds.</p></p>                        
+                            <p><p>Get the expiration timestamp of a given Redis key but in milliseconds.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -6036,7 +6036,7 @@ Redis::expiretime</a>
                     <tr>
                 <td>float</td>
                 <td>$lat</td>
-                <td><p>The lattitude of the first member.</p></td>
+                <td><p>The latitude of the first member.</p></td>
             </tr>
                     <tr>
                 <td>string</td>
@@ -6046,7 +6046,7 @@ Redis::expiretime</a>
                     <tr>
                 <td>mixed</td>
                 <td>...$other_triples_and_options</td>
-                <td><p>You can continue to pass longitude, lattitude, and member
+                <td><p>You can continue to pass longitude, latitude, and member
 arguments to add as many members as you wish.  Optionally, the final argument may be
 a string with options for the command <a href="Redis.html">Redis</a> documentation for the options.</p></td>
             </tr>
@@ -6262,7 +6262,7 @@ if one or both members did not exist.</p></td>
             
 
         <div class="method-description">
-                            <p><p>Return the longitude and lattitude for one or more members of a geospacially encoded sorted set.</p></p>                        
+                            <p><p>Return the longitude and latitude for one or more members of a geospacially encoded sorted set.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -6291,7 +6291,7 @@ if one or both members did not exist.</p></td>
                     <table class="table table-condensed">
         <tr>
             <td>Redis|array|false</td>
-            <td><p>array of longitude and lattitude pairs.</p></td>
+            <td><p>array of longitude and latitude pairs.</p></td>
         </tr>
     </table>
 
@@ -6662,7 +6662,7 @@ See <a href="Redis.html#method_georadius">Redis::georadius</a> for options.</p><
                     <tr>
                 <td>array|string</td>
                 <td>$position</td>
-                <td><p>Either a two element array with longitude and lattitude, or
+                <td><p>Either a two element array with longitude and latitude, or
 a string representing a member of the set.</p></td>
             </tr>
                     <tr>
@@ -6734,7 +6734,7 @@ a new set.</p></p>
                     <tr>
                 <td>array|string</td>
                 <td>$position</td>
-                <td><p>Either a two element array with longitude and lattitude, or
+                <td><p>Either a two element array with longitude and latitude, or
 a string representing a member of the set.</p></td>
             </tr>
                     <tr>
@@ -7452,7 +7452,7 @@ echo $redis-&gt;getRange(&#039;silly-word&#039;, 0, 4) . &quot;\n&quot;;</pre></
                     <tr>
                 <td>array|null</td>
                 <td>$options</td>
-                <td><p>An optional array of modifiers for the comand.</p>
+                <td><p>An optional array of modifiers for the command.</p>
 <pre><code>$options = [
     'MINMATCHLEN'  =&gt; int  # Exclude matching substrings that are less than this value
 
@@ -8755,7 +8755,7 @@ do {<br />
             
 
         <div class="method-description">
-                            <p><p>Increment a key's value, optionally by a specifc amount.</p></p>                        
+                            <p><p>Increment a key's value, optionally by a specific amount.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -9145,7 +9145,7 @@ to that section.</p></p>                <p><p>If connected to Redis server &gt;=
             
 
         <div class="method-description">
-                            <p><p>Retrieve the lenght of a list.</p></p>                        
+                            <p><p>Retrieve the length of a list.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -12781,7 +12781,7 @@ $redis-&gt;sPop(&#039;numbers&#039;);</pre></td>
                 <td><p>An optional count of members to return.</p>
 <p>If this value is positive, Redis will return <em>up to</em> the requested
 number but with unique elements that will never repeat.  This means
-you may recieve fewer then <code>$count</code> replies.</p>
+you may receive fewer then <code>$count</code> replies.</p>
 <p>If the number is negative, Redis will return the exact number requested
 but the result may contain duplicate elements.</p></td>
             </tr>
@@ -14013,7 +14013,7 @@ replica status promoting the instance to a primary.</p></p>
         <tr>
             <td>Redis|bool</td>
             <td><p>Success if we were successfully able to start replicating a primary or
-were able to promote teh replicat to a primary.</p></td>
+were able to promote the replicat to a primary.</p></td>
         </tr>
     </table>
 
@@ -15577,7 +15577,7 @@ var_dump($res);</pre></td>
 
         <div class="method-description">
                             <p><p>Block the client up to the provided timeout until a certain number of replicas have confirmed
-recieving them.</p></p>                        
+receiving them.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -15586,7 +15586,7 @@ recieving them.</p></p>
                     <tr>
                 <td>int</td>
                 <td>$numreplicas</td>
-                <td><p>The number of replicas we want to confirm write operaions</p></td>
+                <td><p>The number of replicas we want to confirm write operations</p></td>
             </tr>
                     <tr>
                 <td>int</td>
@@ -15759,7 +15759,7 @@ var_dump($res);</pre></td>
                 <td><p>The ID for the message we want to add.  This can be the special value '<em>'
 which means Redis will generate the ID that appends the message to the
 end of the stream.  It can also be a value in the form <ms>-</em> which will
-generate an ID that appends to the end ot entries with the same <ms> value
+generate an ID that appends to the end of entries with the same <ms> value
 (if any exist).</p></td>
             </tr>
                     <tr>
@@ -15932,7 +15932,7 @@ $msgs = $redis-&gt;xReadGroup(&#039;combatants&#039;, &quot;Jem&#039;Hadar&quot;
 $pending = $redis-&gt;xPending(&#039;ships&#039;, &#039;combatants&#039;);<br />
 var_dump($pending);<br />
 <br />
-// Asssume control of the pending message with a different consumer.<br />
+// Assume control of the pending message with a different consumer.<br />
 $res = $redis-&gt;xAutoClaim(&#039;ships&#039;, &#039;combatants&#039;, &#039;Sisko&#039;, 0, &#039;0-0&#039;);<br />
 <br />
 // Now the &#039;Sisko&#039; consumer owns the message<br />
@@ -16017,7 +16017,7 @@ $options = [
                     <table class="table table-condensed">
         <tr>
             <td>Redis|array|bool</td>
-            <td><p>An array of claimed messags or false on failure.</p></td>
+            <td><p>An array of claimed messages or false on failure.</p></td>
         </tr>
     </table>
 
@@ -16555,7 +16555,7 @@ acknowledged with XACK.</p></p>
                     <tr>
                 <td>int</td>
                 <td>$count</td>
-                <td><p>An optional limit to how many entries are returnd <em>per stream</em></p></td>
+                <td><p>An optional limit to how many entries are returned <em>per stream</em></p></td>
             </tr>
                     <tr>
                 <td>int</td>
@@ -16718,7 +16718,7 @@ $msgs = $redis-&gt;xReadGroup(&#039;ds9&#039;, &#039;sisko&#039;, [&#039;episode
             
 
         <div class="method-description">
-                            <p><p>Get a range of entries from a STREAM ke in reverse cronological order.</p></p>                        
+                            <p><p>Get a range of entries from a STREAM key in reverse chronological order.</p></p>                        
         </div>
         <div class="tags">
                             <h4>Parameters</h4>
@@ -16997,7 +16997,7 @@ more efficient for Redis given how streams are stored internally.</p></td>
                     <tr>
                 <td>string</td>
                 <td>$key</td>
-                <td><p>The sorted set to retreive cardinality from.</p></td>
+                <td><p>The sorted set to retrieve cardinality from.</p></td>
             </tr>
             </table>
 
@@ -17200,7 +17200,7 @@ more efficient for Redis given how streams are stored internally.</p></td>
             
 
         <div class="method-description">
-                            <p><p>Count the number of elements in a sorted set whos members fall within the provided
+                            <p><p>Count the number of elements in a sorted set whose members fall within the provided
 lexographical range.</p></p>                        
         </div>
         <div class="tags">
@@ -17584,7 +17584,7 @@ controls just the 'WITHSCORES' option.</p>
                     <tr>
                 <td>string</td>
                 <td>$key</td>
-                <td><p>The sorted set to retreive elements from</p></td>
+                <td><p>The sorted set to retrieve elements from</p></td>
             </tr>
                     <tr>
                 <td>string</td>
@@ -18120,7 +18120,7 @@ it will store them in a destination key provided by the user</p></p>
                     <tr>
                 <td>string</td>
                 <td>$key</td>
-                <td><p>The sorted set where we wnat to remove members.</p></td>
+                <td><p>The sorted set where we want to remove members.</p></td>
             </tr>
                     <tr>
                 <td>int</td>
@@ -18191,7 +18191,7 @@ it will store them in a destination key provided by the user</p></p>
                     <tr>
                 <td>string</td>
                 <td>$key</td>
-                <td><p>The sorted set where we wnat to remove members.</p></td>
+                <td><p>The sorted set where we want to remove members.</p></td>
             </tr>
                     <tr>
                 <td>string</td>

--- a/docs/doc-index.html
+++ b/docs/doc-index.html
@@ -317,7 +317,7 @@ Redis::geodist</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a><
 Redis::geohash</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Retrieve one or more GeoHash encoded strings for members of the set.</p></dd><dt><a href="Redis.html#method_geopos">
 Redis::geopos</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Return the longitude and lattitude for one or more members of a geospacially encoded sorted set.</p></dd><dt><a href="Redis.html#method_georadius">
+                    <dd><p>Return the longitude and latitude for one or more members of a geospacially encoded sorted set.</p></dd><dt><a href="Redis.html#method_georadius">
 Redis::georadius</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Retrieve members of a geospacially sorted set that are within a certain radius of a location.</p></dd><dt><a href="Redis.html#method_georadius_ro">
 Redis::georadius_ro</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
@@ -468,7 +468,7 @@ RedisCluster::hvals</a>() &mdash; <em>Method in class <a href="RedisCluster.html
                     <dd></dd>        </dl><h2 id="letterI">I</h2>
         <dl id="indexI"><dt><a href="Redis.html#method_incr">
 Redis::incr</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Increment a key's value, optionally by a specifc amount.</p></dd><dt><a href="Redis.html#method_incrBy">
+                    <dd><p>Increment a key's value, optionally by a specific amount.</p></dd><dt><a href="Redis.html#method_incrBy">
 Redis::incrBy</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Increment a key by a specific integer value</p></dd><dt><a href="Redis.html#method_incrByFloat">
 Redis::incrByFloat</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
@@ -508,7 +508,7 @@ Redis::lcs</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em>
 Redis::lInsert</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd></dd><dt><a href="Redis.html#method_lLen">
 Redis::lLen</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Retrieve the lenght of a list.</p></dd><dt><a href="Redis.html#method_lMove">
+                    <dd><p>Retrieve the length of a list.</p></dd><dt><a href="Redis.html#method_lMove">
 Redis::lMove</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Move an element from one list into another.</p></dd><dt><a href="Redis.html#method_lPop">
 Redis::lPop</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
@@ -601,7 +601,7 @@ RedisCluster::object</a>() &mdash; <em>Method in class <a href="RedisCluster.htm
                     <dd></dd>        </dl><h2 id="letterP">P</h2>
         <dl id="indexP"><dt><a href="Redis.html#method_pexpiretime">
 Redis::pexpiretime</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Get the expriation timestamp of a given Redis key but in milliseconds.</p></dd><dt><a href="Redis.html#method_pconnect">
+                    <dd><p>Get the expiration timestamp of a given Redis key but in milliseconds.</p></dd><dt><a href="Redis.html#method_pconnect">
 Redis::pconnect</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd></dd><dt><a href="Redis.html#method_persist">
 Redis::persist</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
@@ -929,7 +929,7 @@ Redis::watch</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></e
                     <dd><p>Watch one or more keys for conditional execution of a transaction.</p></dd><dt><a href="Redis.html#method_wait">
 Redis::wait</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Block the client up to the provided timeout until a certain number of replicas have confirmed
-recieving them.</p></dd><dt><a href="RedisCluster.html#method_watch">
+receiving them.</p></dd><dt><a href="RedisCluster.html#method_watch">
 RedisCluster::watch</a>() &mdash; <em>Method in class <a href="RedisCluster.html">RedisCluster</a></em></dt>
                     <dd></dd>        </dl><h2 id="letterX">X</h2>
         <dl id="indexX"><dt><a href="Redis.html#method_xack">
@@ -961,7 +961,7 @@ Redis::xread</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></e
 Redis::xreadgroup</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Read one or more messages using a consumer group.</p></dd><dt><a href="Redis.html#method_xrevrange">
 Redis::xrevrange</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Get a range of entries from a STREAM ke in reverse cronological order.</p></dd><dt><a href="Redis.html#method_xtrim">
+                    <dd><p>Get a range of entries from a STREAM key in reverse chronological order.</p></dd><dt><a href="Redis.html#method_xtrim">
 Redis::xtrim</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Truncate a STREAM key in various ways.</p></dd><dt><a href="RedisCluster.html#method_xack">
 RedisCluster::xack</a>() &mdash; <em>Method in class <a href="RedisCluster.html">RedisCluster</a></em></dt>
@@ -1004,7 +1004,7 @@ Redis::zCount</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></
 Redis::zIncrBy</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Create or increment the score of a member in a Redis sorted set</p></dd><dt><a href="Redis.html#method_zLexCount">
 Redis::zLexCount</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
-                    <dd><p>Count the number of elements in a sorted set whos members fall within the provided
+                    <dd><p>Count the number of elements in a sorted set whose members fall within the provided
 lexographical range.</p></dd><dt><a href="Redis.html#method_zMscore">
 Redis::zMscore</a>() &mdash; <em>Method in class <a href="Redis.html">Redis</a></em></dt>
                     <dd><p>Retrieve the score of one or more members in a sorted set.</p></dd><dt><a href="Redis.html#method_zPopMax">

--- a/docs/doctum.js
+++ b/docs/doctum.js
@@ -168,7 +168,7 @@ var Doctum = {
             DoctumSearch.doctumSearchPageAutoCompleteProgressBar.className = 'progress-bar';
         }
     },
-    makeProgess: function () {
+    makeProgress: function () {
         Doctum.makeProgressOnProgressBar(
             Doctum.doctumSearchAutoCompleteProgressBarPercent,
             Doctum.doctumSearchAutoCompleteProgressBar
@@ -209,7 +209,7 @@ var Doctum = {
             oReq.onprogress = function (pe) {
                 if (pe.lengthComputable) {
                     Doctum.doctumSearchAutoCompleteProgressBarPercent = parseInt(pe.loaded / pe.total * 100, 10);
-                    Doctum.makeProgess();
+                    Doctum.makeProgress();
                 }
             };
             oReq.onloadend = function (_) {

--- a/library.c
+++ b/library.c
@@ -159,7 +159,7 @@ static int reselect_db(RedisSock *redis_sock) {
     return 0;
 }
 
-/* Append an AUTH command to a smart string if neccessary.  This will either
+/* Append an AUTH command to a smart string if necessary.  This will either
  * append the new style AUTH <user> <password>, old style AUTH <password>, or
  * append no command at all.  Function returns 1 if we appended a command
  * and 0 otherwise. */
@@ -823,7 +823,7 @@ static zend_string *redis_hash_auth(zend_string *user, zend_string *pass) {
     if (user == NULL && pass == NULL)
         return NULL;
 
-    /* Theoretically inpossible but check anyway */
+    /* Theoretically impossible but check anyway */
     algo = zend_string_init("sha256", sizeof("sha256") - 1, 0);
     if ((ops = redis_hash_fetch_ops(algo)) == NULL) {
         zend_string_release(algo);

--- a/package.xml
+++ b/package.xml
@@ -372,7 +372,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Add cluster support for strict sessions and lazy write [b6cf6361] (Michael Grunder)
     * Add function command [90a0e9cc] (Pavlo Yatsukhnenko)
     * Add FCALL/FCALL_RO commands [7c46ad2c] (Pavlo Yatsukhnenko)
-    * Remove unused macroses [831d6118] (Pavlo Yatsukhnenko)
+    * Remove unused macros [831d6118] (Pavlo Yatsukhnenko)
 
    </notes>
  </release>
@@ -809,7 +809,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     This release contains initial support for Redis Sentinel as well as many
     smaller bug fixes and improvements.  It is especially of interest if you
     use persistent connections, as we've added logic to make sure they are in
-    a good state when retreving them from the pool.
+    a good state when retrieving them from the pool.
 
     IMPORTANT: Sentinel support is considered experimental and the API
                will likely change based on user feedback.
@@ -823,7 +823,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Initial support for RedisSentinel [90cb69f3, c94e28f1, 46da22b0, 5a609fa4,
       383779ed] (Pavlo Yatsukhnenko)
 
-    * Houskeeping (spelling, doc changes, etc) [23f9de30, d07a8df6, 2d39b48d,
+    * Housekeeping (spelling, doc changes, etc) [23f9de30, d07a8df6, 2d39b48d,
       0ef488fc, 2c35e435, f52bd8a8, 2ddc5f21, 1ff7dfb7, db446138] (Tyson Andre,
       Pavlo Yatsukhnenko, Michael Grunder, Tyson Andre)
 
@@ -853,7 +853,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     This release contains initial support for Redis Sentinel as well as many
     smaller bug fixes and improvements.  It is especially of interest if you
     use persistent connections, as we've added logic to make sure they are in
-    a good state when retreving them from the pool.
+    a good state when retrieving them from the pool.
 
     IMPORTANT: Sentinel support is considered experimental and the API
                will likely change based on user feedback.
@@ -867,7 +867,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Initial support for RedisSentinel [90cb69f3, c94e28f1, 46da22b0, 5a609fa4,
       383779ed] (Pavlo Yatsukhnenko)
 
-    * Houskeeping (spelling, doc changes, etc) [23f9de30, d07a8df6, 2d39b48d,
+    * Housekeeping (spelling, doc changes, etc) [23f9de30, d07a8df6, 2d39b48d,
       0ef488fc, 2c35e435, f52bd8a8, 2ddc5f21, 1ff7dfb7, db446138] (Tyson Andre,
       Pavlo Yatsukhnenko, Michael Grunder, Tyson Andre)
 
@@ -984,7 +984,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <notes>
       phpredis 4.3.0
 
-      This is probably the last release with PHP 5 suport!!!
+      This is probably the last release with PHP 5 support!!!
 
       * Proper persistent connections pooling implementation [a3703820, c76e00fb, 0433dc03, c75b3b93] (Pavlo Yatsukhnenko)
       * RedisArray auth [b5549cff, 339cfa2b, 6b411aa8] (Pavlo Yatsukhnenko)
@@ -1036,7 +1036,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
       * Fix incorrect arginfo for `Redis::sRem` and `Redis::multi` [25b043ce] (Pavlo Yatsukhnenko)
       * Update STREAM API to handle STATUS -> BULK reply change [0b97ec37] (Michael Grunder)
       * Treat a -1 response from cluster_check_response as a timeout. [27df9220, 07ef7f4e, d1172426] (Michael Grunder)
-      * Use a ZSET insted of SET for EVAL tests [2e412373] (Michael Grunder)
+      * Use a ZSET instead of SET for EVAL tests [2e412373] (Michael Grunder)
       * Missing space between command and args [0af2a7fe] (@remicollet)
 
       4.2.0RC1:
@@ -1154,7 +1154,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <notes>
     phpredis 3.1.6
 
-    This release conains only fix of RedisArray distributor hashing function
+    This release contains only fix of RedisArray distributor hashing function
     which was broken in 3.1.4. Huge thanks to @rexchen123
    </notes>
    </release>
@@ -1222,8 +1222,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
     phpredis 3.1.3
 
     This release contains two big improvements:
-      1. Adding a new printf like command construction function with additionaly format specifiers specific to phpredis.
-      2. Implementation of custom objects for Redis and RedisArray wich eliminates double hash lookup.
+      1. Adding a new printf like command construction function with additionally format specifiers specific to phpredis.
+      2. Implementation of custom objects for Redis and RedisArray which eliminates double hash lookup.
     Also many small improvements and bug fixes were made.
 
     * A printf like method to construct a Redis RESP command [a4a0ed, d75081, bdd287, 0eaeae, b3d00d] (Michael Grunder)
@@ -1295,7 +1295,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
       wrong size. (@remicollet)
 
     * Added php session unit test (@yatsukhnenko)
-    * Added explicit module dependancy for igbinary (@remicollet)
+    * Added explicit module dependency for igbinary (@remicollet)
     * Added phpinfo serialization information (@remicollet)
    </notes>
    </release>
@@ -1342,7 +1342,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     In addition there have been many bug fixes and improvements to non cluster
     related commands, which are listed below.
 
-    I've attempted to include everyone who contribued to the project in each fix
+    I've attempted to include everyone who contributed to the project in each fix
     description and have included names or github user ids.
 
     Thanks to everyone for submitting bug reports and pull requests.  A special
@@ -1368,7 +1368,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Fixed memory leak in discard function [17b1f427]
     * Sanity check for igbinary unserialization (Maurus Cuelenaere) [3266b222,
       5528297a]
-    * Fix segfault occuring from unclosed socket connection for Redis Cluster
+    * Fix segfault occurring from unclosed socket connection for Redis Cluster
       (CatKang) [04196aee]
     * Case insensitive zRangeByScore options
     * Fixed dreaded size_t vs long long compiler warning

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -705,7 +705,7 @@ class Redis {
      *
      * Following are examples of the two main ways to call this method.
      *
-     * **NOTE**:  We reccomend calling this function with an array and a timeout as the other strategy
+     * **NOTE**:  We recommend calling this function with an array and a timeout as the other strategy
      *            may be deprecated in future versions of PhpRedis
      *
      * @see https://redis.io/commands/bzpopmax
@@ -1160,7 +1160,7 @@ class Redis {
     public function expiretime(string $key): Redis|int|false;
 
     /**
-     * Get the expriation timestamp of a given Redis key but in milliseconds.
+     * Get the expiration timestamp of a given Redis key but in milliseconds.
      *
      * @see https://redis.io/commands/pexpiretime
      * @see Redis::expiretime()
@@ -1245,8 +1245,8 @@ class Redis {
      *
      * @param string $key The sorted set to add data to.
      * @param float  $lng The longitude of the first member
-     * @param float  $lat The lattitude of the first member.
-     * @param member $other_triples_and_options You can continue to pass longitude, lattitude, and member
+     * @param float  $lat The latitude of the first member.
+     * @param member $other_triples_and_options You can continue to pass longitude, latitude, and member
      *               arguments to add as many members as you wish.  Optionally, the final argument may be
      *               a string with options for the command @see Redis documentation for the options.
      *
@@ -1301,13 +1301,13 @@ class Redis {
     public function geohash(string $key, string $member, string ...$other_members): Redis|array|false;
 
     /**
-     * Return the longitude and lattitude for one or more members of a geospacially encoded sorted set.
+     * Return the longitude and latitude for one or more members of a geospacially encoded sorted set.
      *
      * @param string $key           The set to query.
      * @param string $member        The first member to query.
      * @param string $other_members One or more members to query.
      *
-     * @return An array of longitude and lattitude pairs.
+     * @return An array of longitude and latitude pairs.
      *
      * @see https://redis.io/commands/geopos
      *
@@ -1385,7 +1385,7 @@ class Redis {
      * Search a geospacial sorted set for members in various ways.
      *
      * @param string          $key      The set to query.
-     * @param array|string    $position Either a two element array with longitude and lattitude, or
+     * @param array|string    $position Either a two element array with longitude and latitude, or
      *                                  a string representing a member of the set.
      * @param array|int|float $shape    Either a number representine the radius of a circle to search, or
      *                                  a two element array representing the width and height of a box
@@ -1402,7 +1402,7 @@ class Redis {
      *
      * @param string $dst The destination where results will be stored.
      * @param string $src The key to query.
-     * @param array|string    $position Either a two element array with longitude and lattitude, or
+     * @param array|string    $position Either a two element array with longitude and latitude, or
      *                                  a string representing a member of the set.
      * @param array|int|float $shape    Either a number representine the radius of a circle to search, or
      *                                  a two element array representing the width and height of a box
@@ -1569,7 +1569,7 @@ class Redis {
      *
      * @param string $key1    The first key to check
      * @param string $key2    The second key to check
-     * @param array  $options An optional array of modifiers for the comand.
+     * @param array  $options An optional array of modifiers for the command.
      *
      *                        <code>
      *                        $options = [
@@ -1883,7 +1883,7 @@ class Redis {
     public function hscan(string $key, ?int &$iterator, ?string $pattern = null, int $count = 0): Redis|array|bool;
 
     /**
-     * Increment a key's value, optionally by a specifc amount.
+     * Increment a key's value, optionally by a specific amount.
      *
      * @see https://redis.io/commands/incr
      * @see https://redis.io/commands/incrby
@@ -1962,7 +1962,7 @@ class Redis {
     public function lInsert(string $key, string $pos, mixed $pivot, mixed $value);
 
     /**
-     * Retrieve the lenght of a list.
+     * Retrieve the length of a list.
      *
      * @param string $key The list
      *
@@ -2806,7 +2806,7 @@ class Redis {
      *
      *                      If this value is positive, Redis will return *up to* the requested
      *                      number but with unique elements that will never repeat.  This means
-     *                      you may recieve fewer then `$count` replies.
+     *                      you may receive fewer then `$count` replies.
      *
      *                      If the number is negative, Redis will return the exact number requested
      *                      but the result may contain duplicate elements.
@@ -3130,7 +3130,7 @@ class Redis {
      * @param string $port The port of the primary to start replicating.
      *
      * @return Redis|bool Success if we were successfully able to start replicating a primary or
-     *                    were able to promote teh replicat to a primary.
+     *                    were able to promote the replicat to a primary.
      *
      * @example
      * $redis = new Redis(['host' => 'localhost']);
@@ -3585,11 +3585,11 @@ class Redis {
 
     /**
      * Block the client up to the provided timeout until a certain number of replicas have confirmed
-     * recieving them.
+     * receiving them.
      *
      * @see https://redis.io/commands/wait
      *
-     * @param int $numreplicas The number of replicas we want to confirm write operaions
+     * @param int $numreplicas The number of replicas we want to confirm write operations
      * @param int $timeout     How long to wait (zero meaning forever).
      *
      * @return Redis|int|false The number of replicas that have confirmed or false on failure.
@@ -3645,7 +3645,7 @@ class Redis {
      * @param string $id         The ID for the message we want to add.  This can be the special value '*'
      *                           which means Redis will generate the ID that appends the message to the
      *                           end of the stream.  It can also be a value in the form <ms>-* which will
-     *                           generate an ID that appends to the end ot entries with the same <ms> value
+     *                           generate an ID that appends to the end of entries with the same <ms> value
      *                           (if any exist).
      * @param int    $maxlen     If specified Redis will append the new message but trim any number of the
      *                           oldest messages in the stream until the length is <= $maxlen.
@@ -3691,7 +3691,7 @@ class Redis {
      * $pending = $redis->xPending('ships', 'combatants');
      * var_dump($pending);
      *
-     * // Asssume control of the pending message with a different consumer.
+     * // Assume control of the pending message with a different consumer.
      * $res = $redis->xAutoClaim('ships', 'combatants', 'Sisko', 0, '0-0');
      *
      * // Now the 'Sisko' consumer owns the message
@@ -3731,7 +3731,7 @@ class Redis {
      *                               ];
      *                               </code>
      *
-     * @return Redis|array|bool      An array of claimed messags or false on failure.
+     * @return Redis|array|bool      An array of claimed messages or false on failure.
      *
      * @example
      * $redis->xGroup('CREATE', 'ships', 'combatants', '0-0', true);
@@ -3880,7 +3880,7 @@ class Redis {
      * Consume one or more unconsumed elements in one or more streams.
      *
      * @param array $streams An associative array with stream name keys and minimum id values.
-     * @param int   $count   An optional limit to how many entries are returnd *per stream*
+     * @param int   $count   An optional limit to how many entries are returned *per stream*
      * @param int   $block   An optional maximum number of milliseconds to block the caller if no
      *                       data is available on any of the provided streams.
      *
@@ -3936,7 +3936,7 @@ class Redis {
     public function xreadgroup(string $group, string $consumer, array $streams, int $count = 1, int $block = 1): Redis|array|bool;
 
     /**
-     * Get a range of entries from a STREAM ke in reverse cronological order.
+     * Get a range of entries from a STREAM key in reverse chronological order.
      *
      * @param string $key   The stream key to query.
      * @param string $end   The maximum message ID to include.
@@ -4019,7 +4019,7 @@ class Redis {
     /**
      * Return the number of elements in a sorted set.
      *
-     * @param string $key The sorted set to retreive cardinality from.
+     * @param string $key The sorted set to retrieve cardinality from.
      *
      * @return Redis|int|false The number of elements in the set or false on failure
      *
@@ -4063,7 +4063,7 @@ class Redis {
     public function zIncrBy(string $key, float $value, mixed $member): Redis|float|false;
 
     /**
-     * Count the number of elements in a sorted set whos members fall within the provided
+     * Count the number of elements in a sorted set whose members fall within the provided
      * lexographical range.
      *
      * @param string $key The sorted set to check.
@@ -4173,7 +4173,7 @@ class Redis {
     /**
      * Retrieve a range of elements from a sorted set by legographical range.
      *
-     * @param string $key    The sorted set to retreive elements from
+     * @param string $key    The sorted set to retrieve elements from
      * @param string $min    The minimum legographical value to return
      * @param string $max    The maximum legographical value to return
      * @param int    $offset An optional offset within the matching values to return
@@ -4256,7 +4256,7 @@ class Redis {
      * Get the rank of a member of a sorted set, by score.
      *
      * @param string $key     The sorted set to check.
-     * @param mixed  $memeber The member to test.
+     * @param mixed  $member The member to test.
      *
      * @return Redis|int|false The rank of the requested member.
      * @see https://redis.io/commands/zrank
@@ -4301,7 +4301,7 @@ class Redis {
     /**
      * Remove one or more members of a sorted set by their rank.
      *
-     * @param string $key    The sorted set where we wnat to remove members.
+     * @param string $key    The sorted set where we want to remove members.
      * @param int    $start  The rank when we want to start removing members
      * @param int    $end    The rank we want to stop removing membersk.
      *
@@ -4316,7 +4316,7 @@ class Redis {
     /**
      * Remove one or more members of a sorted set by their score.
      *
-     * @param string $key    The sorted set where we wnat to remove members.
+     * @param string $key    The sorted set where we want to remove members.
      * @param int    $start  The lowest score to remove.
      * @param int    $end    The highest score to remove.
      *

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1358,7 +1358,7 @@ PHP_METHOD(RedisCluster, zmpop) {
 }
 /* }}} */
 
-/* {{{ proto Redis|array|false Redis::bzmpop(double $timeout, array $keys, sring $from, int $count = 1) */
+/* {{{ proto Redis|array|false Redis::bzmpop(double $timeout, array $keys, string $from, int $count = 1) */
 PHP_METHOD(RedisCluster, bzmpop) {
     CLUSTER_PROCESS_KW_CMD("BZMPOP", redis_mpop_cmd, cluster_mpop_resp, 0);
 }
@@ -2394,7 +2394,7 @@ PHP_METHOD(RedisCluster, acl) {
 
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc - 1, "ACL");
 
-    /* Read the op, determin if it's readonly, and add it */
+    /* Read the op, determine if it's readonly, and add it */
     zs = zval_get_string(&zargs[1]);
     readonly = redis_acl_op_readonly(zs);
     redis_cmd_append_sstr_zstr(&cmdstr, zs);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1495,7 +1495,7 @@ int redis_pubsub_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     ) {
         if (arg != NULL) {
             if (Z_TYPE_P(arg) != IS_STRING) {
-                php_error_docref(NULL, E_WARNING, "Invalid patern value");
+                php_error_docref(NULL, E_WARNING, "Invalid pattern value");
                 return FAILURE;
             }
             pattern = zval_get_string(arg);

--- a/redis_session.c
+++ b/redis_session.c
@@ -126,7 +126,7 @@ redis_pool_free(redis_pool *pool) {
     efree(pool);
 }
 
-/* Retreive session.gc_maxlifetime from php.ini protecting against an integer overflow */
+/* Retrieve session.gc_maxlifetime from php.ini protecting against an integer overflow */
 static int session_gc_maxlifetime(void) {
     zend_long value = INI_INT("session.gc_maxlifetime");
     if (value > INT_MAX) {

--- a/tests/RedisArrayTest.php
+++ b/tests/RedisArrayTest.php
@@ -558,7 +558,7 @@ class Redis_Multi_Exec_Test extends TestSuite {
         $this->assertEquals(0, $this->ra->exists('1_{employee:joe}_salary'));
     }
 
-    public function testMutliExecUnlink() {
+    public function testMultiExecUnlink() {
         if (version_compare($this->min_version, "4.0.0", "lt")) {
             $this->markTestSkipped();
         }

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -436,7 +436,7 @@ class Redis_Cluster_Test extends Redis_Test {
         // Flush any loaded scripts
         $this->redis->script($str_key, 'flush');
 
-        // Non existant script (but proper sha1), and a random (not) sha1 string
+        // Non existent script (but proper sha1), and a random (not) sha1 string
         $this->assertFalse($this->redis->evalsha(sha1(uniqid()),[$str_key], 1));
         $this->assertFalse($this->redis->evalsha('some-random-data'),[$str_key], 1);
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2400,7 +2400,7 @@ class Redis_Test extends TestSuite
     }
 
     public function testWait() {
-        // Closest we can check based on redis commmit history
+        // Closest we can check based on redis commit history
         if(version_compare($this->version, '2.9.11') < 0) {
             $this->markTestSkipped();
             return;
@@ -2793,7 +2793,7 @@ class Redis_Test extends TestSuite
         $this->assertTrue($this->redis->zScore('{zset}U', 'duplicate')===1.0);
         $this->redis->del('{zset}U');
 
-        //now test zUnion *without* weights but with aggregrate function
+        //now test zUnion *without* weights but with aggregate function
         $this->redis->zUnionStore('{zset}U', ['{zset}1','{zset}2'], null, 'MIN');
         $this->assertTrue($this->redis->zScore('{zset}U', 'duplicate')===1.0);
         $this->redis->del('{zset}U', '{zset}1', '{zset}2');
@@ -3481,7 +3481,7 @@ return;
         $this->assertEquals(5, count($ret)); // should be 5 atomic operations
     }
 
-    /* Github issue #1211 (ignore redundant calls to pipeline or multi) */
+    /* GitHub issue #1211 (ignore redundant calls to pipeline or multi) */
     public function testDoublePipeNoOp() {
         /* Only the first pipeline should be honored */
         for ($i = 0; $i < 6; $i++) {
@@ -5569,7 +5569,7 @@ return;
         // Flush any loaded scripts
         $this->redis->script('flush');
 
-        // Non existant script (but proper sha1), and a random (not) sha1 string
+        // Non existent script (but proper sha1), and a random (not) sha1 string
         $this->assertFalse($this->redis->evalsha(sha1(uniqid())));
         $this->assertFalse($this->redis->evalsha('some-random-data'));
 
@@ -6813,7 +6813,7 @@ return;
             ['{stream}-1' => [$new_id => ['final' => 'row']]]
         );
 
-        /* Emtpy query should fail */
+        /* Empty query should fail */
         $this->assertFalse($this->redis->xRead([]));
     }
 
@@ -7105,7 +7105,7 @@ return;
         $pending = $this->redis->xPending('ships', 'combatants');
         $this->assertTrue($pending && isset($pending[3][0][0]) && $pending[3][0][0] == "Jem'Hadar");
 
-        // Asssume control of the pending message with a different consumer.
+        // Assume control of the pending message with a different consumer.
         $res = $this->redis->xAutoClaim('ships', 'combatants', 'Sisko', 0, '0-0');
 
         $this->assertTrue($res && count($res) == 3 && $res[0] == '0-0' &&


### PR DESCRIPTION
Found few misspellings using `typos`.

💡 `docs/doctum-search.json` is excluded.