### PR TITLE
Play around with more ZEND_STRL usage

### DIFF
--- a/library.c
+++ b/library.c
@@ -3125,7 +3125,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
 
             int limit = INI_INT("redis.pconnect.connection_limit");
             if (limit > 0 && p->nb_active >= limit) {
-                redis_sock_set_err(redis_sock, "Connection limit reached", sizeof("Connection limit reached") - 1);
+                redis_sock_set_err(redis_sock, ZEND_STRL("Connection limit reached"));
                 return FAILURE;
             }
 

--- a/redis.c
+++ b/redis.c
@@ -567,8 +567,8 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 
     /* Does the host look like a unix socket */
     af_unix = (host_len > 0 && host[0] == '/') ||
-              (host_len > 6 && !strncasecmp(host, "unix://", sizeof("unix://") - 1)) ||
-              (host_len > 6 && !strncasecmp(host, "file://", sizeof("file://") - 1));
+              (host_len > 6 && (!strncasecmp(host, ZEND_STRL("unix://")) ||
+                                !strncasecmp(host, ZEND_STRL("file://"))));
 
     /* If it's not a unix socket, set to default */
     if (port == -1 && !af_unix) {
@@ -1258,18 +1258,18 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
     }
 
     /* Start constructing final command and append key */
-    redis_cmd_init_sstr(&cmd, argc, "SORT", 4);
+    redis_cmd_init_sstr(&cmd, argc, ZEND_STRL("SORT"));
     redis_cmd_append_sstr_key(&cmd, key, keylen, redis_sock, NULL);
 
     /* BY pattern */
     if (pattern && patternlen) {
-        redis_cmd_append_sstr(&cmd, "BY", sizeof("BY") - 1);
+        redis_cmd_append_sstr(&cmd, ZEND_STRL("BY"));
         redis_cmd_append_sstr(&cmd, pattern, patternlen);
     }
 
     /* LIMIT offset count */
     if (offset >= 0 && count >= 0) {
-        redis_cmd_append_sstr(&cmd, "LIMIT", sizeof("LIMIT") - 1);
+        redis_cmd_append_sstr(&cmd, ZEND_STRL("LIMIT"));
         redis_cmd_append_sstr_long(&cmd, offset);
         redis_cmd_append_sstr_long(&cmd, count);
     }
@@ -1279,25 +1279,25 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
         if (Z_TYPE_P(zget) == IS_ARRAY) {
             ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(zget), zele) {
                 zpattern = zval_get_string(zele);
-                redis_cmd_append_sstr(&cmd, "GET", sizeof("GET") - 1);
+                redis_cmd_append_sstr(&cmd, ZEND_STRL("GET"));
                 redis_cmd_append_sstr(&cmd, ZSTR_VAL(zpattern), ZSTR_LEN(zpattern));
                 zend_string_release(zpattern);
             } ZEND_HASH_FOREACH_END();
         } else {
             zpattern = zval_get_string(zget);
-            redis_cmd_append_sstr(&cmd, "GET", sizeof("GET") - 1);
+            redis_cmd_append_sstr(&cmd, ZEND_STRL("GET"));
             redis_cmd_append_sstr(&cmd, ZSTR_VAL(zpattern), ZSTR_LEN(zpattern));
             zend_string_release(zpattern);
         }
     }
 
     /* Append optional DESC and ALPHA modifiers */
-    if (desc)  redis_cmd_append_sstr(&cmd, "DESC", sizeof("DESC") - 1);
-    if (alpha) redis_cmd_append_sstr(&cmd, "ALPHA", sizeof("ALPHA") - 1);
+    if (desc)  redis_cmd_append_sstr(&cmd, ZEND_STRL("DESC"));
+    if (alpha) redis_cmd_append_sstr(&cmd, ZEND_STRL("ALPHA"));
 
     /* Finally append STORE if we've got it */
     if (store && storelen) {
-        redis_cmd_append_sstr(&cmd, "STORE", sizeof("STORE") - 1);
+        redis_cmd_append_sstr(&cmd, ZEND_STRL("STORE"));
         redis_cmd_append_sstr_key(&cmd, store, storelen, redis_sock, NULL);
     }
 

--- a/redis.c
+++ b/redis.c
@@ -567,8 +567,8 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 
     /* Does the host look like a unix socket */
     af_unix = (host_len > 0 && host[0] == '/') ||
-              (host_len > 6 && (!strncasecmp(host, ZEND_STRL("unix://")) ||
-                                !strncasecmp(host, ZEND_STRL("file://"))));
+              (host_len > 6 && (!strncasecmp(host, "unix://", sizeof("unix://") - 1) ||
+                                !strncasecmp(host, "file://", sizeof("file://") - 1)));
 
     /* If it's not a unix socket, set to default */
     if (port == -1 && !af_unix) {

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -90,38 +90,43 @@ ra_init_function_table(RedisArray *ra)
     ALLOC_HASHTABLE(ra->pure_cmds);
     zend_hash_init(ra->pure_cmds, 0, NULL, NULL, 0);
 
-    zend_hash_str_update_ptr(ra->pure_cmds, "EXISTS", sizeof("EXISTS") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "GET", sizeof("GET") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "GETBIT", sizeof("GETBIT") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "GETRANGE", sizeof("GETRANGE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HEXISTS", sizeof("HEXISTS") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HGET", sizeof("HGET") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HGETALL", sizeof("HGETALL") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HKEYS", sizeof("HKEYS") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HLEN", sizeof("HLEN") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HMGET", sizeof("HMGET") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "HVALS", sizeof("HVALS") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "LINDEX", sizeof("LINDEX") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "LLEN", sizeof("LLEN") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "LRANGE", sizeof("LRANGE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "OBJECT", sizeof("OBJECT") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SCARD", sizeof("SCARD") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SDIFF", sizeof("SDIFF") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SINTER", sizeof("SINTER") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SISMEMBER", sizeof("SISMEMBER") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SMEMBERS", sizeof("SMEMBERS") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SRANDMEMBER", sizeof("SRANDMEMBER") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "STRLEN", sizeof("STRLEN") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "SUNION", sizeof("SUNION") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "TYPE", sizeof("TYPE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZCARD", sizeof("ZCARD") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZCOUNT", sizeof("ZCOUNT") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZRANGE", sizeof("ZRANGE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZRANK", sizeof("ZRANK") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZREVRANGE", sizeof("ZREVRANGE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZREVRANGEBYSCORE", sizeof("ZREVRANGEBYSCORE") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZREVRANK", sizeof("ZREVRANK") - 1, NULL);
-    zend_hash_str_update_ptr(ra->pure_cmds, "ZSCORE", sizeof("ZSCORE") - 1, NULL);
+    #define ra_add_pure_cmd(cmd) \
+        zend_hash_str_update_ptr(ra->pure_cmds, cmd, sizeof(cmd) - 1, NULL);
+
+    ra_add_pure_cmd("EXISTS");
+    ra_add_pure_cmd("GET");
+    ra_add_pure_cmd("GETBIT");
+    ra_add_pure_cmd("GETRANGE");
+    ra_add_pure_cmd("HEXISTS");
+    ra_add_pure_cmd("HGET");
+    ra_add_pure_cmd("HGETALL");
+    ra_add_pure_cmd("HKEYS");
+    ra_add_pure_cmd("HLEN");
+    ra_add_pure_cmd("HMGET");
+    ra_add_pure_cmd("HVALS");
+    ra_add_pure_cmd("LINDEX");
+    ra_add_pure_cmd("LLEN");
+    ra_add_pure_cmd("LRANGE");
+    ra_add_pure_cmd("OBJECT");
+    ra_add_pure_cmd("SCARD");
+    ra_add_pure_cmd("SDIFF");
+    ra_add_pure_cmd("SINTER");
+    ra_add_pure_cmd("SISMEMBER");
+    ra_add_pure_cmd("SMEMBERS");
+    ra_add_pure_cmd("SRANDMEMBER");
+    ra_add_pure_cmd("STRLEN");
+    ra_add_pure_cmd("SUNION");
+    ra_add_pure_cmd("TYPE");
+    ra_add_pure_cmd("ZCARD");
+    ra_add_pure_cmd("ZCOUNT");
+    ra_add_pure_cmd("ZRANGE");
+    ra_add_pure_cmd("ZRANK");
+    ra_add_pure_cmd("ZREVRANGE");
+    ra_add_pure_cmd("ZREVRANGEBYSCORE");
+    ra_add_pure_cmd("ZREVRANK");
+    ra_add_pure_cmd("ZSCORE");
+
+    #undef ra_add_pure_cmd
 }
 
 static int


### PR DESCRIPTION
Replace a lot of boilerplate code like:

```c
fn("string", sizeof("string") - 1);
```

With 

```c
fn(ZEND_STRL("string"))
```