### PR TITLE
More test refactoring.

### DIFF
--- a/arrays.md
+++ b/arrays.md
@@ -121,7 +121,7 @@ For instance, the keys “{user:1}:name” and “{user:1}:email” will be stor
 ## Custom key distribution function
 In order to control the distribution of keys by hand, you can provide a custom function or closure that returns the server number, which is the index in the array of servers that you created the RedisArray object with.
 
-For instance, instantiate a RedisArray object with `new RedisArray(array("us-host", "uk-host", "de-host"), array("distributor" => "dist"));` and write a function called "dist" that will return `2` for all the keys that should end up on the "de-host" server.
+For instance, instantiate a RedisArray object with `new RedisArray(["us-host", "uk-host", "de-host"], ["distributor" => "dist"]);` and write a function called "dist" that will return `2` for all the keys that should end up on the "de-host" server.
 
 ### Example
 <pre>

--- a/cluster.md
+++ b/cluster.md
@@ -24,7 +24,7 @@ $obj_cluster = new RedisCluster(NULL, ["host:7000", "host:7001"], 1.5, 1.5, true
 
 // Connect with cluster using SSL/TLS
 // last argument is an array with [SSL context](https://www.php.net/manual/en/context.ssl.php) options
-$obj_cluster = new RedisCluster(NULL, ["host:7000", "host:7001"], 1.5, 1.5, true, NULL, Array("verify_peer" => false));
+$obj_cluster = new RedisCluster(NULL, ["host:7000", "host:7001"], 1.5, 1.5, true, NULL, ["verify_peer" => false]);
 ```
 
 #### Loading a cluster configuration by name


### PR DESCRIPTION
* Switch remaining old-style PHP 5.4 `Array(...)` declarations to `[...]`
* Update variable names getting rid hungarian notation prefixes (e.g. `str_`, `i_`, etc).
* Allow cluster seeds to be passed on the command-line instead of soley relying on either a node environment variable or our tests/nodes/nodemap file.  This should make it easier to run ad-hoc cluster tests by specifying just a single seed.
* Add some diagnostics for when we can't find a suitable cluster to run our tests against indicating exactly where we looked for the env var and node file.
* Refactor RedisArray tests to use our newer TestSuite assertions.
* Allow `RedisArray` ports to be specified on the command-line as well.
* Various formatting fixes.
* More robust KeyDB detection.