### PR TITLE
Mention Valkey support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/13205/badge.svg)](https://scan.coverity.com/projects/phpredis-phpredis)
 [![PHP version](https://img.shields.io/badge/php-%3E%3D%207.0-8892BF.svg)](https://github.com/phpredis/phpredis)
 
-The phpredis extension provides an API for communicating with the [Redis](http://redis.io/) key-value store. It also supports [KeyDB](https://docs.keydb.dev/), an open source alternative to Redis.
+The phpredis extension provides an API for communicating with the [Redis](http://redis.io/) key-value store. It also supports [KeyDB](https://docs.keydb.dev/) and [Valkey](https://valkey.io/), which are open source alternatives to Redis.
 
 It is released under the [PHP License, version 3.01](http://www.php.net/license/3_01.txt).
 


### PR DESCRIPTION
This pull request adds a mention of Valkey support in README.md as said in [this comment](https://github.com/phpredis/phpredis/pull/2476#pullrequestreview-1984870372), and just like one for KeyDB was added in #2470.