### PR TITLE
Fix HRANDFIELD command when WITHVALUES is used.

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1798,7 +1798,7 @@ class Redis {
      * @example $redis->hrandfield('settings');
      * @example $redis->hrandfield('settings', ['count' => 2, 'withvalues' => true]);
      */
-    public function hRandField(string $key, ?array $options = null): Redis|string|array;
+    public function hRandField(string $key, ?array $options = null): Redis|string|array|false;
 
     public function hSet(string $key, string $member, mixed $value): Redis|int|false;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 04fe88bbcc4d3dc3be06385e8931dfb080442f23 */
+ * Stub hash: 70b942571cb2e3ef0b2531492840d9207f693b00 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -434,7 +434,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Red
 	ZEND_ARG_TYPE_INFO(0, fieldvals, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hRandField, 0, 1, Redis, MAY_BE_STRING|MAY_BE_ARRAY)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hRandField, 0, 1, Redis, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
@@ -1069,7 +1069,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zrangestore, 0, 
 	ZEND_ARG_TYPE_MASK(0, options, MAY_BE_ARRAY|MAY_BE_BOOL|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_zRandMember arginfo_class_Redis_hRandField
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zRandMember, 0, 1, Redis, MAY_BE_STRING|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_zRank, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3577,9 +3577,17 @@ redis_hrandfield_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 } else if (zend_string_equals_literal_ci(zkey, "withvalues")) {
                     withvalues = zval_is_true(z_ele);
                 }
+            } else if (Z_TYPE_P(z_ele) == IS_STRING) {
+                if (zend_string_equals_literal_ci(Z_STR_P(z_ele), "WITHVALUES")) {
+                    withvalues = 1;
+                }
             }
         } ZEND_HASH_FOREACH_END();
     }
+
+    /* If we're sending WITHVALUES we must also send a count */
+    if (count == 0 && withvalues)
+        count = 1;
 
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, 1 + (count != 0) + withvalues, "HRANDFIELD");
     redis_cmd_append_sstr_key(&cmdstr, key, key_len, redis_sock, slot);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 04fe88bbcc4d3dc3be06385e8931dfb080442f23 */
+ * Stub hash: 70b942571cb2e3ef0b2531492840d9207f693b00 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3255,6 +3255,16 @@ class Redis_Test extends TestSuite {
         $result = $this->redis->hRandField('key', ['count' => 2, 'withvalues' => true]);
         $this->assertEquals(2, count($result));
         $this->assertEquals(array_intersect_key($result, ['a' => 0, 'b' => 1, 'c' => 'foo', 'd' => 'bar', 'e' => null]), $result);
+
+        /* Make sure PhpRedis sends COUNt (1) when `WITHVALUES` is set */
+        $result = $this->redis->hRandField('key', ['withvalues' => true]);
+        $this->assertNull($this->redis->getLastError());
+        $this->assertIsArray($result);
+        $this->assertEquals(1, count($result));
+
+        /* We can return false if the key doesn't exist */
+        $this->assertIsInt($this->redis->del('notahash'));
+        $this->assertFalse($this->redis->hRandField('notahash'));
     }
 
     public function testSetRange() {


### PR DESCRIPTION
Redis requires the user to send a count if `WITHVALUES` is specified, otherwise it sees the `WITHVALUES` argument as the count and will error out that it's not a number.