### PR TITLE
Switch pipeline_cmd from smart_str to smart_string

### DIFF
--- a/common.h
+++ b/common.h
@@ -177,7 +177,7 @@ typedef enum {
 #define IS_PIPELINE(redis_sock) (redis_sock->mode & PIPELINE)
 
 #define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) do { \
-    smart_str_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len); \
+    smart_string_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len); \
 } while (0)
 
 #define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
@@ -318,7 +318,7 @@ typedef struct {
     struct fold_item    *head;
     struct fold_item    *current;
 
-    smart_str           pipeline_cmd;
+    smart_string        pipeline_cmd;
 
     zend_string         *err;
 

--- a/library.c
+++ b/library.c
@@ -3564,7 +3564,7 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
     if (redis_sock->prefix) {
         zend_string_release(redis_sock->prefix);
     }
-    smart_str_free(&redis_sock->pipeline_cmd);
+    smart_string_free(&redis_sock->pipeline_cmd);
     if (redis_sock->err) {
         zend_string_release(redis_sock->err);
     }

--- a/redis.c
+++ b/redis.c
@@ -1948,7 +1948,7 @@ PHP_METHOD(Redis, discard)
 
     if (IS_PIPELINE(redis_sock)) {
         ret = SUCCESS;
-        smart_str_free(&redis_sock->pipeline_cmd);
+        smart_string_free(&redis_sock->pipeline_cmd);
     } else if (IS_MULTI(redis_sock)) {
         ret = redis_send_discard(redis_sock);
     }
@@ -2025,12 +2025,12 @@ PHP_METHOD(Redis, exec)
     }
 
     if (IS_PIPELINE(redis_sock)) {
-        if (smart_str_get_len(&redis_sock->pipeline_cmd) == 0) {
+        if (redis_sock->pipeline_cmd.len == 0) {
             /* Empty array when no command was run. */
             ZVAL_EMPTY_ARRAY(&z_ret);
         } else {
-            if (redis_sock_write(redis_sock, ZSTR_VAL(redis_sock->pipeline_cmd.s),
-                    ZSTR_LEN(redis_sock->pipeline_cmd.s)) < 0) {
+            if (redis_sock_write(redis_sock, redis_sock->pipeline_cmd.c,
+                    redis_sock->pipeline_cmd.len) < 0) {
                 ZVAL_FALSE(&z_ret);
             } else {
                 array_init(&z_ret);
@@ -2040,7 +2040,7 @@ PHP_METHOD(Redis, exec)
                     ZVAL_FALSE(&z_ret);
                 }
             }
-            smart_str_free(&redis_sock->pipeline_cmd);
+            smart_string_free(&redis_sock->pipeline_cmd);
         }
         free_reply_callbacks(redis_sock);
         REDIS_DISABLE_MODE(redis_sock, PIPELINE);


### PR DESCRIPTION
As we don't need to extract zend_string from pipeline_cmd, we can use simple smart_string structure.