### PR TITLE
Update tests so they can run in php-cgi.

### DIFF
--- a/tests/RedisArrayTest.php
+++ b/tests/RedisArrayTest.php
@@ -1,5 +1,6 @@
 <?php defined('PHPREDIS_TESTRUN') or die("Use TestRedis.php to run tests!\n");
-require_once(dirname($_SERVER['PHP_SELF'])."/TestSuite.php");
+
+require_once __DIR__ . "/TestSuite.php";
 
 define('REDIS_ARRAY_DATA_SIZE', 1000);
 define('REDIS_RA_DEFAULT_PORTS', [6379, 6380, 6381, 6382]);

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -1,5 +1,6 @@
 <?php defined('PHPREDIS_TESTRUN') or die("Use TestRedis.php to run tests!\n");
-require_once(dirname($_SERVER['PHP_SELF'])."/RedisTest.php");
+
+require_once __DIR__ . "/RedisTest.php";
 
 /**
  * Most RedisCluster tests should work the same as the standard Redis object
@@ -111,9 +112,9 @@ class Redis_Cluster_Test extends Redis_Test {
         if (($seeds = $this->loadSeedsFromHostPort($host, $port)))
             return $seeds;
 
-        fprintf(STDERR, "Error:  Unable to load seeds for RedisCluster tests\n");
+        TestSuite::errorMessage("Error:  Unable to load seeds for RedisCluster tests");
         foreach (self::$seed_messages as $msg) {
-            fprintf(STDERR, "   Tried: %s\n", $msg);
+            TestSuite::errorMessage("   Tried: %s", $msg);
         }
 
         exit(1);
@@ -139,9 +140,9 @@ class Redis_Cluster_Test extends Redis_Test {
         try {
             return new RedisCluster(NULL, self::$seeds, 30, 30, true, $this->getAuth());
         } catch (Exception $ex) {
-            fprintf(STDERR, "Fatal error: %s\n", $ex->getMessage());
-            fprintf(STDERR, "Seeds: %s\n", implode(' ', self::$seeds));
-            fprintf(STDERR, "Seed source: %s\n", self::$seed_source);
+            TestSuite::errorMessage("Fatal error: %s\n", $ex->getMessage());
+            TestSuite::errorMessage("Seeds: %s\n", implode(' ', self::$seeds));
+            TestSuite::errorMessage("Seed source: %s\n", self::$seed_source);
             exit(1);
         }
     }

--- a/tests/RedisSentinelTest.php
+++ b/tests/RedisSentinelTest.php
@@ -1,6 +1,6 @@
 <?php defined('PHPREDIS_TESTRUN') or die("Use TestRedis.php to run tests!\n");
 
-require_once(dirname($_SERVER['PHP_SELF'])."/TestSuite.php");
+require_once __DIR__ . "/TestSuite.php";
 
 class Redis_Sentinel_Test extends TestSuite
 {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1,7 +1,7 @@
 <?php defined('PHPREDIS_TESTRUN') or die('Use TestRedis.php to run tests!\n');
 
-require_once(dirname($_SERVER['PHP_SELF']).'/TestSuite.php');
-require_once(dirname($_SERVER['PHP_SELF']).'/SessionHelpers.php');
+require_once __DIR__ . '/TestSuite.php';
+require_once __DIR__ . '/SessionHelpers.php';
 
 class Redis_Test extends TestSuite {
     /**
@@ -7223,7 +7223,15 @@ class Redis_Test extends TestSuite {
             ->savePath($this->sessionSavePath());
     }
 
+    protected function testRequiresMode(string $mode) {
+        if (php_sapi_name() != $mode) {
+            $this->markTestSkipped("Test requires PHP running in '$mode' mode");
+        }
+    }
+
     public function testSession_compression() {
+        $this->testRequiresMode('cli');
+
         foreach ($this->getCompressors() as $name => $val) {
             $data = "testing_compression_$name";
 
@@ -7244,6 +7252,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_savedToRedis() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner();
 
         $this->assertEquals('SUCCESS', $runner->execFg());
@@ -7260,6 +7270,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockKeyCorrect() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()->sleep(5);
 
         $this->assertTrue($runner->execBg());
@@ -7272,6 +7284,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockingDisabledByDefault() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()
             ->lockingEnabled(false)
             ->sleep(5);
@@ -7281,6 +7295,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockReleasedOnClose() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()
             ->sleep(1)
             ->lockingEnabled(true);
@@ -7291,6 +7307,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lock_ttlMaxExecutionTime() {
+        $this->testRequiresMode('cli');
+
         $runner1 = $this->sessionRunner()
             ->sleep(10)
             ->maxExecutionTime(2);
@@ -7309,6 +7327,7 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lock_ttlLockExpire() {
+        $this->testRequiresMode('cli');
 
         $runner1 = $this->sessionRunner()
             ->sleep(10)
@@ -7329,6 +7348,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockHoldCheckBeforeWrite_otherProcessHasLock() {
+        $this->testRequiresMode('cli');
+
         $id = 'test-id';
 
         $runner = $this->sessionRunner()
@@ -7352,6 +7373,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockHoldCheckBeforeWrite_nobodyHasLock() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()
             ->sleep(2)
             ->lockingEnabled(true)
@@ -7363,6 +7386,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_correctLockRetryCount() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()
             ->sleep(10);
 
@@ -7394,6 +7419,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_defaultLockRetryCount() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()
             ->sleep(10);
 
@@ -7420,6 +7447,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_noUnlockOfOtherProcess() {
+        $this->testRequiresMode('cli');
+
         $st = microtime(true);
 
         $sleep = 3;
@@ -7453,6 +7482,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_lockWaitTime() {
+        $this->testRequiresMode('cli');
+
 
         $runner = $this->sessionRunner()
             ->sleep(1)
@@ -7603,6 +7634,8 @@ class Redis_Test extends TestSuite {
     }
 
     protected function regenerateIdHelper(bool $lock, bool $destroy, bool $proxy) {
+        $this->testRequiresMode('cli');
+
         $data   = uniqid('regenerate-id:');
         $runner = $this->sessionRunner()
             ->sleep(0)
@@ -7652,12 +7685,16 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_ttl_equalsToSessionLifetime() {
+        $this->testRequiresMode('cli');
+
         $runner = $this->sessionRunner()->lifetime(600);
         $this->assertEquals('SUCCESS', $runner->execFg());
         $this->assertEquals(600, $this->redis->ttl($runner->getSessionKey()));
     }
 
     public function testSession_ttl_resetOnWrite() {
+        $this->testRequiresMode('cli');
+
         $runner1 = $this->sessionRunner()->lifetime(600);
         $this->assertEquals('SUCCESS', $runner1->execFg());
 
@@ -7668,6 +7705,8 @@ class Redis_Test extends TestSuite {
     }
 
     public function testSession_ttl_resetOnRead() {
+        $this->testRequiresMode('cli');
+
         $data = uniqid(__FUNCTION__);
 
         $runner = $this->sessionRunner()->lifetime(600)->data($data);

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -1,10 +1,10 @@
 <?php define('PHPREDIS_TESTRUN', true);
 
-require_once(dirname($_SERVER['PHP_SELF'])."/TestSuite.php");
-require_once(dirname($_SERVER['PHP_SELF'])."/RedisTest.php");
-require_once(dirname($_SERVER['PHP_SELF'])."/RedisArrayTest.php");
-require_once(dirname($_SERVER['PHP_SELF'])."/RedisClusterTest.php");
-require_once(dirname($_SERVER['PHP_SELF'])."/RedisSentinelTest.php");
+require_once __DIR__ . "/TestSuite.php";
+require_once __DIR__ . "/RedisTest.php";
+require_once __DIR__ . "/RedisArrayTest.php";
+require_once __DIR__ . "/RedisClusterTest.php";
+require_once __DIR__ . "/RedisSentinelTest.php";
 
 function getClassArray($classes) {
     $result = [];

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -43,6 +43,16 @@ class TestSuite
     public function getPort() { return $this->port; }
     public function getAuth() { return $this->auth; }
 
+    public static function errorMessage(string $fmt, ...$args) {
+        $msg = vsprintf($fmt . "\n", $args);
+
+        if (defined('STDERR')) {
+            fwrite(STDERR, $msg);
+        } else {
+            echo $msg;
+        }
+    }
+
     public static function make_bold(string $msg) {
         return self::$colorize ? self::$BOLD_ON . $msg . self::$BOLD_OFF : $msg;
     }
@@ -516,7 +526,7 @@ class TestSuite
     /* Flag colorization */
     public static function flagColorization(bool $override) {
         self::$colorize = $override && function_exists('posix_isatty') &&
-            posix_isatty(STDOUT);
+                          defined('STDOUT') && posix_isatty(STDOUT);
     }
 
     public static function run($class_name, ?string $limit = NULL,


### PR DESCRIPTION
This probably isn't a very common scenerio since we've never had someone ask it in a decade, but it was very simple to get them working.

Primarily we just needed to test for `STDTOUT`/`STDERR` and use `__DIR__` instead of `$_SERVER['PHP_SELF']`.

Fixes #2507