### PR TITLE
Add false as possible return value in stub for some get-type connection metadata methods

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -813,7 +813,7 @@ class Redis {
      * Reset any last error on the connection to NULL
      *
      * @see Redis::getLastError()
-     * @return bool This should always return true or throw an exception if we're not connected.
+     * @return bool False if not connected, otherwise always true.
      *
      * @example
      * $redis = new Redis(['host' => 'localhost']);
@@ -1444,7 +1444,7 @@ class Redis {
     /**
      * Get the authentication information on the connection, if any.
      *
-     * @return mixed The authentication information used to authenticate the connection.
+     * @return mixed The authentication information used to authenticate the connection, or false if not connected.
      *
      * @see Redis::auth()
      */
@@ -1490,12 +1490,12 @@ class Redis {
      *
      * This value is updated internally in PhpRedis each time {@link Redis::select} is called.
      *
-     * @return The database we're connected to.
+     * @return int|false The database we're connected to, or false if not connected.
      *
      * @see Redis::select()
      * @see https://redis.io/commands/select
      */
-    public function getDBNum(): int;
+    public function getDBNum(): int|false;
 
     /**
      * Get a key from Redis and delete it in an atomic operation.
@@ -1512,24 +1512,24 @@ class Redis {
     /**
      * Return the host or Unix socket we are connected to.
      *
-     * @return string The host or Unix socket.
+     * @return string|false The host or Unix socket, or false if not connected.
      */
-    public function getHost(): string;
+    public function getHost(): string|false;
 
     /**
      * Get the last error returned to us from Redis, if any.
      *
-     * @return string The error string or NULL if there is none.
+     * @return string|null|false The error string or NULL if there is none, or false if not connected.
      */
-    public function getLastError(): ?string;
+    public function getLastError(): string|null|false;
 
     /**
      * Returns whether the connection is in ATOMIC, MULTI, or PIPELINE mode
      *
-     * @return int The mode we're in.
+     * @return int|false The mode we're in, or false if not connected.
      *
      */
-    public function getMode(): int;
+    public function getMode(): int|false;
 
     /**
      * Retrieve the value of a configuration setting as set by Redis::setOption()
@@ -1543,16 +1543,16 @@ class Redis {
     /**
      * Get the persistent connection ID, if there is one.
      *
-     * @return string The ID or NULL if we don't have one.
+     * @return string|null|false The ID or NULL if we don't have one, or false if not connected.
      */
-    public function getPersistentID(): ?string;
+    public function getPersistentID(): string|null|false;
 
     /**
      * Get the port we are connected to.  This number will be zero if we are connected to a unix socket.
      *
-     * @return int The port.
+     * @return int|false The port, or false if not connected.
      */
-    public function getPort(): int;
+    public function getPort(): int|false;
 
     /**
      * Retrieve a substring of a string by index.
@@ -1607,9 +1607,9 @@ class Redis {
     /**
      * Get the currently set read timeout on the connection.
      *
-     * @return float The timeout.
+     * @return float|false The timeout, or false if not connected.
      */
-    public function getReadTimeout(): float;
+    public function getReadTimeout(): float|false;
 
     /**
      * Sets a key and returns any previously set value, if the key already existed.
@@ -1630,7 +1630,7 @@ class Redis {
     /**
      * Retrieve any set connection timeout
      *
-     * @return float The currently set timeout or false on failure (e.g. we aren't connected).
+     * @return float|false The currently set timeout or false on failure (e.g. we aren't connected).
      */
     public function getTimeout(): float|false;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1cc5fe0df8dfa7d95f2bc45c2383132a68629f24 */
+ * Stub hash: a7663c7c53835cd982e056ae4783c1dde1b1e65a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -336,17 +336,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getEx, 0, 1, Red
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getDBNum, 0, 0, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getDBNum, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getDel, 0, 1, Redis, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getHost, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getHost, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getLastError, 0, 0, IS_STRING, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getLastError, 0, 0, MAY_BE_STRING|MAY_BE_NULL|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_getMode arginfo_class_Redis_getDBNum
@@ -371,7 +371,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_lcs, 0, 2, Redis
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getReadTimeout, 0, 0, IS_DOUBLE, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getReadTimeout, 0, 0, MAY_BE_DOUBLE|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getset, 0, 2, Redis, MAY_BE_STRING|MAY_BE_FALSE)
@@ -379,8 +379,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getset, 0, 2, Re
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_getTimeout, 0, 0, MAY_BE_DOUBLE|MAY_BE_FALSE)
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_getTimeout arginfo_class_Redis_getReadTimeout
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getTransferredBytes, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -535,7 +534,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_lSet, 0, 3, Redi
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_lastSave arginfo_class_Redis_getDBNum
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_lastSave, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_lindex, 0, 2, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1cc5fe0df8dfa7d95f2bc45c2383132a68629f24 */
+ * Stub hash: a7663c7c53835cd982e056ae4783c1dde1b1e65a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)


### PR DESCRIPTION
These methods return `false` if we're not connected. This should be reflected in the stub and arginfo.

I'm sure that the same applies to many other methods as well, but here I've focused on the `get*()` methods that return metadata about the connection.