### PR TITLE
Invalidate slot cache on failed cluster connections

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -390,6 +390,7 @@ PHP_REDIS_API char **cluster_sock_read_multibulk_reply(RedisSock *redis_sock, in
 
 PHP_REDIS_API void cluster_cache_store(zend_string *hash, HashTable *nodes);
 PHP_REDIS_API redisCachedCluster *cluster_cache_load(zend_string *hash);
+void cluster_cache_clear(redisCluster *c);
 
 /*
  * Redis Cluster response handlers.  Our response handlers generally take the


### PR DESCRIPTION
Prevents a stale slot cache from causing connection errors which persist until the process restarts.

Fixes #2516