### PR TITLE
Initialize array with known size

### DIFF
--- a/library.c
+++ b/library.c
@@ -3389,9 +3389,13 @@ redis_mbulk_reply_raw(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval 
         return FAILURE;
     }
     zval z_multi_result;
-    array_init_size(&z_multi_result, numElems); /* pre-allocate array for multi's results. */
 
-    redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_NONE);
+    if (numElems < 1) {
+        ZVAL_EMPTY_ARRAY(&z_multi_result);
+    } else {
+        array_init_size(&z_multi_result, numElems); /* pre-allocate array for multi's results. */
+        redis_mbulk_reply_loop(redis_sock, &z_multi_result, numElems, UNSERIALIZE_NONE);
+    }
 
     if (IS_ATOMIC(redis_sock)) {
         RETVAL_ZVAL(&z_multi_result, 0, 1);

--- a/library.h
+++ b/library.h
@@ -29,6 +29,9 @@
     /* use RedisException when ValueError not available */
     #define REDIS_VALUE_EXCEPTION(m) REDIS_THROW_EXCEPTION(m, 0)
     #define RETURN_THROWS() RETURN_FALSE
+    /* ZVAL_STRINGL_FAST and RETVAL_STRINGL_FAST macros are supported since PHP 8 */
+    #define ZVAL_STRINGL_FAST(z, s, l) ZVAL_STRINGL(z, s, l)
+    #define RETVAL_STRINGL_FAST(s, l) RETVAL_STRINGL(s, l)
 #else
     #define redis_hash_fetch_ops(zstr) php_hash_fetch_ops(zstr)
 

--- a/redis.c
+++ b/redis.c
@@ -1974,6 +1974,12 @@ redis_sock_read_multibulk_multi_reply(INTERNAL_FUNCTION_PARAMETERS,
         return FAILURE;
     }
 
+    // No command issued, return empty immutable array
+    if (redis_sock->head == NULL) {
+        ZVAL_EMPTY_ARRAY(z_tab);
+        return SUCCESS;
+    }
+
     array_init(z_tab);
 
     return redis_sock_read_multibulk_multi_reply_loop(INTERNAL_FUNCTION_PARAM_PASSTHRU,

--- a/redis.c
+++ b/redis.c
@@ -2021,7 +2021,7 @@ PHP_METHOD(Redis, exec)
     if (IS_PIPELINE(redis_sock)) {
         if (smart_str_get_len(&redis_sock->pipeline_cmd) == 0) {
             /* Empty array when no command was run. */
-            array_init(&z_ret);
+            ZVAL_EMPTY_ARRAY(&z_ret);
         } else {
             if (redis_sock_write(redis_sock, ZSTR_VAL(redis_sock->pipeline_cmd.s),
                     ZSTR_LEN(redis_sock->pipeline_cmd.s)) < 0) {

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -268,11 +268,11 @@ int redis_key_long_val_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     zend_long expire;
     zval *z_val;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "slz", &key, &key_len,
-                             &expire, &z_val) == FAILURE)
-    {
-        return FAILURE;
-    }
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(key, key_len)
+        Z_PARAM_LONG(expire)
+        Z_PARAM_ZVAL(z_val)
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
     *cmd_len = REDIS_CMD_SPPRINTF(cmd, kw, "klv", key, key_len, expire, z_val);
 
@@ -451,11 +451,9 @@ int redis_key_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char *key;
     size_t key_len;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len)
-                             ==FAILURE)
-    {
-        return FAILURE;
-    }
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(key, key_len);
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
     *cmd_len = REDIS_CMD_SPPRINTF(cmd, kw, "k", key, key_len);
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3456,6 +3456,22 @@ class Redis_Test extends TestSuite {
         $this->assertEquals(5, count($ret)); // should be 5 atomic operations
     }
 
+    public function testMultiEmpty()
+    {
+        $ret = $this->redis->multi()->exec();
+        $this->assertEquals([], $ret);
+    }
+
+    public function testPipelineEmpty()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped();
+        }
+
+        $ret = $this->redis->pipeline()->exec();
+        $this->assertEquals([], $ret);
+    }
+
     /* GitHub issue #1211 (ignore redundant calls to pipeline or multi) */
     public function testDoublePipeNoOp() {
         /* Only the first pipeline should be honored */


### PR DESCRIPTION
We known in advance the array size, so it makes sense to avoid reallocation when adding new elements