### PR TITLE
Introduce `Redis::OPT_PACK_IGNORE_NUMBERS` option.

### DIFF
--- a/common.h
+++ b/common.h
@@ -91,20 +91,21 @@ typedef enum _PUBSUB_TYPE {
 #define REDIS_SUBS_BUCKETS   3
 
 /* options */
-#define REDIS_OPT_SERIALIZER         1
-#define REDIS_OPT_PREFIX             2
-#define REDIS_OPT_READ_TIMEOUT       3
-#define REDIS_OPT_SCAN               4
-#define REDIS_OPT_FAILOVER           5
-#define REDIS_OPT_TCP_KEEPALIVE      6
-#define REDIS_OPT_COMPRESSION        7
-#define REDIS_OPT_REPLY_LITERAL      8
-#define REDIS_OPT_COMPRESSION_LEVEL  9
-#define REDIS_OPT_NULL_MBULK_AS_NULL 10
-#define REDIS_OPT_MAX_RETRIES        11
-#define REDIS_OPT_BACKOFF_ALGORITHM  12
-#define REDIS_OPT_BACKOFF_BASE       13
-#define REDIS_OPT_BACKOFF_CAP        14
+#define REDIS_OPT_SERIALIZER          1
+#define REDIS_OPT_PREFIX              2
+#define REDIS_OPT_READ_TIMEOUT        3
+#define REDIS_OPT_SCAN                4
+#define REDIS_OPT_FAILOVER            5
+#define REDIS_OPT_TCP_KEEPALIVE       6
+#define REDIS_OPT_COMPRESSION         7
+#define REDIS_OPT_REPLY_LITERAL       8
+#define REDIS_OPT_COMPRESSION_LEVEL   9
+#define REDIS_OPT_NULL_MBULK_AS_NULL  10
+#define REDIS_OPT_MAX_RETRIES         11
+#define REDIS_OPT_BACKOFF_ALGORITHM   12
+#define REDIS_OPT_BACKOFF_BASE        13
+#define REDIS_OPT_BACKOFF_CAP         14
+#define REDIS_OPT_PACK_IGNORE_NUMBERS 15
 
 /* cluster options */
 #define REDIS_FAILOVER_NONE              0
@@ -300,6 +301,7 @@ typedef struct {
     zend_string         *persistent_id;
     HashTable           *subs[REDIS_SUBS_BUCKETS];
     redis_serializer    serializer;
+    zend_bool           pack_ignore_numbers;
     int                 compression;
     int                 compression_level;
     long                dbNumber;

--- a/library.c
+++ b/library.c
@@ -3882,10 +3882,10 @@ redis_unpack(RedisSock *redis_sock, const char *src, int srclen, zval *zdst) {
     size_t len;
     char *buf;
 
-    if (UNEXPECTED((redis_sock->serializer != REDIS_SERIALIZER_NONE &&
+    if (UNEXPECTED((redis_sock->serializer != REDIS_SERIALIZER_NONE ||
                     redis_sock->compression != REDIS_COMPRESSION_NONE) &&
                     redis_sock->pack_ignore_numbers) &&
-                    srclen > 0 && srclen < 24)
+                    srclen > 0 && srclen < 512)
     {
         switch (is_numeric_string(src, srclen, &lval, &dval, 0)) {
             case IS_LONG:

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -152,6 +152,13 @@ class Redis {
     public const OPT_NULL_MULTIBULK_AS_NULL = UNKNOWN;
 
     /**
+     * @var int
+     * @cvalue REDIS_OPT_PACK_IGNORE_NUMBERS
+     *
+     */
+    public const OPT_PACK_IGNORE_NUMBERS = UNKNOWN;
+
+    /**
      *
      * @var int
      * @cvalue REDIS_SERIALIZER_NONE

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -155,6 +155,25 @@ class Redis {
      * @var int
      * @cvalue REDIS_OPT_PACK_IGNORE_NUMBERS
      *
+     * When enabled, this option tells PhpRedis to ignore purely numeric values
+     * when packing and unpacking data. This does not include numeric strings.
+     * If you want numeric strings to be ignored, typecast them to an int or float.
+     *
+     * The primary purpose of this option is to make it more ergonomic when
+     * setting keys that will later be incremented or decremented.
+     *
+     * Note: This option incurs a small performance penalty when reading data
+     * because we have to see if the data is a string representation of an int
+     * or float.
+     *
+     * @example
+     * $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
+     * $redis->setOption(Redis::OPT_PACK_IGNORE_NUMBERS, true);
+     *
+     * $redis->set('answer', 32);
+     *
+     * var_dump($redis->incrBy('answer', 10));  // int(42)
+     * var_dump($redis->get('answer'));         // int(42)
      */
     public const OPT_PACK_IGNORE_NUMBERS = UNKNOWN;
 

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 78283cf59cefb411c09adf7a0f0bd234c65327b3 */
+ * Stub hash: 3c4051fdd9f860523bcd72aba260b1af823d1d9c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8f22ab9cd1635066463b20ab12d295c11b4ac7 */
+ * Stub hash: 78283cf59cefb411c09adf7a0f0bd234c65327b3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -1816,6 +1816,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_OPT_NULL_MULTIBULK_AS_NULL_name = zend_string_init_interned("OPT_NULL_MULTIBULK_AS_NULL", sizeof("OPT_NULL_MULTIBULK_AS_NULL") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_OPT_NULL_MULTIBULK_AS_NULL_name, &const_OPT_NULL_MULTIBULK_AS_NULL_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_NULL_MULTIBULK_AS_NULL_name);
+
+	zval const_OPT_PACK_IGNORE_NUMBERS_value;
+	ZVAL_LONG(&const_OPT_PACK_IGNORE_NUMBERS_value, REDIS_OPT_PACK_IGNORE_NUMBERS);
+	zend_string *const_OPT_PACK_IGNORE_NUMBERS_name = zend_string_init_interned("OPT_PACK_IGNORE_NUMBERS", sizeof("OPT_PACK_IGNORE_NUMBERS") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_PACK_IGNORE_NUMBERS_name, &const_OPT_PACK_IGNORE_NUMBERS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_PACK_IGNORE_NUMBERS_name);
 
 	zval const_SERIALIZER_NONE_value;
 	ZVAL_LONG(&const_SERIALIZER_NONE_value, REDIS_SERIALIZER_NONE);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -6147,6 +6147,8 @@ void redis_getoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             RETURN_LONG(redis_sock->compression);
         case REDIS_OPT_COMPRESSION_LEVEL:
             RETURN_LONG(redis_sock->compression_level);
+        case REDIS_OPT_PACK_IGNORE_NUMBERS:
+            RETURN_BOOL(redis_sock->pack_ignore_numbers);
         case REDIS_OPT_PREFIX:
             if (redis_sock->prefix) {
                 RETURN_STRINGL(ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
@@ -6235,6 +6237,9 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
                 RETURN_TRUE;
             }
             break;
+        case REDIS_OPT_PACK_IGNORE_NUMBERS:
+            redis_sock->pack_ignore_numbers = zval_is_true(val);
+            RETURN_TRUE;
         case REDIS_OPT_COMPRESSION_LEVEL:
             val_long = zval_get_long(val);
             redis_sock->compression_level = val_long;

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8f22ab9cd1635066463b20ab12d295c11b4ac7 */
+ * Stub hash: 78283cf59cefb411c09adf7a0f0bd234c65327b3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -1659,6 +1659,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_OPT_NULL_MULTIBULK_AS_NULL_name = zend_string_init_interned("OPT_NULL_MULTIBULK_AS_NULL", sizeof("OPT_NULL_MULTIBULK_AS_NULL") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_OPT_NULL_MULTIBULK_AS_NULL_name, &const_OPT_NULL_MULTIBULK_AS_NULL_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_OPT_NULL_MULTIBULK_AS_NULL_name);
+
+	zval const_OPT_PACK_IGNORE_NUMBERS_value;
+	ZVAL_LONG(&const_OPT_PACK_IGNORE_NUMBERS_value, REDIS_OPT_PACK_IGNORE_NUMBERS);
+	zend_string *const_OPT_PACK_IGNORE_NUMBERS_name = zend_string_init_interned("OPT_PACK_IGNORE_NUMBERS", sizeof("OPT_PACK_IGNORE_NUMBERS") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_OPT_PACK_IGNORE_NUMBERS_name, &const_OPT_PACK_IGNORE_NUMBERS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_OPT_PACK_IGNORE_NUMBERS_name);
 
 	zval const_SERIALIZER_NONE_value;
 	ZVAL_LONG(&const_SERIALIZER_NONE_value, REDIS_SERIALIZER_NONE);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 78283cf59cefb411c09adf7a0f0bd234c65327b3 */
+ * Stub hash: 3c4051fdd9f860523bcd72aba260b1af823d1d9c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)


### PR DESCRIPTION
Adds an option that instructs PhpRedis to not serialize or compress numeric values. Specifically where `Z_TYPE_P(z) == IS_LONG` or `Z_TYPE_P(z) == IS_DOUBLE`.

This flag lets the user enable serialization and/or compression while still using the various increment/decrement command (`INCR`, `INCRBY`, `DECR`, `DECRBY`, `INCRBYFLOAT`, `HINCRBY`, and `HINCRBYFLOAT`).

Note that PhpRedis cannot know when reading data back, so ther will still be a cost incurred as we attempt and then fail to deserialize and/or uncompress the value.

This is particularly problematic for `COMPRESSION_LZ4` as we use a small 5 byte header as a sanity check which could happen to pass depending on the specific numeric value stored.

See #23