### PR TITLE
More unit  test utility functions/usage.

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -148,7 +148,7 @@ class Redis_Test extends TestSuite {
         $this->tearDown();
     }
 
-    /* Helper function to determine if the clsas has pipeline support */
+    /* Helper function to determine if the class has pipeline support */
     protected function havePipeline() {
         return defined(get_class($this->redis) . '::PIPELINE');
     }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -125,8 +125,30 @@ class TestSuite
         self::$errors []= $this->assertionTrace($fmt, ...$args);
     }
 
-    protected function assertKeyExists($redis, $key): bool {
-        if ($redis->exists($key))
+    protected function assertKeyEquals($expected, $key, $redis = NULL): bool {
+        $actual = ($redis ??= $this->redis)->get($key);
+        if ($actual === $expected)
+            return true;
+
+        self::$errors []= $this->assertionTrace("%s !== %s", $this->printArg($actual),
+                                                $this->printArg($expected));
+
+        return false;
+    }
+
+    protected function assertKeyEqualsWeak($expected, $key, $redis = NULL): bool {
+        $actual = ($redis ??= $this->redis)->get($key);
+        if ($actual == $expected)
+            return true;
+
+        self::$errors []= $this->assertionTrace("%s != %s", $this->printArg($actual),
+                                                $this->printArg($expected));
+
+        return false;
+    }
+
+    protected function assertKeyExists($key, $redis = NULL): bool {
+        if (($redis ??= $this->redis)->exists($key))
             return true;
 
         self::$errors []= $this->assertionTrace("Key '%s' does not exist.", $key);
@@ -134,8 +156,8 @@ class TestSuite
         return false;
     }
 
-    protected function assertKeyMissing($redis, $key): bool {
-        if ( ! $redis->exists($key))
+    protected function assertKeyMissing($key, $redis = NULL): bool {
+        if ( ! ($redis ??= $this->redis)->exists($key))
             return true;
 
         self::$errors []= $this->assertionTrace("Key '%s' exists but shouldn't.", $key);


### PR DESCRIPTION
* Add `assertKeyEquals` and `assertKeyEqualsWeak` as we test key values hundreds of places in `RedisTest.php`

* We are almost always using `$this->redis` when we want to run an assertion that needs access to the client, so make this argument optional and default to `$this->redis`.

* Update a few more assertions to use our new methods.

* Various minor fixes/tweaks.