### PR TITLE
Print cursor as unsigned 64 bit integer

### DIFF
--- a/library.c
+++ b/library.c
@@ -1060,7 +1060,7 @@ int redis_cmd_append_sstr_long(smart_string *str, long append) {
  * Append a 64-bit integer to our command
  */
 int redis_cmd_append_sstr_i64(smart_string *str, int64_t append) {
-    char nbuf[64];
+    char nbuf[21];
     int len = snprintf(nbuf, sizeof(nbuf), "%" PRId64, append);
     return redis_cmd_append_sstr(str, nbuf, len);
 }

--- a/library.c
+++ b/library.c
@@ -1068,8 +1068,8 @@ int redis_cmd_append_sstr_i64(smart_string *str, int64_t append) {
 /*
  * Append a 64-bit unsigned integer to our command
  */
-int redis_cmd_append_sstr_ui64(smart_string *str, uint64_t append) {
-    char nbuf[64];
+int redis_cmd_append_sstr_u64(smart_string *str, uint64_t append) {
+    char nbuf[21];
     int len = snprintf(nbuf, sizeof(nbuf), "%" PRIu64, append);
     return redis_cmd_append_sstr(str, nbuf, len);
 }

--- a/library.c
+++ b/library.c
@@ -1066,6 +1066,15 @@ int redis_cmd_append_sstr_i64(smart_string *str, int64_t append) {
 }
 
 /*
+ * Append a 64-bit unsigned integer to our command
+ */
+int redis_cmd_append_sstr_ui64(smart_string *str, uint64_t append) {
+    char nbuf[64];
+    int len = snprintf(nbuf, sizeof(nbuf), "%" PRIu64, append);
+    return redis_cmd_append_sstr(str, nbuf, len);
+}
+
+/*
  * Append a double to a smart string command
  */
 int

--- a/library.h
+++ b/library.h
@@ -50,7 +50,7 @@ int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);
 int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
 int redis_cmd_append_sstr_i64(smart_string *str, int64_t append);
-int redis_cmd_append_sstr_ui64(smart_string *str, uint64_t append);
+int redis_cmd_append_sstr_u64(smart_string *str, uint64_t append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
 int redis_cmd_append_sstr_zstr(smart_string *str, zend_string *zstr);
 int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock);

--- a/library.h
+++ b/library.h
@@ -50,6 +50,7 @@ int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);
 int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
 int redis_cmd_append_sstr_i64(smart_string *str, int64_t append);
+int redis_cmd_append_sstr_ui64(smart_string *str, uint64_t append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);
 int redis_cmd_append_sstr_zstr(smart_string *str, zend_string *zstr);
 int redis_cmd_append_sstr_zval(smart_string *str, zval *z, RedisSock *redis_sock);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -591,7 +591,7 @@ int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
     }
 
     // Append cursor
-    redis_cmd_append_sstr_ui64(&cmdstr, it);
+    redis_cmd_append_sstr_u64(&cmdstr, it);
 
     // Append count if we've got one
     if (count) {

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -574,7 +574,7 @@ int redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic to construct SCAN and variant commands */
 int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
-                       long it, char *pat, int pat_len, long count)
+                       uint64_t it, char *pat, int pat_len, long count)
 {
     static char *kw[] = {"SCAN","SSCAN","HSCAN","ZSCAN"};
     int argc;
@@ -591,7 +591,7 @@ int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
     }
 
     // Append cursor
-    redis_cmd_append_sstr_long(&cmdstr, it);
+    redis_cmd_append_sstr_ui64(&cmdstr, it);
 
     // Append count if we've got one
     if (count) {

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -309,7 +309,7 @@ int redis_copy_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
 int redis_fmt_scan_cmd(char **cmd, REDIS_SCAN_TYPE type, char *key, int key_len,
-    long it, char *pat, int pat_len, long count);
+    uint64_t it, char *pat, int pat_len, long count);
 
 int redis_geoadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);


### PR DESCRIPTION
Prevent cursor from being converted from an unsigned 64-bit integer to a long (and therefore truncated in some situations) when the redis command is generated.

Should fix #2600.

Am I able to get some help testing this? I'm not very familiar with C, I spend too much time in PHP land 🙈 