### PR TITLE
KeyDB:  Get our tests passing against KeyDB.

### DIFF
--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -94,6 +94,7 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->redis = $this->newInstance();
         $info = $this->redis->info(uniqid());
         $this->version = (isset($info['redis_version'])?$info['redis_version']:'0.0.0');
+        $this->is_keydb = $this->redis->info('keydb') !== false;
     }
 
     /* Override newInstance as we want a RedisCluster object */

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -15,6 +15,7 @@ class TestSuite
 
     /* Redis server version */
     protected $version;
+    protected $is_keydb;
 
     private static $_boo_colorize = false;
 

--- a/tests/make-cluster.sh
+++ b/tests/make-cluster.sh
@@ -13,6 +13,8 @@ BASEDIR=`pwd`
 NODEDIR=$BASEDIR/nodes
 MAPFILE=$NODEDIR/nodemap
 
+REDIS_BINARY=${REDIS_BINARY:-redis-server}
+
 # Host, nodes, replicas, ports, etc.  Change if you want different values
 HOST="127.0.0.1"
 NOASK=0
@@ -43,7 +45,7 @@ spawnNode() {
     fi
 
     # Attempt to spawn the node
-    verboseRun redis-server --cluster-enabled yes --dir $NODEDIR --port $PORT \
+    verboseRun "$REDIS_BINARY" --cluster-enabled yes --dir $NODEDIR --port $PORT \
         --cluster-config-file node-$PORT.conf --daemonize yes --save \'\' \
         --bind $HOST --dbfilename node-$PORT.rdb $ACLARG
 
@@ -167,8 +169,7 @@ printUsage() {
     exit 0
 }
 
-# We need redis-server
-checkExe redis-server
+checkExe "$REDIS_BINARY"
 
 while getopts "u:p:a:hy" OPT; do
     case $OPT in


### PR DESCRIPTION
This commit fixes our unit tests so they also pass against the KeyDB server.  We didn't ned to change all that much.  Most of it was just adding a version/keydb check.

The only change to PhpRedis itself was to relax the reply requirements for XAUTOCLAIM.  Redis 7.0.0 added a third "these elements were recently removed" reply which KeyDB does not have.

Fixes #2466