### PR TITLE
Create a strncmp wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           grep "REDIS_SHARED_LIBADD.*-L$GITHUB_WORKSPACE/libzstd" Makefile
 
   ubuntu:
-    runs-on: ubuntu:23.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     strategy:
       fail-fast: false

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1908,17 +1908,17 @@ PHP_REDIS_API void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
     }
 
     // Switch on the type
-    if (strncmp (c->line_reply, "string", 6) == 0) {
+    if (redis_strncmp(c->line_reply, ZEND_STRL("string")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_STRING);
-    } else if (strncmp(c->line_reply, ZEND_STRL("set")) == 0) {
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("set")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_SET);
-    } else if (strncmp(c->line_reply, ZEND_STRL("list")) == 0) {
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("list")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_LIST);
-    } else if (strncmp(c->line_reply, ZEND_STRL("hash")) == 0) {
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("hash")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_HASH);
-    } else if (strncmp(c->line_reply, ZEND_STRL("zset")) == 0) {
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("zset")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_ZSET);
-    } else if (strncmp(c->line_reply, ZEND_STRL("stream")) == 0) {
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("stream")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_STREAM);
     } else {
         CLUSTER_RETURN_LONG(c, REDIS_NOT_FOUND);
@@ -1977,9 +1977,9 @@ PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
         }
 
         // Make sure we have a message or pmessage
-        if (!strncmp(Z_STRVAL_P(z_type), ZEND_STRL("message")) ||
-            !strncmp(Z_STRVAL_P(z_type), ZEND_STRL("pmessage"))
-        ) {
+        if (zend_string_equals_literal(Z_STR_P(z_type), "message") ||
+            zend_string_equals_literal(Z_STR_P(z_type), "pmessage"))
+        {
             is_pmsg = *Z_STRVAL_P(z_type) == 'p';
         } else {
             zval_dtor(&z_tab);

--- a/common.h
+++ b/common.h
@@ -262,6 +262,12 @@ typedef enum {
 #define REDIS_STRICMP_STATIC(s, len, sstr) \
     (len == sizeof(sstr) - 1 && !strncasecmp(s, sstr, len))
 
+/* On some versions of glibc strncmp is a macro. This wrapper allows us to
+   use it in combination with ZEND_STRL in those cases. */
+static inline int redis_strncmp(const char *s1, const char *s2, size_t n) {
+    return strncmp(s1, s2, n);
+}
+
 /* Test if a zval is a string and (case insensitive) matches a static string */
 #define ZVAL_STRICMP_STATIC(zv, sstr) \
     REDIS_STRICMP_STATIC(Z_STRVAL_P(zv), Z_STRLEN_P(zv), sstr)

--- a/library.c
+++ b/library.c
@@ -147,7 +147,7 @@ static int reselect_db(RedisSock *redis_sock) {
         return -1;
     }
 
-    if (strncmp(response, ZEND_STRL("+OK"))) {
+    if (redis_strncmp(response, ZEND_STRL("+OK"))) {
         efree(response);
         return -1;
     }
@@ -247,7 +247,7 @@ PHP_REDIS_API int redis_sock_auth(RedisSock *redis_sock) {
     efree(cmd);
 
     if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0 ||
-        strncmp(inbuf, ZEND_STRL("+OK")))
+        redis_strncmp(inbuf, ZEND_STRL("+OK")))
     {
         return FAILURE;
     }
@@ -1202,17 +1202,17 @@ PHP_REDIS_API int redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *r
         return FAILURE;
     }
 
-    if (strncmp(response, ZEND_STRL("+string")) == 0) {
+    if (redis_strncmp(response, ZEND_STRL("+string")) == 0) {
         l = REDIS_STRING;
-    } else if (strncmp(response, ZEND_STRL("+set")) == 0){
+    } else if (redis_strncmp(response, ZEND_STRL("+set")) == 0){
         l = REDIS_SET;
-    } else if (strncmp(response, ZEND_STRL("+list")) == 0){
+    } else if (redis_strncmp(response, ZEND_STRL("+list")) == 0){
         l = REDIS_LIST;
-    } else if (strncmp(response, ZEND_STRL("+zset")) == 0){
+    } else if (redis_strncmp(response, ZEND_STRL("+zset")) == 0){
         l = REDIS_ZSET;
-    } else if (strncmp(response, ZEND_STRL("+hash")) == 0){
+    } else if (redis_strncmp(response, ZEND_STRL("+hash")) == 0){
         l = REDIS_HASH;
-    } else if (strncmp(response, ZEND_STRL("+stream")) == 0) {
+    } else if (redis_strncmp(response, ZEND_STRL("+stream")) == 0) {
         l = REDIS_STREAM;
     } else {
         l = REDIS_NOT_FOUND;
@@ -3013,18 +3013,18 @@ redis_sock_check_liveness(RedisSock *redis_sock)
     }
 
     if (auth) {
-        if (strncmp(inbuf, ZEND_STRL("+OK")) == 0 ||
-            strncmp(inbuf, ZEND_STRL("-ERR Client sent AUTH")) == 0)
+        if (redis_strncmp(inbuf, ZEND_STRL("+OK")) == 0 ||
+            redis_strncmp(inbuf, ZEND_STRL("-ERR Client sent AUTH")) == 0)
         {
             /* successfully authenticated or authentication isn't required */
             if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0) {
                 goto failure;
             }
-        } else if (strncmp(inbuf, ZEND_STRL("-NOAUTH")) == 0) {
+        } else if (redis_strncmp(inbuf, ZEND_STRL("-NOAUTH")) == 0) {
             /* connection is fine but authentication failed, next command must
              * fail too */
             if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0
-                || strncmp(inbuf, ZEND_STRL("-NOAUTH")) != 0)
+                || redis_strncmp(inbuf, ZEND_STRL("-NOAUTH")) != 0)
             {
                 goto failure;
             }
@@ -3034,7 +3034,7 @@ redis_sock_check_liveness(RedisSock *redis_sock)
         }
         redis_sock->status = REDIS_SOCK_STATUS_AUTHENTICATED;
     } else {
-        if (strncmp(inbuf, ZEND_STRL("-NOAUTH")) == 0) {
+        if (redis_strncmp(inbuf, ZEND_STRL("-NOAUTH")) == 0) {
             /* connection is fine but authentication required */
             return SUCCESS;
         }
@@ -3042,11 +3042,11 @@ redis_sock_check_liveness(RedisSock *redis_sock)
 
     /* check echo response */
     if ((redis_sock->sentinel && (
-        strncmp(inbuf, ZEND_STRL("-ERR unknown command")) != 0 ||
+        redis_strncmp(inbuf, ZEND_STRL("-ERR unknown command")) != 0 ||
         strstr(inbuf, id) == NULL
     )) || *inbuf != TYPE_BULK || atoi(inbuf + 1) != idlen ||
         redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0 ||
-        strncmp(inbuf, id, idlen) != 0
+        redis_strncmp(inbuf, id, idlen) != 0
     ) {
         goto failure;
     }

--- a/redis.c
+++ b/redis.c
@@ -174,7 +174,7 @@ redis_send_discard(RedisSock *redis_sock)
        (resp = redis_sock_read(redis_sock,&resp_len)) != NULL)
     {
         /* success if we get OK */
-        result = (resp_len == 3 && strncmp(resp,"+OK", 3) == 0) ? SUCCESS:FAILURE;
+        result = (resp_len == 3 && redis_strncmp(resp, ZEND_STRL("+OK")) == 0) ? SUCCESS:FAILURE;
 
         /* free our response */
         efree(resp);
@@ -1906,7 +1906,7 @@ PHP_METHOD(Redis, multi)
                 }
                 if ((resp = redis_sock_read(redis_sock, &resp_len)) == NULL) {
                     RETURN_FALSE;
-                } else if (strncmp(resp, ZEND_STRL("+OK")) != 0) {
+                } else if (redis_strncmp(resp, ZEND_STRL("+OK")) != 0) {
                     efree(resp);
                     RETURN_FALSE;
                 }
@@ -2045,7 +2045,7 @@ redis_response_enqueued(RedisSock *redis_sock)
     int resp_len, ret = FAILURE;
 
     if ((resp = redis_sock_read(redis_sock, &resp_len)) != NULL) {
-        if (strncmp(resp, ZEND_STRL("+QUEUED")) == 0) {
+        if (redis_strncmp(resp, ZEND_STRL("+QUEUED")) == 0) {
             ret = SUCCESS;
         }
         efree(resp);
@@ -2069,7 +2069,7 @@ redis_sock_read_multibulk_multi_reply_loop(INTERNAL_FUNCTION_PARAMETERS,
         char inbuf[255];
 
         if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0 ||
-            strncmp(inbuf, ZEND_STRL("+OK")) != 0)
+            redis_strncmp(inbuf, ZEND_STRL("+OK")) != 0)
         {
             return FAILURE;
         }

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -139,7 +139,7 @@ ra_find_name(const char *name) {
     for(p = ini_names; p;) {
         next = strchr(p, ',');
         if(next) {
-            if(strncmp(p, name, next - p) == 0) {
+            if(redis_strncmp(p, name, next - p) == 0) {
                 return 1;
             }
         } else {
@@ -283,7 +283,7 @@ RedisArray *ra_load_array(const char *name) {
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         if ((z_data = zend_hash_str_find(Z_ARRVAL(z_tmp), name, name_len)) != NULL) {
             consistent = Z_TYPE_P(z_data) == IS_STRING &&
-                         strncmp(Z_STRVAL_P(z_data), ZEND_STRL("1")) == 0;
+                         redis_strncmp(Z_STRVAL_P(z_data), ZEND_STRL("1")) == 0;
         }
         zval_dtor(&z_tmp);
     }

--- a/redis_session.c
+++ b/redis_session.c
@@ -336,7 +336,7 @@ static int lock_acquire(RedisSock *redis_sock, redis_session_lock_status *lock_s
     return lock_status->is_locked ? SUCCESS : FAILURE;
 }
 
-#define IS_LOCK_SECRET(reply, len, secret) (len == ZSTR_LEN(secret) && !strncmp(reply, ZSTR_VAL(secret), len))
+#define IS_LOCK_SECRET(reply, len, secret) (len == ZSTR_LEN(secret) && !redis_strncmp(reply, ZSTR_VAL(secret), len))
 static int write_allowed(RedisSock *redis_sock, redis_session_lock_status *lock_status)
 {
     if (!INI_INT("redis.session.locking_enabled")) {
@@ -444,7 +444,7 @@ PS_OPEN_FUNC(redis)
             zend_string *user = NULL, *pass = NULL;
 
             /* translate unix: into file: */
-            if (!strncmp(save_path+i, "unix:", sizeof("unix:")-1)) {
+            if (!redis_strncmp(save_path+i, ZEND_STRL("unix:"))) {
                 int len = j-i;
                 char *path = estrndup(save_path+i, len);
                 memcpy(path, "file:", sizeof("file:")-1);


### PR DESCRIPTION
On some glibc implementations strncmp is a macro. This commit simply creates a `redis_strncmp` static inline wrapper function so we can `ZEND_STRL` instead of manually counting the length or using `sizeof(s)-1` each time.

Fixes #2565