### PR TITLE
SRANDMEMBER can return any type because of serialization.

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -2826,7 +2826,7 @@ class Redis {
      * @example $redis->sRandMember('myset', 10);
      * @example $redis->sRandMember('myset', -10);
      */
-    public function sRandMember(string $key, int $count = 0): Redis|string|array|false;
+    public function sRandMember(string $key, int $count = 0): mixed;
 
     /**
      * Returns the union of one or more Redis SET keys.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70b942571cb2e3ef0b2531492840d9207f693b00 */
+ * Stub hash: a888154a03dc0edbe479e0226f012a34c7cb4100 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -750,7 +750,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_sPop, 0, 1, Redi
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_sRandMember arginfo_class_Redis_sPop
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_sRandMember, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_sUnion arginfo_class_Redis_sDiff
 

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70b942571cb2e3ef0b2531492840d9207f693b00 */
+ * Stub hash: a888154a03dc0edbe479e0226f012a34c7cb4100 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1697,6 +1697,13 @@ class Redis_Test extends TestSuite {
             $this->assertInArray($reply_mem, $mems);
         }
 
+        /* Ensure we can handle basically any return type */
+        foreach ([3.1415, new stdClass(), 42, 'hello', NULL] as $val) {
+            $this->assertEquals(1, $this->redis->del('set0'));
+            $this->assertEquals(1, $this->redis->sadd('set0', $val));
+            $this->assertSameType($val, $this->redis->srandmember('set0'));
+        }
+
         $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
     }
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -237,6 +237,15 @@ class TestSuite
         return false;
     }
 
+    protected function assertIsFloat($v): bool {
+        if (is_float($v))
+            return true;
+
+        self::$errors []= $this->assertionTrace("%s is not a float", $this->printArg($v));
+
+        return false;
+    }
+
     protected function assertIsObject($v, ?string $type = NULL): bool {
         if ( ! is_object($v)) {
             self::$errors []= $this->assertionTrace("%s is not an object", $this->printArg($v));
@@ -248,6 +257,17 @@ class TestSuite
         }
 
         return true;
+    }
+
+    protected function assertSameType($expected, $actual): bool {
+        if (gettype($expected) === gettype($actual))
+            return true;
+
+        self::$errors []= $this->assertionTrace("%s is not the same type as %s",
+                                                $this->printArg($actual),
+                                                $this->printArg($expected));
+
+        return false;
     }
 
     protected function assertIsArray($v, ?int $size = null): bool {


### PR DESCRIPTION
Mac CI failures seem to be a problem with `setup-php`.

Edit:  https://github.com/shivammathur/setup-php/issues/857