### PR TITLE
fix 2 tests with redis 6.2

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -245,7 +245,7 @@ class Redis_Test extends TestSuite {
         $this->redis->set('bitcountkey', hex2bin('10eb8939e68bfdb640260f0629f3'));
         $this->assertEquals(1, $this->redis->bitcount('bitcountkey', 8, 8, false));
 
-        if ( ! $this->is_keydb) {
+        if ( ! $this->is_keydb && $this->minVersionCheck('7.0')) {
             /* key, start, end, BIT */
             $this->redis->set('bitcountkey', hex2bin('cd0e4c80f9e4590d888a10'));
             $this->assertEquals(5, $this->redis->bitcount('bitcountkey', 0, 9, true));
@@ -7625,7 +7625,7 @@ class Redis_Test extends TestSuite {
         $this->assertIsArray($commands);
         $this->assertEquals(count($commands), $this->redis->command('count'));
 
-        if ( ! $this->is_keydb) {
+        if ( ! $this->is_keydb && $this->minVersionCheck('7.0')) {
             $infos = $this->redis->command('info');
             $this->assertIsArray($infos);
             $this->assertEquals(count($infos), count($commands));


### PR DESCRIPTION
Using redis 6.2 (default version in RHEL-9)

```
Assertion failed: testBitcount - (false) !== 5
                  /builddir/build/BUILD/php-pecl-redis6-6.1.0~RC2/redis-6.1.0RC2/tests/RedisTest.php:251 (testBitcount) (false) !== 5
Assertion failed: testCommand - 224 !== 0
                  /builddir/build/BUILD/php-pecl-redis6-6.1.0~RC2/redis-6.1.0RC2/tests/RedisTest.php:7631 (testCommand) 224 !== 0

```

From documentation

**BITCOUNT**
```
    Starting with Redis version 7.0.0: Added the BYTE|BIT option.
```

**COMMAND**
```
    Starting with Redis version 7.0.0: Allowed to be called with no argument to get info on all commands.
```

So skip both usage when running test suite with redis 6.2