### PR TITLE
Simplify redis_unpack method calling

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -6444,8 +6444,6 @@ void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
         RETURN_FALSE;
     }
 
-    if (redis_unpack(redis_sock, ZSTR_VAL(str), ZSTR_LEN(str), return_value) == 0) {
-        RETURN_STR_COPY(str);
-    }
+    redis_unpack(redis_sock, ZSTR_VAL(str), ZSTR_LEN(str), return_value);
 }
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */


### PR DESCRIPTION
This method always unpack given string to zval, so it is not necessary to check output value