### PR TITLE
add missing SessionHelpers.php in pecl package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -209,6 +209,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
      <file role='test' name='getSessionData.php'/>
      <file role='test' name='regenerateSessionId.php'/>
      <file role='test' name='startSession.php'/>
+     <file role='test' name='SessionHelpers.php'/>
      <file role='test' name='make-cluster.sh'/>
      <file role='test' name='mkring.sh'/>
    </dir> <!-- tests -->


### PR DESCRIPTION
Cannot run test suite without this file

```
+ /usr/bin/php --no-php-ini --define extension=igbinary.so --define extension=msgpack.so --define extension=/dev/shm/BUILDROOT/php-pecl-redis6-6.1.0~RC1-1.fc39.remi.8.2.x86_64/usr/lib64/php/modules/redis.so TestRedis.php

Warning: require_once(/dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/SessionHelpers.php): Failed to open stream: No such file or directory in /dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/RedisTest.php on line 4

Fatal error: Uncaught Error: Failed opening required '/dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/SessionHelpers.php' (include_path='.:/usr/share/pear:/usr/share/php') in /dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/RedisTest.php:4
Stack trace:
#0 /dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/TestRedis.php(4): require_once()
#1 {main}
  thrown in /dev/shm/BUILD/php-pecl-redis6-6.1.0~RC1/redis-6.1.0RC1/tests/RedisTest.php on line 4

```

`users.acl` and `vg.supp` are also not packaged, but only used by CI, so fine to ignore