### PR TITLE
Add `GETEX` to README docs + minor change to command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ $redis->slowLog('len');
 * [bitOp](#bitop) - Perform bitwise operations between strings
 * [decr, decrBy](#decr-decrby) - Decrement the value of a key
 * [get](#get) - Get the value of a key
+* [getEx](#getex) - Get the value of a key and set its expiration
 * [getBit](#getbit) - Returns the bit value at offset in the string value stored at key
 * [getRange](#getrange) - Get a substring of the string stored at a key
 * [getSet](#getset) - Set the string value of a key and return its old value
@@ -839,6 +840,28 @@ _**Description**_: Get the value related to the specified key
 
 ~~~php
 $redis->get('key');
+~~~
+
+### getEx
+-----
+_**Description**_: Get the value related to the specified key and set its expiration
+
+##### *Parameters*
+*key* 
+*options array* (optional) with the following keys:
+  * `EX` - expire time in seconds
+  * `PX` - expire time in milliseconds
+  * `EXAT` - expire time in seconds since UNIX epoch
+  * `PXAT` - expire time in milliseconds since UNIX epoch
+  * `PERSIST` - remove the expiration from the key
+
+##### *Return value*
+*String* or *Bool*: If key didn't exist, `FALSE` is returned. Otherwise, the value related to this key is returned.
+
+##### *Examples*
+
+~~~php
+$redis->getEx('key', ['EX' => 10]); // get key and set its expiration to 10 seconds
 ~~~
 
 ### set

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -727,6 +727,10 @@ PHP_METHOD(RedisCluster, msetnx) {
 }
 /* }}} */
 
+PHP_METHOD(RedisCluster, getex) {
+    CLUSTER_PROCESS_CMD(getex, cluster_bulk_resp, 0);
+}
+
 /* {{{ proto bool RedisCluster::setex(string key, string value, int expiry) */
 PHP_METHOD(RedisCluster, setex) {
     CLUSTER_PROCESS_KW_CMD("SETEX", redis_key_long_val_cmd, cluster_bool_resp, 0);

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -391,6 +391,11 @@ class RedisCluster {
     public function get(string $key): mixed;
 
     /**
+     * @see Redis::getEx
+     */
+    public function getex(string $key, array $options = []): RedisCluster|string|false;
+
+    /**
      * @see Redis::getbit
      */
     public function getbit(string $key, int $value): RedisCluster|int|false;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c19108e54b637b6c76a529c1285104a0c38da220 */
+ * Stub hash: 5713c5b2f88ddead50088f14026447801120fa33 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -323,6 +323,11 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_getex, 0, 1, RedisCluster, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_getbit arginfo_class_RedisCluster_decrby
@@ -1109,6 +1114,7 @@ ZEND_METHOD(RedisCluster, georadiusbymember_ro);
 ZEND_METHOD(RedisCluster, geosearch);
 ZEND_METHOD(RedisCluster, geosearchstore);
 ZEND_METHOD(RedisCluster, get);
+ZEND_METHOD(RedisCluster, getex);
 ZEND_METHOD(RedisCluster, getbit);
 ZEND_METHOD(RedisCluster, getlasterror);
 ZEND_METHOD(RedisCluster, getmode);
@@ -1335,6 +1341,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, geosearch, arginfo_class_RedisCluster_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, geosearchstore, arginfo_class_RedisCluster_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, get, arginfo_class_RedisCluster_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, getex, arginfo_class_RedisCluster_getex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getbit, arginfo_class_RedisCluster_getbit, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getlasterror, arginfo_class_RedisCluster_getlasterror, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getmode, arginfo_class_RedisCluster_getmode, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c19108e54b637b6c76a529c1285104a0c38da220 */
+ * Stub hash: 5713c5b2f88ddead50088f14026447801120fa33 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -295,6 +295,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_get arginfo_class_RedisCluster__prefix
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_getex, 0, 0, 1)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_RedisCluster_getbit arginfo_class_RedisCluster_append
 
 #define arginfo_class_RedisCluster_getlasterror arginfo_class_RedisCluster__masters
@@ -363,10 +368,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hscan, 0, 0, 2)
 	ZEND_ARG_INFO(0, count)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hrandfield, 0, 0, 1)
-	ZEND_ARG_INFO(0, key)
-	ZEND_ARG_INFO(0, options)
-ZEND_END_ARG_INFO()
+#define arginfo_class_RedisCluster_hrandfield arginfo_class_RedisCluster_getex
 
 #define arginfo_class_RedisCluster_hset arginfo_class_RedisCluster_hincrby
 
@@ -636,9 +638,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_smove, 0, 0, 3)
 	ZEND_ARG_INFO(0, member)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_RedisCluster_sort arginfo_class_RedisCluster_hrandfield
+#define arginfo_class_RedisCluster_sort arginfo_class_RedisCluster_getex
 
-#define arginfo_class_RedisCluster_sort_ro arginfo_class_RedisCluster_hrandfield
+#define arginfo_class_RedisCluster_sort_ro arginfo_class_RedisCluster_getex
 
 #define arginfo_class_RedisCluster_spop arginfo_class_RedisCluster_lpop
 
@@ -824,7 +826,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zrangestore, 0, 0, 4)
 	ZEND_ARG_INFO(0, options)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_RedisCluster_zrandmember arginfo_class_RedisCluster_hrandfield
+#define arginfo_class_RedisCluster_zrandmember arginfo_class_RedisCluster_getex
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zrangebylex, 0, 0, 3)
 	ZEND_ARG_INFO(0, key)
@@ -954,6 +956,7 @@ ZEND_METHOD(RedisCluster, georadiusbymember_ro);
 ZEND_METHOD(RedisCluster, geosearch);
 ZEND_METHOD(RedisCluster, geosearchstore);
 ZEND_METHOD(RedisCluster, get);
+ZEND_METHOD(RedisCluster, getex);
 ZEND_METHOD(RedisCluster, getbit);
 ZEND_METHOD(RedisCluster, getlasterror);
 ZEND_METHOD(RedisCluster, getmode);
@@ -1180,6 +1183,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, geosearch, arginfo_class_RedisCluster_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, geosearchstore, arginfo_class_RedisCluster_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, get, arginfo_class_RedisCluster_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, getex, arginfo_class_RedisCluster_getex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getbit, arginfo_class_RedisCluster_getbit, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getlasterror, arginfo_class_RedisCluster_getlasterror, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getmode, arginfo_class_RedisCluster_getmode, ZEND_ACC_PUBLIC)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2476,6 +2476,11 @@ redis_getex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     persist = zval_is_true(z_ele);
                     exp_type = NULL;
                 }
+            } else if (Z_TYPE_P(z_ele) == IS_STRING &&
+                       zend_string_equals_literal_ci(Z_STR_P(z_ele), "PERSIST"))
+            {
+                persist = zval_is_true(z_ele);
+                exp_type = NULL;
             }
         } ZEND_HASH_FOREACH_END();
     }


### PR DESCRIPTION
* Adds `GETEX` to the README.md documentation.
* Allow the user to send `PERSIST` either as an array key or just in the array, to conform with similar methods.
* Implement getEx for `RedisCluster`

Fixes #2512