### PR TITLE
Use smart str for constructing pipeline cmd

### DIFF
--- a/common.h
+++ b/common.h
@@ -177,13 +177,7 @@ typedef enum {
 #define IS_PIPELINE(redis_sock) (redis_sock->mode & PIPELINE)
 
 #define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) do { \
-    if (redis_sock->pipeline_cmd == NULL) { \
-        redis_sock->pipeline_cmd = zend_string_init(cmd, cmd_len, 0); \
-    } else { \
-        size_t pipeline_len = ZSTR_LEN(redis_sock->pipeline_cmd); \
-        redis_sock->pipeline_cmd = zend_string_realloc(redis_sock->pipeline_cmd, pipeline_len + cmd_len, 0); \
-        memcpy(&ZSTR_VAL(redis_sock->pipeline_cmd)[pipeline_len], cmd, cmd_len); \
-    } \
+    smart_str_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len); \
 } while (0)
 
 #define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
@@ -324,7 +318,7 @@ typedef struct {
     struct fold_item    *head;
     struct fold_item    *current;
 
-    zend_string         *pipeline_cmd;
+    smart_str           pipeline_cmd;
 
     zend_string         *err;
 

--- a/library.c
+++ b/library.c
@@ -3605,9 +3605,7 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
     if (redis_sock->prefix) {
         zend_string_release(redis_sock->prefix);
     }
-    if (redis_sock->pipeline_cmd) {
-        zend_string_release(redis_sock->pipeline_cmd);
-    }
+    smart_str_free(&redis_sock->pipeline_cmd);
     if (redis_sock->err) {
         zend_string_release(redis_sock->err);
     }

--- a/redis.c
+++ b/redis.c
@@ -1948,10 +1948,7 @@ PHP_METHOD(Redis, discard)
 
     if (IS_PIPELINE(redis_sock)) {
         ret = SUCCESS;
-        if (redis_sock->pipeline_cmd) {
-            zend_string_release(redis_sock->pipeline_cmd);
-            redis_sock->pipeline_cmd = NULL;
-        }
+        smart_str_free(&redis_sock->pipeline_cmd);
     } else if (IS_MULTI(redis_sock)) {
         ret = redis_send_discard(redis_sock);
     }
@@ -2022,12 +2019,12 @@ PHP_METHOD(Redis, exec)
     }
 
     if (IS_PIPELINE(redis_sock)) {
-        if (redis_sock->pipeline_cmd == NULL) {
+        if (smart_str_get_len(&redis_sock->pipeline_cmd) == 0) {
             /* Empty array when no command was run. */
             array_init(&z_ret);
         } else {
-            if (redis_sock_write(redis_sock, ZSTR_VAL(redis_sock->pipeline_cmd),
-                    ZSTR_LEN(redis_sock->pipeline_cmd)) < 0) {
+            if (redis_sock_write(redis_sock, ZSTR_VAL(redis_sock->pipeline_cmd.s),
+                    ZSTR_LEN(redis_sock->pipeline_cmd.s)) < 0) {
                 ZVAL_FALSE(&z_ret);
             } else {
                 array_init(&z_ret);
@@ -2037,8 +2034,7 @@ PHP_METHOD(Redis, exec)
                     ZVAL_FALSE(&z_ret);
                 }
             }
-            zend_string_release(redis_sock->pipeline_cmd);
-            redis_sock->pipeline_cmd = NULL;
+            smart_str_free(&redis_sock->pipeline_cmd);
         }
         free_reply_callbacks(redis_sock);
         REDIS_DISABLE_MODE(redis_sock, PIPELINE);


### PR DESCRIPTION
PHP's smart str provides easier API for appending new string and also do not need new allocation and deallocation for every command issued in pipeline like previously used zend_string.

