### PR TITLE
Fix segfault and remove redundant macros

### DIFF
--- a/common.h
+++ b/common.h
@@ -186,12 +186,6 @@ typedef enum {
     } \
 } while (0)
 
-#define SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len) \
-    if(redis_sock_write(redis_sock, cmd, cmd_len) < 0) { \
-    efree(cmd); \
-    RETURN_FALSE; \
-}
-
 #define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
     fold_item *fi = malloc(sizeof(fold_item)); \
     fi->fun = callback; \
@@ -209,8 +203,9 @@ typedef enum {
 #define REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len) \
     if (IS_PIPELINE(redis_sock)) { \
         PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len); \
-    } else { \
-        SOCKET_WRITE_COMMAND(redis_sock, cmd, cmd_len); \
+    } else if (redis_sock_write(redis_sock, cmd, cmd_len) < 0) { \
+        efree(cmd); \
+        RETURN_FALSE; \
     } \
     efree(cmd);
 

--- a/redis.c
+++ b/redis.c
@@ -1899,7 +1899,9 @@ PHP_METHOD(Redis, multi)
                 REDIS_SAVE_CALLBACK(NULL, NULL);
                 REDIS_ENABLE_MODE(redis_sock, MULTI);
             } else {
-                SOCKET_WRITE_COMMAND(redis_sock, RESP_MULTI_CMD, sizeof(RESP_MULTI_CMD) - 1)
+                if (redis_sock_write(redis_sock, ZEND_STRL(RESP_MULTI_CMD)) < 0) {
+                    RETURN_FALSE;
+                }
                 if ((resp = redis_sock_read(redis_sock, &resp_len)) == NULL) {
                     RETURN_FALSE;
                 } else if (strncmp(resp, "+OK", 3) != 0) {
@@ -1995,8 +1997,9 @@ PHP_METHOD(Redis, exec)
             REDIS_DISABLE_MODE(redis_sock, MULTI);
             RETURN_ZVAL(getThis(), 1, 0);
         }
-        SOCKET_WRITE_COMMAND(redis_sock, RESP_EXEC_CMD, sizeof(RESP_EXEC_CMD) - 1)
-
+        if (redis_sock_write(redis_sock, ZEND_STRL(RESP_EXEC_CMD)) < 0) {
+            RETURN_FALSE;
+        }
         ret = redis_sock_read_multibulk_multi_reply(
             INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &z_ret);
         free_reply_callbacks(redis_sock);


### PR DESCRIPTION
Replace `SOCKET_WRITE_COMMAND` with `redis_sock_write` because it can't be used with pre-defined commands (it frees memory in case of failed writing operation). After replacement `SOCKET_WRITE_COMMAND` becomes redundant so remove it.