### PR TITLE
POC: Avoid reallocation

### DIFF
--- a/library.h
+++ b/library.h
@@ -59,6 +59,8 @@ PHP_REDIS_API int redis_spprintf(RedisSock *redis_sock, short *slot, char **ret,
 PHP_REDIS_API zend_string *redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...);
 
 PHP_REDIS_API char *redis_sock_read(RedisSock *redis_sock, int *buf_len);
+PHP_REDIS_API zend_string *redis_sock_read_zstr(RedisSock *redis_sock);
+PHP_REDIS_API zend_string *redis_sock_read_zstr_ex(RedisSock *redis_sock, int *buf_len);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len);
 PHP_REDIS_API int redis_1_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_long_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval* z_tab, void *ctx);


### PR DESCRIPTION
When fetching data from redis, data are saved to buffer and then copied to new zend_string structure. So if you fetch from Redis for example 100 MB of data, you need to allocate 200 MB.

This is proof-of-concept that introduces two new functions `redis_sock_read_bulk_reply_zstr` and `redis_sock_read_zstr` that returns `zend_string*` object instead of `char*` and use these new functions for some methods (but not all). After this patch, data are saved directly to zend_string structure, so we can avoid double allocation.

If you consider that this change makes sense, I will replace all `redis_sock_read_bulk_reply` and `redis_sock_read` usages with new functions. 
