### PR TITLE
Add compression support for PHP Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ redis.session.lock_wait_time = 50000
 redis.session.lock_retries = 2000
 ~~~
 
+### Session compression
+
+Following INI variables can be used to configure session compression:
+~~~
+; Should session compression be enabled? Possible values are zstd, lzf, lz4, none. Defaults to: none
+redis.session.compression = zstd
+; What compression level should be used? Compression level depends on used library. For most deployments range 1-9 should be fine. Defaults to: 3
+redis.session.compression_level = 3
+~~~
+
 ## Running the unit tests
 
 phpredis uses a small custom unit test suite for testing functionality of the various classes.  To run tests, simply do the following:

--- a/cluster.md
+++ b/cluster.md
@@ -206,3 +206,13 @@ To enable, set the following INI variable:
 redis.session.early_refresh = 1
 ```
 Note: This is disabled by default since it may significantly reduce the session lifetime for long-running scripts. Redis server version 6.2+ required.
+
+### Session compression
+
+Following INI variables can be used to configure session compression:
+~~~
+; Should session compression be enabled? Possible values are zstd, lzf, lz4, none. Defaults to: none
+redis.session.compression = zstd
+; What compression level should be used? Compression level depends on used library. For most deployments range 1-9 should be fine. Defaults to: 3
+redis.session.compression_level = 3
+~~~

--- a/redis.c
+++ b/redis.c
@@ -115,6 +115,8 @@ PHP_INI_BEGIN()
     PHP_INI_ENTRY("redis.session.lock_retries", "100", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.lock_wait_time", "20000", PHP_INI_ALL, NULL)
     PHP_INI_ENTRY("redis.session.early_refresh", "0", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.compression", "none", PHP_INI_ALL, NULL)
+    PHP_INI_ENTRY("redis.session.compression_level", "3", PHP_INI_ALL, NULL)
 PHP_INI_END()
 
 static const zend_module_dep redis_deps[] = {

--- a/redis_session.c
+++ b/redis_session.c
@@ -143,21 +143,21 @@ static int session_gc_maxlifetime(void) {
 /* Retrieve redis.session.compression from php.ini */
 static int session_compression_type(void) {
 #ifdef HAVE_REDIS_LZF
-    if(strncasecmp(INI_STR("redis.session.compression"), ZEND_STRL("lzf")) == 0) {
+    if(strncasecmp(INI_STR("redis.session.compression"), "lzf", sizeof("lzf") - 1) == 0) {
         return REDIS_COMPRESSION_LZF;
     }
 #endif
 #ifdef HAVE_REDIS_ZSTD
-    if(strncasecmp(INI_STR("redis.session.compression"), ZEND_STRL("zstd")) == 0) {
+    if(strncasecmp(INI_STR("redis.session.compression"), "zstd", sizeof("zstd") - 1) == 0) {
         return REDIS_COMPRESSION_ZSTD;
     }
 #endif
 #ifdef HAVE_REDIS_LZ4
-    if(strncasecmp(INI_STR("redis.session.compression"), ZEND_STRL("lz4")) == 0) {
+    if(strncasecmp(INI_STR("redis.session.compression"), "lz4", sizeof("lz4") - 1) == 0) {
         return REDIS_COMPRESSION_LZ4;
     }
 #endif
-    if(strncasecmp(INI_STR("redis.session.compression"), ZEND_STRL("none")) == 0) {
+    if(strncasecmp(INI_STR("redis.session.compression"), "none", sizeof("none") - 1) == 0) {
         return REDIS_COMPRESSION_NONE;
     }
 
@@ -168,24 +168,35 @@ static int session_compression_type(void) {
 }
 
 /* Helper to compress session data */
-static int session_compress_data(RedisSock *redis_sock, char *data, size_t len,
-                                 char **compressed_data, size_t *compressed_len) {
+static int
+session_compress_data(RedisSock *redis_sock, char *data, size_t len,
+                      char **compressed_data, size_t *compressed_len)
+{
     if (redis_sock->compression) {
         if(redis_compress(redis_sock, compressed_data, compressed_len, data, len)) {
             return 1;
         }
     }
+
+    *compressed_data = data;
+    *compressed_len = len;
+
     return 0;
 }
 
 /* Helper to uncompress session data */
-static int session_uncompress_data(RedisSock *redis_sock, char *data, size_t len,
+static int 
+session_uncompress_data(RedisSock *redis_sock, char *data, size_t len,
                                    char **decompressed_data, size_t *decompressed_len) {
     if (redis_sock->compression) {
         if(redis_uncompress(redis_sock, decompressed_data, decompressed_len, data, len)) {
             return 1;
         }
     }
+
+    *decompressed_data = data;
+    *decompressed_len = len;
+
     return 0;
 }
 
@@ -738,7 +749,7 @@ PS_UPDATE_TIMESTAMP_FUNC(redis)
 PS_READ_FUNC(redis)
 {
     char *resp, *cmd, *compressed_buf;
-    int resp_len, cmd_len;
+    int resp_len, cmd_len, compressed_free;
     const char *skey = ZSTR_VAL(key);
     size_t skeylen = ZSTR_LEN(key), compressed_len;
 
@@ -789,11 +800,10 @@ PS_READ_FUNC(redis)
     if (resp_len < 0) {
         *val = ZSTR_EMPTY_ALLOC();
     } else {
-        if (session_uncompress_data(redis_sock, resp, resp_len, &compressed_buf, &compressed_len)) { // Try uncompress
-            *val = zend_string_init(compressed_buf, compressed_len, 0);
+        compressed_free = session_uncompress_data(redis_sock, resp, resp_len, &compressed_buf, &compressed_len);
+        *val = zend_string_init(compressed_buf, compressed_len, 0);
+        if (compressed_free) {
             efree(compressed_buf); // Free the buffer allocated by redis_uncompress
-        } else { // Return raw data
-            *val = zend_string_init(resp, resp_len, 0);
         }
     }
 
@@ -826,10 +836,8 @@ PS_WRITE_FUNC(redis)
     zend_string *session = redis_session_key(redis_sock, skey, skeylen);
 
     compressed_free = session_compress_data(redis_sock, ZSTR_VAL(val), ZSTR_LEN(val), &compressed_buf, &compressed_len);
-    if(compressed_free) {
-        sval = compressed_buf;
-        svallen = compressed_len;
-    }
+    sval = compressed_buf;
+    svallen = compressed_len;
     
     cmd_len = REDIS_SPPRINTF(&cmd, "SETEX", "Sds", session, session_gc_maxlifetime(), sval, svallen);
     zend_string_release(session);
@@ -1213,7 +1221,7 @@ PS_READ_FUNC(rediscluster) {
     redisCluster *c = PS_GET_MOD_DATA();
     clusterReply *reply;
     char *cmd, *skey, *compressed_buf;
-    int cmdlen, skeylen, free_flag;
+    int cmdlen, skeylen, free_flag, compressed_free;
     size_t compressed_len;
     short slot;
 
@@ -1252,12 +1260,10 @@ PS_READ_FUNC(rediscluster) {
     if (reply->str == NULL) {
         *val = ZSTR_EMPTY_ALLOC();
     } else {
-        *val = zend_string_init(reply->str, reply->len, 0);
-        if (session_uncompress_data(c->flags, reply->str, reply->len, &compressed_buf, &compressed_len)) { // Try uncompress
-            *val = zend_string_init(compressed_buf, compressed_len, 0);
+        compressed_free = session_uncompress_data(c->flags, reply->str, reply->len, &compressed_buf, &compressed_len);
+        *val = zend_string_init(compressed_buf, compressed_len, 0);
+        if (compressed_free) {
             efree(compressed_buf); // Free the buffer allocated by redis_uncompress
-        } else { // Return raw data
-            *val = zend_string_init(reply->str, reply->len, 0);
         }
     }
 
@@ -1281,10 +1287,8 @@ PS_WRITE_FUNC(rediscluster) {
     size_t compressed_len = 0;
 
     compressed_free = session_compress_data(c->flags, sval, svallen, &compressed_buf, &compressed_len);
-    if(compressed_free) {
-        sval = compressed_buf;
-        svallen = compressed_len;
-    }
+    sval = compressed_buf;
+    svallen = compressed_len;
 
     /* Set up command and slot info */
     skey = cluster_session_key(c, ZSTR_VAL(key), ZSTR_LEN(key), &skeylen, &slot);


### PR DESCRIPTION
Previously, compression was available for standard data but not for session handling. This update enables the compression of PHP sessions, allowing for more efficient Redis memory usage.