### PR TITLE
Refactor session tests

### DIFF
--- a/tests/SessionHelpers.php
+++ b/tests/SessionHelpers.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace SessionHelpers;
+
+class PhpSpawner {
+    protected static function append_php_args(string $php): string {
+        $modules   = shell_exec("$php --no-php-ini -m");
+
+        /* Determine if we need to specifically add extensions */
+        $extensions = array_filter(
+            ['igbinary', 'msgpack', 'json', 'redis'],
+            function ($module) use ($modules) {
+                return strpos($modules, $module) === false;
+            }
+        );
+
+        /* If any are needed add them to the command */
+        if ($extensions) {
+            $php .= ' --no-php-ini';
+            foreach ($extensions as $extension) {
+                /* We want to use the locally built redis extension */
+                if ($extension == 'redis') {
+                    $path = dirname(__DIR__) . '/modules/redis';
+                    if (is_file("{$path}.so"))
+                        $extension = $path;
+                }
+
+                $php .= " -dextension=$extension.so";
+            }
+        }
+
+        return $php;
+    }
+
+    /**
+     * Return command to launch PHP with built extension enabled
+     * taking care of environment (TEST_PHP_EXECUTABLE and TEST_PHP_ARGS)
+     *
+     * @param string $script
+     *
+     * @return string
+     */
+    public static function cmd(string $script): string {
+        static $cmd = NULL;
+
+        if ( ! $cmd) {
+            $cmd = getenv('TEST_PHP_EXECUTABLE') ?: PHP_BINARY;
+
+            if ($test_args = getenv('TEST_PHP_ARGS')) {
+                $cmd .= ' ' . $test_args;
+            } else {
+                $cmd = self::append_php_args($cmd);
+            }
+        }
+
+        return $cmd . ' ' . __DIR__ . '/' . $script . ' ';
+    }
+}
+
+class Runner {
+    const start_script = 'startSession.php';
+    const regenerate_id_script = 'regenerateSessionId.php';
+    const get_data_script = 'getSessionData.php';
+
+    private $required = ['host', 'handler', 'id'];
+
+    private $args = [
+        'handler' => null,
+        'save-path' => null,
+        'id' => null,
+        'sleep' => 0,
+        'max-execution-time' => 300,
+        'locking-enabled' => true,
+        'lock-wait-time' => null,
+        'lock-retries' => -1,
+        'lock-expires' => 0,
+        'data' => '',
+        'lifetime' => 1440,
+        'compression' => 'none',
+    ];
+
+    private $prefix = NULL;
+    private $output_file;
+    private $exit_code = -1;
+    private $cmd = NULL;
+    private $pid;
+    private $output;
+
+    public function __construct() {
+        $this->args['id'] = $this->generate_id();
+    }
+
+    public function get_exit_code(): int {
+        return $this->exit_code;
+    }
+
+    public function get_cmd(): ?string {
+        return $this->cmd;
+    }
+
+    public function get_id(): ?string {
+        return $this->args['id'];
+    }
+
+    public function prefix(string $prefix): self {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    public function get_session_key(): string {
+        return $this->prefix . $this->get_id();
+    }
+
+    public function get_session_lock_key(): string {
+        return $this->get_session_key() . '_LOCK';
+    }
+
+    protected function set($setting, $v): self {
+        $this->args[$setting] = $v;
+        return $this;
+    }
+
+    public function handler(string $handler): self {
+        return $this->set('handler', $handler);
+    }
+
+    public function save_path(string $path): self {
+        return $this->set('save-path', $path);
+    }
+
+    public function id(string $id): self {
+        return $this->set('id', $id);
+    }
+
+    public function sleep(int $sleep): self {
+        return $this->set('sleep', $sleep);
+    }
+
+    public function max_execution_time(int $time): self {
+        return $this->set('max-execution-time', $time);
+    }
+
+    public function locking_enabled(bool $enabled): self {
+        return $this->set('locking-enabled', $enabled);
+    }
+
+    public function lock_wait_time(int $time): self {
+        return $this->set('lock-wait-time', $time);
+    }
+
+    public function lock_retries(int $retries): self {
+        return $this->set('lock-retries', $retries);
+    }
+
+    public function lock_expires(int $expires): self {
+        return $this->set('lock-expires', $expires);
+    }
+
+    public function data(string $data): self {
+        return $this->set('data', $data);
+    }
+
+    public function lifetime(int $lifetime): self {
+        return $this->set('lifetime', $lifetime);
+    }
+
+    public function compression(string $compression): self {
+        return $this->set('compression', $compression);
+    }
+
+    protected function validate_args(array $required) {
+        foreach ($required as $req) {
+            if ( ! isset($this->args[$req]) || $this->args[$req] === null)
+                throw new \Exception("Command requires '$req' arg");
+        }
+    }
+
+    private function generate_id(): string {
+        if (function_exists('session_create_id'))
+            return session_create_id();
+
+        return uniqid();
+    }
+
+    private function get_tmp_file_name() {
+        return '/tmp/sessiontmp.txt';
+        return tempnam(sys_get_temp_dir(), 'session');
+    }
+
+    /*
+     * @param $client Redis client
+     * @param string $max_wait_sec
+     *
+     * Sometimes we want to block until a session lock has been detected
+     * This is better and faster than arbitrarily sleeping.  If we don't
+     * detect the session key within the specified maximum number of
+     * seconds, the function returns failure.
+     *
+     * @return bool
+     */
+    public function wait_for_lock_key($redis, $max_wait_sec) {
+        $now = microtime(true);
+
+        do {
+            if ($redis->exists($this->get_session_lock_key()))
+                return true;
+            usleep(10000);
+        } while (microtime(true) <= $now + $max_wait_sec);
+
+        return false;
+    }
+
+    private function append_cmd_args(array $args): string {
+        $append = [];
+
+        foreach ($args as $arg => $val) {
+            if ( ! $val)
+                continue;
+
+            if (is_string($val))
+                $val = escapeshellarg($val);
+
+            $append[] = "--$arg";
+            $append[] = $val;
+        }
+
+        return implode(' ', $append);
+    }
+
+    private function build_php_cmd(string $script, array $args): string {
+        return PhpSpawner::cmd($script) . ' ' . $this->append_cmd_args($args);
+    }
+
+    public function start_session_cmd(): string {
+        return $this->build_php_cmd(self::start_script, $this->args);
+    }
+
+    public function output(?int $timeout = NULL): ?string {
+        if ($this->output) {
+            var_dump("early return");
+            return $this->output;
+        }
+
+        if ( ! $this->output_file || ! $this->pid) {
+            throw new \Exception("Process was not started in the background");
+        }
+
+        $st = microtime(true);
+
+        do {
+            if (pcntl_waitpid($this->pid, $exit_code, WNOHANG) == 0)
+                break;
+            usleep(100000);
+        } while ((microtime(true) - $st) < $timeout);
+
+        if ( ! file_exists($this->output_file))
+            return "";
+
+        $this->output      = file_get_contents($this->output_file);
+        $this->output_file = NULL;
+        $this->exit_code   = $exit_code;
+        $this->pid         = NULL;
+
+        return $this->output;
+    }
+
+    public function exec_bg(): bool {
+        if ($this->cmd)
+            throw new \Exception("Command already executed!");
+
+        $output_file = $this->get_tmp_file_name();
+
+        $this->cmd  = $this->start_session_cmd();
+        $this->cmd .= " >$output_file 2>&1 & echo $!";
+
+        $pid = exec($this->cmd, $output, $exit_code);
+        $this->exit_code = $exit_code;
+
+        if ($this->exit_code || !is_numeric($pid))
+            return false;
+
+        $this->pid = (int)$pid;
+        $this->output_file = $output_file;
+
+        return true;
+    }
+
+    public function exec_fg() {
+        if ($this->cmd)
+            throw new \Exception("Command already executed!");
+
+        $this->cmd = $this->start_session_cmd() . ' 2>&1';
+
+        exec($this->cmd, $output, $exit_code);
+        $this->exit_code = $exit_code;
+        $this->output = implode("\n", array_filter($output));
+
+        return $this->output;
+    }
+
+    private function regenerate_id_cmd($locking, $destroy, $proxy): string {
+        $this->validate_args(['handler', 'id', 'save-path']);
+
+        $args = [
+            'handler' => $this->args['handler'],
+            'save-path' => $this->args['save-path'],
+            'id' => $this->args['id'],
+            'locking-enabled' => !!$locking,
+            'destroy' => !!$destroy,
+            'proxy' => !!$proxy,
+        ];
+
+        return $this->build_php_cmd(self::regenerate_id_script, $args);
+    }
+
+    public function regenerate_id($locking = false, $destroy = false, $proxy = false) {
+        if ( ! $this->cmd)
+            throw new \Exception("Cannot regenerate id before starting session!");
+
+        $cmd = $this->regenerate_id_cmd($locking, $destroy, $proxy);
+
+        exec($cmd, $output, $exit_code);
+
+        if ($exit_code != 0)
+            return false;
+
+        return $output[0];
+    }
+
+    private function get_data_cmd(?int $lifetime): string {
+        $this->validate_args(['handler', 'save-path', 'id']);
+
+        $args = [
+            'handler' => $this->args['handler'],
+            'save-path' => $this->args['save-path'],
+            'id' => $this->args['id'],
+            'lifetime' => is_int($lifetime) ? $lifetime : $this->args['lifetime'],
+        ];
+
+        return $this->build_php_cmd(self::get_data_script, $args);
+    }
+
+    public function get_data(?int $lifetime = NULL): string {
+        $cmd = $this->get_data_cmd($lifetime);
+
+        exec($cmd, $output, $exit_code);
+        if ($exit_code != 0) {
+            return implode("\n", $output);
+        }
+
+        return $output[0];
+    }
+}

--- a/tests/getSessionData.php
+++ b/tests/getSessionData.php
@@ -1,22 +1,33 @@
 <?php
+
+require_once __DIR__ . '/SessionHelpers.php';
+
 error_reporting(E_ERROR | E_WARNING);
 
-$redisHost = $argv[1];
-$saveHandler = $argv[2];
-$sessionId = $argv[3];
-$sessionLifetime = $argv[4];
+$opt = getopt('', ['handler:', 'save-path:', 'id:', 'lifetime:']);
 
-if (empty($redisHost)) {
-    $redisHost = 'tcp://localhost:6379';
+$handler = $opt['handler'] ?? NULL;
+$save_path = $opt['save-path'] ?? NULL;
+$id = $opt['id'] ?? NULL;
+$lifetime = $opt['lifetime'] ?? NULL;
+
+if ( ! $handler) {
+    fprintf(STDERR, "--handler is required\n");
+    exit(1);
+} else if ( ! $save_path) {
+    fprintf(STDERR, "--save-path is required\n");
+    exit(1);
 }
 
-ini_set('session.save_handler', $saveHandler);
-ini_set('session.save_path', $redisHost);
-ini_set('session.gc_maxlifetime', $sessionLifetime);
+ini_set('session.save_handler', $handler);
+ini_set('session.save_path', $save_path);
+ini_set('session.gc_maxlifetime', $lifetime);
 
-session_id($sessionId);
+session_id($id);
 if (!session_start()) {
-    echo "session_start() was nut successful";
+    fprintf(STDERR, "session_start() was nut successful");
+    exit(1);
 } else {
     echo isset($_SESSION['redis_test']) ? $_SESSION['redis_test'] : 'Key redis_test not found';
+    exit(0);
 }

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -80,8 +80,8 @@ session_id($id);
 
 if (!session_start()) {
     $result = "FAILED: session_start()";
-} else if (!session_regenerate_id($destroy_previous)) {
-    $result = "FAILED: session_regenerate_id()";
+} else if (!session_regenerateId($destroy_previous)) {
+    $result = "FAILED: session_regenerateId()";
 } else {
     $result = session_id();
 }

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -1,23 +1,30 @@
 <?php
+
 error_reporting(E_ERROR | E_WARNING);
 
-$redisHost = $argv[1];
-$saveHandler = $argv[2];
-$sessionId = $argv[3];
-$locking = !!$argv[4];
-$destroyPrevious = !!$argv[5];
-$sessionProxy = !!$argv[6];
+$opt = getopt('', [
+    'handler:', 'save-path:', 'id:', 'locking-enabled:',
+    'destroy-previous:', 'proxy:'
+]);
 
-if (empty($redisHost)) {
-    $redisHost = 'tcp://localhost:6379';
+$handler = $opt['handler'] ?? NULL;
+$save_path = $opt['save-path'] ?? NULL;
+$id = $opt['id'] ?? NULL;
+$locking_enabled = !!($opt['locking-enabled'] ?? false);
+$destroy_previous = !!($opt['destroy-previous'] ?? false);
+$proxy = !!($opt['proxy'] ?? false);
+
+if ( ! $handler) {
+    fprintf(STDERR, "--handler is required\n");
+    exit(1);
+} else if ( ! $save_path) {
+    fprintf(STDERR, "--save-path is required\n");
+    exit(1);
 }
 
-ini_set('session.save_handler', $saveHandler);
-ini_set('session.save_path', $redisHost);
-
-if ($locking) {
-    ini_set('redis.session.locking_enabled', true);
-}
+ini_set('session.save_handler', $handler);
+ini_set('session.save_path', $save_path);
+ini_set('redis.session.locking_enabled', $locking_enabled);
 
 if (interface_exists('SessionHandlerInterface')) {
     class TestHandler implements SessionHandlerInterface
@@ -64,21 +71,21 @@ if (interface_exists('SessionHandlerInterface')) {
     }
 }
 
-if ($sessionProxy) {
+if ($proxy) {
     $handler = new TestHandler();
     session_set_save_handler($handler);
 }
 
-session_id($sessionId);
+session_id($id);
+
 if (!session_start()) {
     $result = "FAILED: session_start()";
-}
-elseif (!session_regenerate_id($destroyPrevious)) {
+} else if (!session_regenerate_id($destroy_previous)) {
     $result = "FAILED: session_regenerate_id()";
-}
-else {
+} else {
     $result = session_id();
 }
-session_write_close();
-echo $result;
 
+session_write_close();
+
+echo $result;

--- a/tests/startSession.php
+++ b/tests/startSession.php
@@ -1,40 +1,52 @@
 <?php
 error_reporting(E_ERROR | E_WARNING);
 
-$redisHost = $argv[1];
-$saveHandler = $argv[2];
-$sessionId = $argv[3];
-$sleepTime = $argv[4];
-$maxExecutionTime = $argv[5];
-$lock_retries = $argv[6];
-$lock_expire = $argv[7];
-$sessionData = $argv[8];
-$sessionLifetime = $argv[9];
-$lockingEnabled = $argv[10];
-$lockWaitTime = $argv[11];
-$sessionCompression = $argv[12];
+$opt = getopt('', [
+    'handler:', 'save-path:', 'id:', 'sleep:', 'max-execution-time:' ,
+    'locking-enabled:', 'lock-wait-time:', 'lock-retries:', 'lock-expires:',
+    'data:', 'lifetime:', 'compression:'
+]);
 
-if (empty($redisHost)) {
-    $redisHost = 'tcp://localhost:6379';
+$handler = $opt['handler'] ?? NULL;
+$save_path = $opt['save-path'] ?? NULL;
+$id = $opt['id'] ?? NULL;
+$sleep = $opt['sleep'] ?? 0;
+$max_execution_time = $opt['max-execution-time'] ?? 0;
+$lock_retries = $opt['lock-retries'] ?? 0;
+$lock_expire = $opt['lock-expires'] ?? 0;
+$data = $opt['data'] ?? NULL;
+$lifetime = $opt['lifetime'] ?? 0;
+$locking_enabled = $opt['locking-enabled'] ?? NULL;
+$lock_wait_time = $opt['lock-wait-time'] ?? 0;
+$compression = $opt['compression'] ?? NULL;
+
+if ( ! $handler) {
+    fprintf(STDERR, "--handler is required\n");
+    exit(1);
+} else if ( ! $save_path) {
+    fprintf(STDERR, "--save-path is required\n");
+    exit(1);
 }
 
-ini_set('session.save_handler', $saveHandler);
-ini_set('session.save_path', $redisHost);
-ini_set('max_execution_time', $maxExecutionTime);
-ini_set("{$saveHandler}.session.lock_retries", $lock_retries);
-ini_set("{$saveHandler}.session.lock_expire", $lock_expire);
-ini_set('session.gc_maxlifetime', $sessionLifetime);
-ini_set("{$saveHandler}.session.locking_enabled", $lockingEnabled);
-ini_set("{$saveHandler}.session.lock_wait_time", $lockWaitTime);
-ini_set('redis.session.compression', $sessionCompression);
+ini_set('session.save_handler', $handler);
+ini_set('session.save_path', $save_path);
+ini_set('max_execution_time', $max_execution_time);
+ini_set("{$handler}.session.lock_retries", $lock_retries);
+ini_set("{$handler}.session.lock_expire", $lock_expire);
+ini_set('session.gc_maxlifetime', $lifetime);
+ini_set("{$handler}.session.locking_enabled", $locking_enabled);
+ini_set("{$handler}.session.lock_wait_time", $lock_wait_time);
+ini_set('redis.session.compression', $compression);
 
-session_id($sessionId);
-$sessionStartSuccessful = session_start();
-sleep($sleepTime);
-if (!empty($sessionData)) {
-    $_SESSION['redis_test'] = $sessionData;
+session_id($id);
+$status = session_start();
+
+sleep($sleep);
+
+if ($data) {
+    $_SESSION['redis_test'] = $data;
 }
 
 session_write_close();
 
-echo $sessionStartSuccessful ? 'SUCCESS' : 'FAILURE';
+echo $status ? 'SUCCESS' : 'FAILURE';


### PR DESCRIPTION
* Update these external scripts to take formal arguments with `getopt` to make it more straightforward what each of the currently positional arguments are actually for.

* Create small helper classes for invoking these external scripts. Instead of `startSessionProcess` that takes a dozen arguments all but three of which have defaults, we can use a construct like this:

```php
$runner = $this->sessionRunner() 
    ->max_execution_time(300) 
    ->locking_enabled(true) 
    ->lock_wait_time(-1) 
    ->lock_expires(0) 
    ->data($data) 
    ->compression($name);

// Invokes startSession.php with above args.
$result = $runner->exec_fg();

// Invokes regenerateSessionId.php with above args
$new_id = $runner->regenerate_id();

// Invokes getSessionData.php for this session ID.
$data   = $runner->get_data();
```

* Add a bit of logic to TestSuite to dump more information about the source of an assertion to make it easier to track down problems when we assert outside of a top level public `test_*` method.

* Create a few new assertions like `assertKeyExists` and `assertKeyMissing` which will generate much nicer assertions as opposed to

```php
$this->assertTrue($this->redis->exists($some_key)); 
```

* If our externally spawned session scripts fail output the exact call that was made along with all arguments as well as the output that we received to make it easier to narrow down.