### PR TITLE
Fix argument count issue in HSET with associative array, update method signature for HSET and add documentation

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1800,7 +1800,21 @@ class Redis {
      */
     public function hRandField(string $key, ?array $options = null): Redis|string|array|false;
 
-    public function hSet(string $key, string $member, mixed $value): Redis|int|false;
+    /**
+     * Add or update one or more hash fields and values.
+     *
+     * @param string $key             The hash to create/update.
+     * @param mixed  $fields_and_vals Argument pairs of fields and values. Alternatively, an associative array with the
+     *                                fields and their values.
+     *
+     * @return Redis|int|false The number of fields that were added, or false on failure.
+     *
+     * @see https://redis.io/commands/hset/
+     *
+     * @example $redis->hSet('player:1', 'name', 'Kim', 'score', 78);
+     * @example $redis->hSet('player:1', ['name' => 'Kim', 'score' => 78]);
+     */
+    public function hSet(string $key, mixed ...$fields_and_vals): Redis|int|false;
 
     /**
      * Set a hash field and value, but only if that field does not exist

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a888154a03dc0edbe479e0226f012a34c7cb4100 */
+ * Stub hash: 1cc5fe0df8dfa7d95f2bc45c2383132a68629f24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -439,10 +439,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hRandField, 0, 1
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hSet, 0, 3, Redis, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hSet, 0, 1, Redis, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, member, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, fields_and_vals, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hSetNx, 0, 3, Redis, MAY_BE_BOOL)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -3481,7 +3481,7 @@ int redis_hset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         }
 
         /* Initialize our command */
-        redis_cmd_init_sstr(&cmdstr, 1 + zend_hash_num_elements(Z_ARRVAL(z_args[1])), ZEND_STRL("HSET"));
+        redis_cmd_init_sstr(&cmdstr, 1 + zend_hash_num_elements(Z_ARRVAL(z_args[1])) * 2, ZEND_STRL("HSET"));
 
         /* Append key */
         zkey = zval_get_string(&z_args[0]);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a888154a03dc0edbe479e0226f012a34c7cb4100 */
+ * Stub hash: 1cc5fe0df8dfa7d95f2bc45c2383132a68629f24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -395,10 +395,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_hRandField arginfo_class_Redis_getEx
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hSet, 0, 0, 3)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hSet, 0, 0, 1)
 	ZEND_ARG_INFO(0, key)
-	ZEND_ARG_INFO(0, member)
-	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_VARIADIC_INFO(0, fields_and_vals)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_hSetNx arginfo_class_Redis_hIncrBy

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3237,6 +3237,24 @@ class Redis_Test extends TestSuite {
         $this->assertEquals('Object', $h1['z']);
         $this->assertEquals('', $h1['t']);
 
+        // hset with fields + values as an associative array
+        if (version_compare($this->version, '4.0.0') >= 0) {
+            $this->redis->del('h');
+            $this->assertEquals(3, $this->redis->hSet('h', ['x' => 123, 'y' => 456, 'z' => 'abc']));
+            $this->assertEquals(['x' => '123', 'y' => '456', 'z' => 'abc'], $this->redis->hGetAll('h'));
+            $this->assertEquals(0, $this->redis->hSet('h', ['x' => 789]));
+            $this->assertEquals(['x' => '789', 'y' => '456', 'z' => 'abc'], $this->redis->hGetAll('h'));
+        }
+
+        // hset with variadic fields + values
+        if (version_compare($this->version, '4.0.0') >= 0) {
+            $this->redis->del('h');
+            $this->assertEquals(3, $this->redis->hSet('h', 'x', 123, 'y', 456, 'z', 'abc'));
+            $this->assertEquals(['x' => '123', 'y' => '456', 'z' => 'abc'], $this->redis->hGetAll('h'));
+            $this->assertEquals(0, $this->redis->hSet('h', 'x', 789));
+            $this->assertEquals(['x' => '789', 'y' => '456', 'z' => 'abc'], $this->redis->hGetAll('h'));
+        }
+
         // hstrlen
         if (version_compare($this->version, '3.2.0') >= 0) {
             $this->redis->del('h');


### PR DESCRIPTION
Code changes:
- Fix an issue where the command string for HSET with an associative array has the wrong number of arguments, causing fields and values to be stripped from the command sent to Redis.

Documentation changes:
- Change the method signature for `hSet()` in the stub to reflect the fact that `hSet()` now accepts an arbitrary number of fields and values, rather than just one field and one value.
- Add PHPDoc for `hSet()`, with parameter descriptions, return value description, and examples.

Changes in tests:
- Add test cases for HSET with associative array and HSET with multiple field + value pairs. Requires Redis version 4.0.0 or later, as per the Redis documentation for HSET.

If you prefer to have these split into multiple PRs, let me know.