### PR TITLE
Update random includes.

### DIFF
--- a/backoff.c
+++ b/backoff.c
@@ -1,14 +1,14 @@
 #include "common.h"
 
+#if PHP_VERSION_ID < 80400
 #include <ext/standard/php_rand.h>
-
-#if PHP_VERSION_ID >= 70100
-#include <ext/standard/php_mt_rand.h>
 #else
+#include <ext/random/php_random.h>
+#endif
+
+#if PHP_VERSION_ID < 70100
 static zend_long php_mt_rand_range(zend_long min, zend_long max) {
-    zend_long number = php_rand();
-    RAND_RANGE(number, min, max, PHP_RAND_MAX);
-    return number;
+	return min + php_rand() % (max - min + 1)
 }
 #endif
 

--- a/library.c
+++ b/library.c
@@ -56,8 +56,13 @@
 #include <ext/json/php_json.h>
 #endif
 
-#include <ext/standard/php_rand.h>
 #include <ext/hash/php_hash.h>
+
+#if PHP_VERSION_ID < 80400
+#include <ext/standard/php_rand.h>
+#else
+#include <ext/random/php_random.h>
+#endif
 
 #define UNSERIALIZE_NONE 0
 #define UNSERIALIZE_KEYS 1

--- a/redis.c
+++ b/redis.c
@@ -27,12 +27,16 @@
 #include "redis_cluster.h"
 #include "redis_commands.h"
 #include "redis_sentinel.h"
-#include <standard/php_random.h>
 #include <ext/spl/spl_exceptions.h>
 #include <zend_exceptions.h>
 #include <ext/standard/info.h>
 #include <ext/hash/php_hash.h>
 
+#if PHP_VERSION_ID < 80400
+#include <ext/standard/php_random.h>
+#else
+#include <ext/random/php_random.h>
+#endif
 
 #ifdef PHP_SESSION
 #include <ext/session/php_session.h>


### PR DESCRIPTION
PHP 8.4 has some breaking changes with respect to where PHP's random methods and helpers are.  This commit fixes those issues while staying backward compatible.

Fixes #2463