### PR TITLE
More unit test cleanup.

### DIFF
--- a/tests/RedisArrayTest.php
+++ b/tests/RedisArrayTest.php
@@ -49,7 +49,7 @@ class Redis_Array_Test extends TestSuite
     public function setUp() {
         // initialize strings.
         $n = REDIS_ARRAY_DATA_SIZE;
-        $this->strings = array();
+        $this->strings = [];
         for($i = 0; $i < $n; $i++) {
             $this->strings['key-'.$i] = 'val-'.$i;
         }
@@ -66,11 +66,11 @@ class Redis_Array_Test extends TestSuite
 
     public function testMSet() {
         // run mset
-        $this->assertTrue(TRUE === $this->ra->mset($this->strings));
+        $this->assertTrue($this->ra->mset($this->strings));
 
         // check each key individually using the array
         foreach($this->strings as $k => $v) {
-            $this->assertTrue($v === $this->ra->get($k));
+            $this->assertEquals($v, $this->ra->get($k));
         }
 
         // check each key individually using a new connection
@@ -88,16 +88,16 @@ class Redis_Array_Test extends TestSuite
             if ($this->getAuth()) {
                 $this->assertTrue($r->auth($this->getAuth()));
             }
-            $this->assertTrue($v === $r->get($k));
+            $this->assertEquals($v, $r->get($k));
         }
     }
 
     public function testMGet() {
-        $this->assertTrue(array_values($this->strings) === $this->ra->mget(array_keys($this->strings)));
+        $this->assertEquals(array_values($this->strings), $this->ra->mget(array_keys($this->strings)));
     }
 
     private function addData($commonString) {
-        $this->data = array();
+        $this->data = [];
         for($i = 0; $i < REDIS_ARRAY_DATA_SIZE; $i++) {
             $k = rand().'_'.$commonString.'_'.rand();
             $this->data[$k] = rand();
@@ -111,9 +111,9 @@ class Redis_Array_Test extends TestSuite
         foreach($this->data as $k => $v) {
                 $node = $this->ra->_target($k);
                 if($lastNode) {
-                    $this->assertTrue($node === $lastNode);
+                    $this->assertEquals($node, $lastNode);
                 }
-                $this->assertTrue($this->ra->get($k) == $v);
+                $this->assertEqualsWeak($v, $this->ra->get($k));
                 $lastNode = $node;
         }
     }
@@ -163,7 +163,7 @@ class Redis_Array_Test extends TestSuite
         foreach($this->data as $k => $v) {
             $node = $this->ra->_target($k);
             $pos = $this->customDistributor($k);
-            $this->assertTrue($node === $newRing[$pos]);
+            $this->assertEquals($node, $newRing[$pos]);
         }
     }
 
@@ -225,7 +225,7 @@ class Redis_Rehashing_Test extends TestSuite
 
         // initialize strings.
         $n = REDIS_ARRAY_DATA_SIZE;
-        $this->strings = array();
+        $this->strings = [];
         for($i = 0; $i < $n; $i++) {
             $this->strings['key-'.$i] = 'val-'.$i;
         }
@@ -245,13 +245,13 @@ class Redis_Rehashing_Test extends TestSuite
         // initialize hashes
         for($i = 0; $i < $n; $i++) {
             // each hash has 5 keys
-            $this->hashes['hash-'.$i] = array('A' => $i, 'B' => $i+1, 'C' => $i+2, 'D' => $i+3, 'E' => $i+4);
+            $this->hashes['hash-'.$i] = ['A' => $i, 'B' => $i+1, 'C' => $i+2, 'D' => $i+3, 'E' => $i+4];
         }
 
         // initialize sorted sets
         for($i = 0; $i < $n; $i++) {
             // each sorted sets has 5 elements
-            $this->zsets['zset-'.$i] = array($i, 'A', $i+1, 'B', $i+2, 'C', $i+3, 'D', $i+4, 'E');
+            $this->zsets['zset-'.$i] = [$i, 'A', $i+1, 'B', $i+2, 'C', $i+3, 'D', $i+4, 'E'];
         }
 
         global $newRing, $oldRing, $useIndex;
@@ -289,12 +289,12 @@ class Redis_Rehashing_Test extends TestSuite
 
         // sets
         foreach($this->sets as $k => $v) {
-            call_user_func_array(array($this->ra, 'sadd'), array_merge(array($k), $v));
+            call_user_func_array([$this->ra, 'sadd'], array_merge([$k], $v));
         }
 
         // lists
         foreach($this->lists as $k => $v) {
-            call_user_func_array(array($this->ra, 'rpush'), array_merge(array($k), $v));
+            call_user_func_array([$this->ra, 'rpush'], array_merge([$k], $v));
         }
 
         // hashes
@@ -304,7 +304,7 @@ class Redis_Rehashing_Test extends TestSuite
 
         // sorted sets
         foreach($this->zsets as $k => $v) {
-            call_user_func_array(array($this->ra, 'zadd'), array_merge(array($k), $v));
+            call_user_func_array([$this->ra, 'zadd'], array_merge([$k], $v));
         }
     }
 
@@ -320,7 +320,7 @@ class Redis_Rehashing_Test extends TestSuite
 
         // strings
         foreach($this->strings as $k => $v) {
-            $this->assertTrue($this->ra->get($k) === $v);
+            $this->assertEquals($v, $this->ra->get($k));
         }
 
         // sets
@@ -351,7 +351,7 @@ class Redis_Rehashing_Test extends TestSuite
             $ret = $this->ra->zrange($k, 0, -1, TRUE); // get values with scores
 
             // create assoc array from local dataset
-            $tmp = array();
+            $tmp = [];
             for($i = 0; $i < count($v); $i += 2) {
                 $tmp[$v[$i+1]] = $v[$i];
             }
@@ -402,7 +402,7 @@ class Redis_Auto_Rehashing_Test extends TestSuite {
     public function setUp() {
         // initialize strings.
         $n = REDIS_ARRAY_DATA_SIZE;
-        $this->strings = array();
+        $this->strings = [];
         for($i = 0; $i < $n; $i++) {
             $this->strings['key-'.$i] = 'val-'.$i;
         }
@@ -426,7 +426,7 @@ class Redis_Auto_Rehashing_Test extends TestSuite {
 
     private function readAllvalues() {
         foreach($this->strings as $k => $v) {
-            $this->assertTrue($this->ra->get($k) === $v);
+            $this->assertEquals($v, $this->ra->get($k));
         }
     }
 
@@ -458,7 +458,7 @@ class Redis_Auto_Rehashing_Test extends TestSuite {
                 $this->assertTrue($r->auth($this->getAuth()));
             }
 
-            $this->assertTrue($v === $r->get($k));  // check that the key has actually been migrated to the new node.
+            $this->assertEquals($v, $r->get($k));  // check that the key has actually been migrated to the new node.
         }
     }
 }
@@ -491,10 +491,10 @@ class Redis_Multi_Exec_Test extends TestSuite {
     public function testKeyDistribution() {
         // check that all of joe's keys are on the same instance
         $lastNode = NULL;
-        foreach(array('name', 'group', 'salary') as $field) {
+        foreach(['name', 'group', 'salary'] as $field) {
             $node = $this->ra->_target('1_{employee:joe}_'.$field);
             if($lastNode) {
-                $this->assertTrue($node === $lastNode);
+                $this->assertEquals($node, $lastNode);
             }
             $lastNode = $node;
         }
@@ -514,8 +514,8 @@ class Redis_Multi_Exec_Test extends TestSuite {
             ->exec();
 
         // check that the group and salary have been changed
-        $this->assertTrue($this->ra->get('1_{employee:joe}_group') === $newGroup);
-        $this->assertTrue($this->ra->get('1_{employee:joe}_salary') == $newSalary);
+        $this->assertEquals($newGroup, $this->ra->get('1_{employee:joe}_group'));
+        $this->assertEqualsWeak($newSalary, $this->ra->get('1_{employee:joe}_salary'));
 
     }
 
@@ -527,10 +527,10 @@ class Redis_Multi_Exec_Test extends TestSuite {
 
         // test MSET, making Joe a top-level executive
         $out = $this->ra->multi($this->ra->_target('{employee:joe}'))
-                ->mset(array('1_{employee:joe}_group' => $newGroup, '1_{employee:joe}_salary' => $newSalary))
+                ->mset(['1_{employee:joe}_group' => $newGroup, '1_{employee:joe}_salary' => $newSalary])
                 ->exec();
 
-        $this->assertTrue($out[0] === TRUE);
+        $this->assertTrue($out[0]);
     }
 
     public function testMultiExecMGet() {
@@ -539,7 +539,7 @@ class Redis_Multi_Exec_Test extends TestSuite {
 
         // test MGET
         $out = $this->ra->multi($this->ra->_target('{employee:joe}'))
-                ->mget(array('1_{employee:joe}_group', '1_{employee:joe}_salary'))
+                ->mget(['1_{employee:joe}_group', '1_{employee:joe}_salary'])
                 ->exec();
 
         $this->assertTrue($out[0][0] == $newGroup);
@@ -553,7 +553,7 @@ class Redis_Multi_Exec_Test extends TestSuite {
             ->del('1_{employee:joe}_group', '1_{employee:joe}_salary')
             ->exec();
 
-        $this->assertTrue($out[0] === 2);
+        $this->assertEquals(2, $out[0]);
         $this->assertEquals(0, $this->ra->exists('1_{employee:joe}_group'));
         $this->assertEquals(0, $this->ra->exists('1_{employee:joe}_salary'));
     }
@@ -570,7 +570,7 @@ class Redis_Multi_Exec_Test extends TestSuite {
             ->del('{unlink}:key1', '{unlink}:key2')
             ->exec();
 
-        $this->assertTrue($out[0] === 2);
+        $this->assertEquals(2, $out[0]);
     }
 
     public function testDiscard() {
@@ -578,31 +578,31 @@ class Redis_Multi_Exec_Test extends TestSuite {
         $key = 'test_err';
 
         $this->assertTrue($this->ra->set($key, 'test'));
-        $this->assertTrue('test' === $this->ra->get($key));
+        $this->assertEquals('test', $this->ra->get($key));
 
         $this->ra->watch($key);
 
         // After watch, same
-        $this->assertTrue('test' === $this->ra->get($key));
+        $this->assertEquals('test', $this->ra->get($key));
 
         // change in a multi/exec block.
         $ret = $this->ra->multi($this->ra->_target($key))->set($key, 'test1')->exec();
-        $this->assertTrue($ret === array(true));
+        $this->assertEquals([true], $ret);
 
         // Get after exec, 'test1':
-        $this->assertTrue($this->ra->get($key) === 'test1');
+        $this->assertEquals('test1', $this->ra->get($key));
 
         $this->ra->watch($key);
 
         // After second watch, still test1.
-        $this->assertTrue($this->ra->get($key) === 'test1');
+        $this->assertEquals('test1', $this->ra->get($key));
 
         $ret = $this->ra->multi($this->ra->_target($key))->set($key, 'test2')->discard();
         // Ret after discard: NULL";
-        $this->assertTrue($ret === NULL);
+        $this->assertNull($ret);
 
         // Get after discard, unchanged:
-        $this->assertTrue($this->ra->get($key) === 'test1');
+        $this->assertEquals('test1', $this->ra->get($key));
     }
 }
 
@@ -629,9 +629,9 @@ class Redis_Distributor_Test extends TestSuite {
     }
 
     public function distribute($key) {
-        $matches = array();
+        $matches = [];
         if (preg_match('/{([^}]+)}.*/', $key, $matches) == 1) {
-            $countries = array('uk' => 0, 'us' => 1);
+            $countries = ['uk' => 0, 'us' => 1];
             if (array_key_exists($matches[1], $countries)) {
                 return $countries[$matches[1]];
             }
@@ -646,10 +646,10 @@ class Redis_Distributor_Test extends TestSuite {
         $defaultServer = $this->ra->_target('unknown');
 
         $nodes = $this->ra->_hosts();
-        $this->assertTrue($ukServer === $nodes[0]);
-        $this->assertTrue($usServer === $nodes[1]);
-        $this->assertTrue($deServer === $nodes[2]);
-        $this->assertTrue($defaultServer === $nodes[2]);
+        $this->assertEquals($ukServer, $nodes[0]);
+        $this->assertEquals($usServer,$nodes[1]);
+        $this->assertEquals($deServer,$nodes[2]);
+        $this->assertEquals($defaultServer, $nodes[2]);
     }
 }
 

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -121,14 +121,14 @@ class Redis_Cluster_Test extends Redis_Test {
 
         for ($i = 0; $i < 1000; $i++) {
             $k = $this->redis->randomKey("key:$i");
-            $this->assertTrue($this->redis->exists($k));
+            $this->assertEquals(1, $this->redis->exists($k));
         }
     }
 
     public function testEcho() {
-        $this->assertEquals($this->redis->echo('echo1', 'hello'), 'hello');
-        $this->assertEquals($this->redis->echo('echo2', 'world'), 'world');
-        $this->assertEquals($this->redis->echo('echo3', " 0123 "), " 0123 ");
+        $this->assertEquals('hello', $this->redis->echo('echo1', 'hello'));
+        $this->assertEquals('world', $this->redis->echo('echo2', 'world'));
+        $this->assertEquals(' 0123 ', $this->redis->echo('echo3', " 0123 "));
     }
 
     public function testSortPrefix() {
@@ -138,7 +138,7 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->redis->sadd('some-item', 2);
         $this->redis->sadd('some-item', 3);
 
-        $this->assertEquals(array('1','2','3'), $this->redis->sort('some-item'));
+        $this->assertEquals(['1','2','3'], $this->redis->sort('some-item'));
 
         // Kill our set/prefix
         $this->redis->del('some-item');
@@ -291,7 +291,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         // Should get an array back, with two elements
         $this->assertTrue(is_array($result));
-        $this->assertEquals(count($result), 4);
+        $this->assertEquals(4, count($result));
 
         $arr_zipped = [];
         for ($i = 0; $i <= count($result) / 2; $i+=2) {
@@ -302,7 +302,7 @@ class Redis_Cluster_Test extends Redis_Test {
         // Make sure the elements are correct, and have zero counts
         foreach([$c1,$c2] as $channel) {
             $this->assertTrue(isset($result[$channel]));
-            $this->assertEquals($result[$channel], 0);
+            $this->assertEquals(0, $result[$channel]);
         }
 
         // PUBSUB NUMPAT
@@ -326,9 +326,9 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->redis->del('x');
         $ret = $this->redis->msetnx(['x'=>'a','y'=>'b','z'=>'c']);
         $this->assertTrue(is_array($ret));
-        $this->assertEquals(array_sum($ret),1);
+        $this->assertEquals(1, array_sum($ret));
 
-        $this->assertFalse($this->redis->msetnx(array())); // set ø → FALSE
+        $this->assertFalse($this->redis->msetnx([])); // set ø → FALSE
     }
 
     /* Slowlog needs to take a key or [ip, port], to direct it to a node */
@@ -368,7 +368,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         // This transaction should fail because the other client changed 'x'
         $ret = $this->redis->multi()->get('x')->exec();
-        $this->assertTrue($ret === [false]);
+        $this->assertEquals([false], $ret);
         // watch and unwatch
         $this->redis->watch('x');
         $r->incr('x'); // other instance
@@ -376,7 +376,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         // This should succeed as the watch has been cancelled
         $ret = $this->redis->multi()->get('x')->exec();
-        $this->assertTrue($ret === array('44'));
+        $this->assertEquals(['44'], $ret);
     }
 
     public function testDiscard()
@@ -439,9 +439,9 @@ class Redis_Cluster_Test extends Redis_Test {
         $sha = sha1($scr);
 
         // Run it when it doesn't exist, run it with eval, and then run it with sha1
-        $this->assertTrue(false === $this->redis->evalsha($scr,[$str_key], 1));
-        $this->assertTrue(1 === $this->redis->eval($scr,[$str_key], 1));
-        $this->assertTrue(1 === $this->redis->evalsha($sha,[$str_key], 1));
+        $this->assertFalse($this->redis->evalsha($scr,[$str_key], 1));
+        $this->assertEquals(1, $this->redis->eval($scr,[$str_key], 1));
+        $this->assertEquals(1, $this->redis->evalsha($sha,[$str_key], 1));
     }
 
     public function testEvalBulkResponse() {
@@ -455,8 +455,8 @@ class Redis_Cluster_Test extends Redis_Test {
 
         $result = $this->redis->eval($scr,[$str_key1, $str_key2], 2);
 
-        $this->assertTrue($str_key1 === $result[0]);
-        $this->assertTrue($str_key2 === $result[1]);
+        $this->assertEquals($str_key1, $result[0]);
+        $this->assertEquals($str_key2, $result[1]);
     }
 
     public function testEvalBulkResponseMulti() {
@@ -473,8 +473,8 @@ class Redis_Cluster_Test extends Redis_Test {
 
         $result = $this->redis->exec();
 
-        $this->assertTrue($str_key1 === $result[0][0]);
-        $this->assertTrue($str_key2 === $result[0][1]);
+        $this->assertEquals($str_key1, $result[0][0]);
+        $this->assertEquals($str_key2, $result[0][1]);
     }
 
     public function testEvalBulkEmptyResponse() {
@@ -488,7 +488,7 @@ class Redis_Cluster_Test extends Redis_Test {
 
         $result = $this->redis->eval($scr, [$str_key1, $str_key2], 2);
 
-        $this->assertTrue(null === $result);
+        $this->assertNull($result);
     }
 
     public function testEvalBulkEmptyResponseMulti() {
@@ -504,7 +504,7 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->redis->eval($scr, [$str_key1, $str_key2], 2);
         $result = $this->redis->exec();
 
-        $this->assertTrue(null === $result[0]);
+        $this->assertNull($result[0]);
     }
 
     /* Cluster specific introspection stuff */
@@ -513,9 +513,9 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue(is_array($arr_masters));
 
         foreach ($arr_masters as $arr_info) {
-            $this->assertTrue(is_array($arr_info));
-            $this->assertTrue(is_string($arr_info[0]));
-            $this->assertTrue(is_long($arr_info[1]));
+            $this->assertIsArray($arr_info);
+            $this->assertIsString($arr_info[0]);
+            $this->assertIsInt($arr_info[1]);
         }
     }
 
@@ -598,7 +598,7 @@ class Redis_Cluster_Test extends Redis_Test {
             array_sum($a) != array_sum($b);
 
         if ($boo_diff) {
-            $this->assertEquals($a,$b);
+            $this->assertEquals($a, $b);
             return;
         }
     }
@@ -657,11 +657,11 @@ class Redis_Cluster_Test extends Redis_Test {
     /* Test a 'raw' command */
     public function testRawCommand() {
         $this->redis->rawCommand('mykey', 'set', 'mykey', 'my-value');
-        $this->assertEquals($this->redis->get('mykey'), 'my-value');
+        $this->assertEquals('my-value', $this->redis->get('mykey'));
 
         $this->redis->del('mylist');
         $this->redis->rpush('mylist', 'A','B','C','D');
-        $this->assertEquals($this->redis->lrange('mylist', 0, -1), ['A','B','C','D']);
+        $this->assertEquals(['A','B','C','D'], $this->redis->lrange('mylist', 0, -1));
     }
 
     protected function rawCommandArray($key, $args) {

--- a/tests/regenerateSessionId.php
+++ b/tests/regenerateSessionId.php
@@ -80,7 +80,7 @@ session_id($id);
 
 if (!session_start()) {
     $result = "FAILED: session_start()";
-} else if (!session_regenerateId($destroy_previous)) {
+} else if (!session_regenerate_id($destroy_previous)) {
     $result = "FAILED: session_regenerateId()";
 } else {
     $result = session_id();


### PR DESCRIPTION
* Tighten up `assertTrue` and `assertFalse` such that they test that passed arguments `===` `true` and `===` `false` respectively, instead of testing for truth-like or false-like.

* Start modernizing our unit tests to use explicit types for arguments, return types, member variables, etc.

* Multiple assertion fixes that were exposed when making `assertTrue` and `assertFalse` more explicit.

* Some formatting cleanup to style for incorrect indentation, etc, that had crept in over many years.

* Add some more assertion helpers like `assertNull`, `assertGT`, `assertGTE`, `assertLT`, and `assertLTE`.