### PR TITLE
Remove mention of pickle as an installation option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,9 @@
-# Installation from pecl/pickle
+# Installation from pecl
 
-To pull latest stable released version, from [pecl](https://pecl.php.net/package/redis) / [pickle](https://wiki.php.net/rfc/deprecate-pear-include-composer):
+To pull latest stable released version, from [pecl](https://pecl.php.net/package/redis)
 
 ~~~
 pecl install redis
-
-// If using PHP >= 7.3
-pickle install redis
 ~~~
 
 # Installation from sources


### PR DESCRIPTION
Pickle support was originally added in https://github.com/phpredis/phpredis/pull/1991 when it looked like Pickle was going to be adopted. However it looks like efforts on that front have stalled (see https://github.com/FriendsOfPHP/pickle/issues/265 for discussion between two of the latest commiters to pickle - https://github.com/FriendsOfPHP/pickle/graphs/contributors).

I hadn't heard of pickle before, so just spent some time sorting out the latest history on it because I saw it mentioned here. Thought it'd be worth saving others the time I lost doing so 😉 