### PR TITLE
Fix SIGABRT in PHP 8.4

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2995,7 +2995,7 @@ static zend_string **get_valid_seeds(HashTable *input, uint32_t *nseeds) {
         }
 
         /* Add as a key to avoid duplicates */
-        zend_hash_str_update_ptr(valid, Z_STRVAL_P(z_seed), Z_STRLEN_P(z_seed), NULL);
+        zend_hash_str_add_empty_element(valid, Z_STRVAL_P(z_seed), Z_STRLEN_P(z_seed));
     } ZEND_HASH_FOREACH_END();
 
     /* We need at least one valid seed */


### PR DESCRIPTION
PHP switched from `ZEND_ASSUME` to `ZEND_ASSERT` when making sure `Z_PTR_P(zv)` was nonnull in `zend_hash_str_update_ptr`.

This commit just switches to `zend_hash_str_add_empty_element` which is semantically more correct anyway.

Fixes #2539