### PR TITLE
Update WAITAOF test to use different assertion + add debug info

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -7678,10 +7678,16 @@ return;
     }
 
     public function testWaitAOF() {
+        if (!$this->minVersionCheck("7.2.0"))
+            $this->markTestSkipped();
+
         $res = $this->execWaitAOF();
-        $this->assertTrue(is_array($res) && count($res) == 2 &&
-                          isset($res[0]) && is_int($res[0]) &&
-                          isset($res[1]) && is_int($res[1]));
+        $this->assertValidate($res, function ($v) {
+            if ( ! is_array($v) || count($v) != 2)
+                return false;
+            return isset($v[0]) && is_int($v[0]) &&
+                   isset($v[1]) && is_int($v[1]);
+        });
     }
 
     /* Make sure we handle a bad option value gracefully */

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -140,8 +140,8 @@ class TestSuite
             return true;
 
         $bt = debug_backtrace(false);
-        self::$errors []= sprintf("Assertion failed: %s:%d (%s)\n",
-            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"]);
+        self::$errors []= sprintf("Assertion failed: %s:%d (%s)\n--- VALUE ---\n%s\n",
+            $bt[0]["file"], $bt[0]["line"], $bt[1]["function"], print_r($val, true));
 
         return false;
     }


### PR DESCRIPTION
* Add what value failed to pass our callback assertion so we can see what we actually got from the server.

* WAITAOF requires Redis >= 7.2.0 so don't run it if the server is older than that.