### PR TITLE
Remove erroneously duplicated changelog entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,18 +97,6 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - the VALUE argument type for hSetNx must be the same as for hSet
   [df074dbe](https://github.com/phpredis/phpredis/commit/df074dbe)
   ([Uładzimir Tsykun](https://github.com/vtsykun))
-- Fix `PSUBSCRIBE` to find callback by pattern not string literal.
-  [2f276dcd](https://github.com/phpredis/phpredis/commit/2f276dcd)
-  ([michael-grunder](https://github.com/michael-grunder))
-  [#2395](https://github.com/phpredis/phpredis/pull/2395)
-- Fix memory leak and segfault in Redis::exec
-  [362e1141](https://github.com/phpredis/phpredis/commit/362e1141)
-  ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
-- Fix unknown expiration modifier warning when null argument passed
-  [264c0c7e](https://github.com/phpredis/phpredis/commit/264c0c7e)
-  [3eb60f58](https://github.com/phpredis/phpredis/commit/3eb60f58)
-  [#2388](https://github.com/phpredis/phpredis/pull/2388)
-  ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 - Other fixes
   [e18f6c6d](https://github.com/phpredis/phpredis/commit/e18f6c6d)
   [3d7be358](https://github.com/phpredis/phpredis/commit/3d7be358)
@@ -178,8 +166,6 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [8f8ff72a](https://github.com/phpredis/phpredis/commit/8f8ff72a)
   ([Takayasu Oyama](https://github.com/taka-oyama))
   [5d293245](https://github.com/phpredis/phpredis/commit/5d293245)
-  [95bd184b](https://github.com/phpredis/phpredis/commit/95bd184b)
-  ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
 - Fix config.m4 when using custom dep paths
   [ece3f7be](https://github.com/phpredis/phpredis/commit/ece3f7be)
   ([Michael Grunder](https://github.com/michael-grunder))
@@ -203,9 +189,6 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [dc05d65c](https://github.com/phpredis/phpredis/commit/dc05d65c)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
   [#2381](https://github.com/phpredis/phpredis/pull/2381)
-- Add back old examples with note
-  [1ad95b63](https://github.com/phpredis/phpredis/commit/1ad95b63)
-  ([Joost](https://github.com/OrangeJuiced))
 
 ### Tests/CI
 
@@ -271,12 +254,6 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [e051a5db](https://github.com/phpredis/phpredis/commit/e051a5db)
   [#2427](https://github.com/phpredis/phpredis/pull/2427)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
-- Fix deprecation error when passing null to match_type parameter
-  [b835aaa3](https://github.com/phpredis/phpredis/commit/b835aaa3)
-  ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
-- Fix crash in `OBJECT` command in pipeline.
-  [a7f51f70](https://github.com/phpredis/phpredis/commit/a7f51f70)
-  ([michael-grunder](https://github.com/michael-grunder))
 - Use newInstance in RedisClusterTest
   [954fbab8](https://github.com/phpredis/phpredis/commit/954fbab8)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
@@ -294,12 +271,6 @@ and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   [2bddd84f](https://github.com/phpredis/phpredis/commit/2bddd84f)
   ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
   [#2378](https://github.com/phpredis/phpredis/pull/2378)
-- Update sentinel documentation to reflect changes to constructor in 6.0 release
-  [849bedb6](https://github.com/phpredis/phpredis/commit/849bedb6)
-  ([Joost](https://github.com/OrangeJuiced))
-- Add missing option to example
-  [3674d663](https://github.com/phpredis/phpredis/commit/3674d663)
-  ([Till Krüss](https://github.com/tillkruss))
 - Fix typo in link
   [8f6bc98f](https://github.com/phpredis/phpredis/commit/8f6bc98f)
   ([Timo Sand](https://github.com/deiga))

--- a/package.xml
+++ b/package.xml
@@ -69,11 +69,6 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Fix segfault when passing just false to auth. [6dc0a0be] (Michael Grunder)
     * the VALUE argument type for hSetNx must be the same as for hSet [df074dbe]
       (Uladzimir Tsykun)
-    * Fix `PSUBSCRIBE` to find callback by pattern not string literal. [2f276dcd]
-      (Michael Grunder)
-    * Fix memory leak and segfault in Redis::exec [362e1141] (Pavlo Yatsukhnenko)
-    * Fix unknown expiration modifier warning when null argument passed [264c0c7e,
-      3eb60f58] (Pavlo Yatsukhnenko)
     * Other fixes [e18f6c6d, 3d7be358, 2b555c89, fa1a283a, 37c5f8d4] (Michael Grunder, Viktor Szepe)
 
     Added:
@@ -101,8 +96,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Add session.save_path examples [8a39caeb] (Martin Vancl)
     * Tighter return types for Redis::(keys|hKeys|hVals|hGetAll) [77ab62bc]
       (Benjamin Morel)
-    * Update stubs [4d233977, ff305349, 12966a74, a4a283ab, 8f8ff72a, 5d293245,
-      95bd184b] (Michael Grunder, Takayasu Oyama, Pavlo Yatsukhnenko)
+    * Update stubs [4d233977, ff305349, 12966a74, a4a283ab, 8f8ff72a] 
+      (Michael Grunder, Takayasu Oyama, Pavlo Yatsukhnenko)
     * Fix config.m4 when using custom dep paths [ece3f7be] (Michael Grunder)
     * Fix retry_internal documentation [142c1f4a] (SplotyCode)
     * Fix anchor link [9b5cad31] (Git'Fellow)
@@ -110,7 +105,6 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Fix Fedora package url [60b1ba14, 717713e1] (Dmitrii Kotov)
     * Update Redis Sentinel documentation to reflect changes to constructor in 6.0
       release [dc05d65c] (Pavlo Yatsukhnenko)
-    * Add back old examples with note [1ad95b63] (Joost)
 
     Tests/CI:
 
@@ -129,18 +123,12 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * sessionSaveHandler injection. [9f8f80ca] (Pavlo Yatsukhnenko)
     * KeyDB addiions [54d62c72, d9c48b78] (Michael Grunder)
     * Add PHP 8.3 to CI [78d15140, e051a5db] (Robert Kelcak, Pavlo Yatsukhnenko)
-    * Fix deprecation error when passing null to match_type parameter [b835aaa3]
-      (Pavlo Yatsukhnenko)
-    * Fix crash in `OBJECT` command in pipeline. [a7f51f70] (Michael Grunder)
     * Use newInstance in RedisClusterTest [954fbab8] (Pavlo Yatsukhnenko)
     * Use actions/checkout@v4 [f4c2ac26] (Pavlo Yatsukhnenko)
     * Cluster nodes from ENV [eda39958, 0672703b] (Pavlo Yatsukhnenko)
     * Ensure we're talking to redis-server in our high ports test. [7825efbc]
       (Michael Grunder)
     * Add missing option to installation example [2bddd84f] (Pavlo Yatsukhnenko)
-    * Update sentinel documentation to reflect changes to constructor in 6.0 release
-      [849bedb6] (Joost)
-    * Add missing option to example [3674d663] (Till Kruss)
     * Fix typo in link [8f6bc98f] (Timo Sand)
     * Update tests to allow users to use a custom class. [5f6ce414] (Michael Grunder)
  </notes>
@@ -277,11 +265,6 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Fix segfault when passing just false to auth. [6dc0a0be] (Michael Grunder)
     * the VALUE argument type for hSetNx must be the same as for hSet [df074dbe]
       (Uladzimir Tsykun)
-    * Fix `PSUBSCRIBE` to find callback by pattern not string literal. [2f276dcd]
-      (Michael Grunder)
-    * Fix memory leak and segfault in Redis::exec [362e1141] (Pavlo Yatsukhnenko)
-    * Fix unknown expiration modifier warning when null argument passed [264c0c7e,
-      3eb60f58] (Pavlo Yatsukhnenko)
     * Other fixes [e18f6c6d, 3d7be358, 2b555c89, fa1a283a, 37c5f8d4] (Michael Grunder, Viktor Szepe)
 
     Added:
@@ -309,8 +292,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Add session.save_path examples [8a39caeb] (Martin Vancl)
     * Tighter return types for Redis::(keys|hKeys|hVals|hGetAll) [77ab62bc]
       (Benjamin Morel)
-    * Update stubs [4d233977, ff305349, 12966a74, a4a283ab, 8f8ff72a, 5d293245,
-      95bd184b] (Michael Grunder, Takayasu Oyama, Pavlo Yatsukhnenko)
+    * Update stubs [4d233977, ff305349, 12966a74, a4a283ab, 8f8ff72a, 5d293245] 
+      (Michael Grunder, Takayasu Oyama, Pavlo Yatsukhnenko)
     * Fix config.m4 when using custom dep paths [ece3f7be] (Michael Grunder)
     * Fix retry_internal documentation [142c1f4a] (SplotyCode)
     * Fix anchor link [9b5cad31] (Git'Fellow)
@@ -318,7 +301,6 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * Fix Fedora package url [60b1ba14, 717713e1] (Dmitrii Kotov)
     * Update Redis Sentinel documentation to reflect changes to constructor in 6.0
       release [dc05d65c] (Pavlo Yatsukhnenko)
-    * Add back old examples with note [1ad95b63] (Joost)
 
     Tests/CI:
 
@@ -337,18 +319,12 @@ http://pear.php.net/dtd/package-2.0.xsd">
     * sessionSaveHandler injection. [9f8f80ca] (Pavlo Yatsukhnenko)
     * KeyDB addiions [54d62c72, d9c48b78] (Michael Grunder)
     * Add PHP 8.3 to CI [78d15140, e051a5db] (Robert Kelcak, Pavlo Yatsukhnenko)
-    * Fix deprecation error when passing null to match_type parameter [b835aaa3]
-      (Pavlo Yatsukhnenko)
-    * Fix crash in `OBJECT` command in pipeline. [a7f51f70] (Michael Grunder)
     * Use newInstance in RedisClusterTest [954fbab8] (Pavlo Yatsukhnenko)
     * Use actions/checkout@v4 [f4c2ac26] (Pavlo Yatsukhnenko)
     * Cluster nodes from ENV [eda39958, 0672703b] (Pavlo Yatsukhnenko)
     * Ensure we're talking to redis-server in our high ports test. [7825efbc]
       (Michael Grunder)
     * Add missing option to installation example [2bddd84f] (Pavlo Yatsukhnenko)
-    * Update sentinel documentation to reflect changes to constructor in 6.0 release
-      [849bedb6] (Joost)
-    * Add missing option to example [3674d663] (Till Kruss)
     * Fix typo in link [8f6bc98f] (Timo Sand)
     * Update tests to allow users to use a custom class. [5f6ce414] (Michael Grunder)
    </notes>


### PR DESCRIPTION
When constructing the 6.1.0RC1 CHANGELOG.md and package.xml a few commits from older releases were accidentally included.

See #2474