### PR TITLE
Switch from linked list to growing array for reply callbacks

### DIFF
--- a/library.h
+++ b/library.h
@@ -40,7 +40,8 @@
 
 
 void redis_register_persistent_resource(zend_string *id, void *ptr, int le_id);
-void free_reply_callbacks(RedisSock *redis_sock);
+fold_item* redis_add_reply_callback(RedisSock *redis_sock);
+void redis_free_reply_callbacks(RedisSock *redis_sock);
 
 PHP_REDIS_API int redis_extract_auth_info(zval *ztest, zend_string **user, zend_string **pass);
 


### PR DESCRIPTION
Reduce allocation and deallocation count and also memory usage when using pipelining.

Currently, every command issued in pipeline mode requires one allocation of 24 bytes (plus overhead that depends on allocator, usually it should be 8 bytes). Another disadvantage is that allocating and deallocating memory is slow.

So after this patch, commands are stored in array. For one issued command it requires just 16 bytes. So for example for 1000 commands, it will use 16 kB of memory (currently it is at least 32 kB). Also iterating this array should be faster, because of memory caching.