### PR TITLE
Fix phpdoc type of '$pattern'

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1874,7 +1874,7 @@ class Redis {
      * @param int    $iterator  The scan iterator, which should be initialized to NULL before the first call.
      *                          This value will be updated after every call to hscan, until it reaches zero
      *                          meaning the scan is complete.
-     * @param string $pattern   An optional glob-style pattern to filter fields with.
+     * @param string|null $pattern An optional glob-style pattern to filter fields with.
      * @param int    $count     An optional hint to Redis about how many fields and values to return per HSCAN.
      *
      * @return Redis|array|bool An array with a subset of fields and values.
@@ -1995,7 +1995,10 @@ class Redis {
      */
     public function isConnected(): bool;
 
-    /** @return Redis|list<string>|false */
+    /**
+     * @param string $pattern
+     * @return Redis|list<string>|false
+     */
     public function keys(string $pattern);
 
     /**
@@ -2920,7 +2923,7 @@ class Redis {
      *                         updated to a new number, until finally Redis will set the value to
      *                         zero, indicating that the scan is complete.
      *
-     * @param string $pattern  An optional glob-style pattern for matching key names.  If passed as
+     * @param string|null $pattern An optional glob-style pattern for matching key names.  If passed as
      *                         NULL, it is the equivalent of sending '*' (match every key).
      *
      * @param int    $count    A hint to redis that tells it how many keys to return in a single
@@ -3311,7 +3314,7 @@ class Redis {
      *                          PhpRedis will update with the value returned from Redis after each
      *                          subsequent call to SSCAN.  Once this cursor is zero you know all
      *                          members have been traversed.
-     * @param string $pattern   An optional glob style pattern to match against, so Redis only
+     * @param string|null $pattern An optional glob style pattern to match against, so Redis only
      *                          returns the subset of members matching this pattern.
      * @param int    $count     A hint to Redis as to how many members it should scan in one command
      *                          before returning members for that iteration.
@@ -4598,7 +4601,7 @@ class Redis {
      * @param int    $iterator   A reference to an iterator that should be initialized to NULL initially, that
      *                           will be updated after each subsequent call to ZSCAN.  Once the iterator
      *                           has returned to zero the scan is complete
-     * @param string $pattern    An optional glob-style pattern that limits which members are returned during
+     * @param string|null $pattern An optional glob-style pattern that limits which members are returned during
      *                           the scanning process.
      * @param int    $count      A hint for Redis that tells it how many elements it should test before returning
      *                           from the call.  The higher the more work Redis may do in any one given call to


### PR DESCRIPTION
Hello :)

I noticed that when I tried to use zScan while specifying the $count parameter, passing null (the default value) for $pattern resulted in a PHPDoc type mismatch. I've created a pull request to fix this issue. If possible, I would greatly appreciate it if you could review and merge the changes.