### PR TITLE
Fix random connection timeouts with Redis Cluster

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -833,7 +833,7 @@ PHP_REDIS_API redisCluster *cluster_create(double timeout, double read_timeout,
     c->err = NULL;
 
     /* Set up our waitms based on timeout */
-    c->waitms  = (long)(1000 * timeout);
+    c->waitms  = (long)(1000 * (timeout + read_timeout));
 
     /* Allocate our seeds hash table */
     ALLOC_HASHTABLE(c->seeds);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -139,7 +139,7 @@ static void redis_cluster_init(redisCluster *c, HashTable *ht_seeds, double time
     c->flags->timeout = timeout;
     c->flags->read_timeout = read_timeout;
     c->flags->persistent = persistent;
-    c->waitms = timeout * 1000L;
+    c->waitms = (long)(1000 * (timeout + read_timeout));
 
     /* Attempt to load slots from cache if caching is enabled */
     if (CLUSTER_CACHING_ENABLED()) {


### PR DESCRIPTION
When a node timeout occurs, then phpredis will try to connect to another node, whose answer probably will be MOVED redirect. After this we need more time to accomplish the redirection, otherwise we get "Timed out attempting to find data in the correct node" error message immediately in the first cycle.

Especially under Kubernetes with StatefulSet installation, where IP addresses could change over time, or after redeployment. Old IPs will be unaccessible, but the call will survive with this fix, and does not cause timeout errors.

fixes #795, fixes #888, fixes #1142, fixes #1385, fixes #1633, fixes #1707, fixes #1811, fixes #2407