### PR TITLE
Update codeql to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: cpp
           queries: +security-and-quality
@@ -16,6 +16,6 @@ jobs:
         run: |
           phpize
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/56010bb2-68a0-4040-ada5-39d318b2a1de)

https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/