### PR TITLE
Add `getWithMeta` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All changes to phpredis will be documented in this file.
 We're basing this format on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and PhpRedis adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `getWithMeta` method
+  [9036ffca](https://github.com/phpredis/phpredis/commit/9036ffca)
+  ([Pavlo Yatsukhnenko](https://github.com/yatsukhnenko))
+
+
 ## [6.1.0] - 2024-10-04 ([Github](https://github.com/phpredis/phpredis/releases/6.1.0), [PECL](https://pecl.php.net/package/redis/6.1.0))
 
 **NOTE**: There were no changes to C code between 6.1.0RC2 and 6.1.0.

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -264,6 +264,8 @@ struct clusterFoldItem {
 
     /* Next item in our list */
     struct clusterFoldItem *next;
+
+    uint8_t flags;
 };
 
 /* Key and value container, with info if they need freeing */

--- a/common.h
+++ b/common.h
@@ -152,6 +152,7 @@ typedef enum {
 #define PIPELINE 2
 
 #define PHPREDIS_DEBUG_LOGGING 0
+#define PHPREDIS_WITH_METADATA 1
 
 #if PHP_VERSION_ID < 80000
 #define Z_PARAM_ARRAY_HT_OR_NULL(dest) \
@@ -184,6 +185,7 @@ typedef enum {
 #define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
     fold_item *fi = redis_add_reply_callback(redis_sock); \
     fi->fun = callback; \
+    fi->flags = redis_sock->flags; \
     fi->ctx = closure_context; \
 } while (0)
 
@@ -266,6 +268,9 @@ static inline int redis_strncmp(const char *s1, const char *s2, size_t n) {
 #define REDIS_ENABLE_MODE(redis_sock, m) (redis_sock->mode |= m)
 #define REDIS_DISABLE_MODE(redis_sock, m) (redis_sock->mode &= ~m)
 
+#define REDIS_ENABLE_FLAG(redis_sock, f) (redis_sock->flags |= f)
+#define REDIS_DISABLE_FLAG(redis_sock, f) (redis_sock->flags &= ~f)
+
 /* HOST_NAME_MAX doesn't exist everywhere */
 #ifndef HOST_NAME_MAX
     #if defined(_POSIX_HOST_NAME_MAX)
@@ -325,6 +330,7 @@ typedef struct {
     int                 sentinel;
     size_t              txBytes;
     size_t              rxBytes;
+    uint8_t             flags;
 } RedisSock;
 /* }}} */
 
@@ -334,6 +340,7 @@ typedef int (*FailableResultCallback)(INTERNAL_FUNCTION_PARAMETERS, RedisSock*, 
 
 typedef struct fold_item {
     FailableResultCallback fun;
+    uint8_t flags;
     void *ctx;
 } fold_item;
 

--- a/library.h
+++ b/library.h
@@ -44,6 +44,7 @@ fold_item* redis_add_reply_callback(RedisSock *redis_sock);
 void redis_free_reply_callbacks(RedisSock *redis_sock);
 
 PHP_REDIS_API int redis_extract_auth_info(zval *ztest, zend_string **user, zend_string **pass);
+PHP_REDIS_API void redis_with_metadata(zval *zdst, zval *zsrc, zend_long length);
 
 int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyword_len);
 int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1468,6 +1468,16 @@ class Redis {
     public function get(string $key): mixed;
 
     /**
+     * Retrieve a value and metadata of key.
+     *
+     * @param  string  $key The key to query
+     * @return Redis|array|false
+     *
+     * @example $redis->getWithMeta('foo');
+     */
+    public function getWithMeta(string $key): Redis|array|false;
+
+    /**
      * Get the authentication information on the connection, if any.
      *
      * @return mixed The authentication information used to authenticate the connection.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3c4051fdd9f860523bcd72aba260b1af823d1d9c */
+ * Stub hash: 6dd5a9e9d1d5ed8a78e248c99352232e30046f28 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -323,6 +323,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_get, 0, 1, IS_MIXED,
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getWithMeta, 0, 1, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_getAuth, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
@@ -404,9 +408,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_hGet, 0, 2, IS_MIXED
 	ZEND_ARG_TYPE_INFO(0, member, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hGetAll, 0, 1, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_hGetAll arginfo_class_Redis_getWithMeta
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hIncrBy, 0, 3, Redis, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -420,7 +422,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hIncrByFloat, 0,
 	ZEND_ARG_TYPE_INFO(0, value, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_hKeys arginfo_class_Redis_hGetAll
+#define arginfo_class_Redis_hKeys arginfo_class_Redis_getWithMeta
 
 #define arginfo_class_Redis_hLen arginfo_class_Redis_expiretime
 
@@ -455,7 +457,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hStrLen, 0, 2, R
 	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_hVals arginfo_class_Redis_hGetAll
+#define arginfo_class_Redis_hVals arginfo_class_Redis_getWithMeta
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hscan, 0, 2, Redis, MAY_BE_ARRAY|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -747,7 +749,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_sInterStore arginfo_class_Redis_del
 
-#define arginfo_class_Redis_sMembers arginfo_class_Redis_hGetAll
+#define arginfo_class_Redis_sMembers arginfo_class_Redis_getWithMeta
 
 #define arginfo_class_Redis_sMisMember arginfo_class_Redis_geohash
 
@@ -1249,6 +1251,7 @@ ZEND_METHOD(Redis, georadiusbymember_ro);
 ZEND_METHOD(Redis, geosearch);
 ZEND_METHOD(Redis, geosearchstore);
 ZEND_METHOD(Redis, get);
+ZEND_METHOD(Redis, getWithMeta);
 ZEND_METHOD(Redis, getAuth);
 ZEND_METHOD(Redis, getBit);
 ZEND_METHOD(Redis, getEx);
@@ -1507,6 +1510,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, geosearch, arginfo_class_Redis_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, geosearchstore, arginfo_class_Redis_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, get, arginfo_class_Redis_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, getWithMeta, arginfo_class_Redis_getWithMeta, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getAuth, arginfo_class_Redis_getAuth, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getBit, arginfo_class_Redis_getBit, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getEx, arginfo_class_Redis_getEx, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -275,11 +275,27 @@ PHP_METHOD(RedisCluster, close) {
     RETURN_TRUE;
 }
 
-/* {{{ proto string RedisCluster::get(string key) */
-PHP_METHOD(RedisCluster, get) {
+static void
+cluster_get_passthru(INTERNAL_FUNCTION_PARAMETERS)
+{
     CLUSTER_PROCESS_KW_CMD("GET", redis_key_cmd, cluster_bulk_resp, 1);
 }
+
+/* {{{ proto string RedisCluster::get(string key) */
+PHP_METHOD(RedisCluster, get) {
+    cluster_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
 /* }}} */
+
+/* {{{ proto array|false RedisCluster::getWithMeta(string key) */
+PHP_METHOD(RedisCluster, getWithMeta) {
+    redisCluster *c = GET_CONTEXT();
+    REDIS_ENABLE_FLAG(c->flags, PHPREDIS_WITH_METADATA);
+    cluster_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+    REDIS_DISABLE_FLAG(c->flags, PHPREDIS_WITH_METADATA);
+}
+/* }}} */
+
 
 /* {{{ proto bool RedisCluster::set(string key, string value) */
 PHP_METHOD(RedisCluster, set) {

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -22,6 +22,7 @@
     _item->slot = slot; \
     _item->ctx = ctx; \
     _item->next = NULL; \
+    _item->flags = c->flags->flags; \
     if(c->multi_head == NULL) { \
         c->multi_head = _item; \
         c->multi_curr = _item; \

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -391,6 +391,11 @@ class RedisCluster {
     public function get(string $key): mixed;
 
     /**
+     * @see Redis::getWithMeta
+     */
+    public function getWithMeta(string $key): RedisCluster|array|false;
+
+    /**
      * @see Redis::getEx
      */
     public function getex(string $key, array $options = []): RedisCluster|string|false;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9310b607794caa862d509ba316a2a512d2736fe */
+ * Stub hash: 5966b99fd578eca94880e09539542edfbcbcdaed */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -325,6 +325,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_get, 0, 1, IS
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_getWithMeta, 0, 1, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_getex, 0, 1, RedisCluster, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
@@ -379,9 +383,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster_hget, 0, 2, I
 	ZEND_ARG_TYPE_INFO(0, member, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetall, 0, 1, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_RedisCluster_hgetall arginfo_class_RedisCluster_getWithMeta
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hincrby, 0, 3, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -395,7 +397,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hincrbyfl
 	ZEND_ARG_TYPE_INFO(0, value, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_RedisCluster_hkeys arginfo_class_RedisCluster_hgetall
+#define arginfo_class_RedisCluster_hkeys arginfo_class_RedisCluster_getWithMeta
 
 #define arginfo_class_RedisCluster_hlen arginfo_class_RedisCluster_expiretime
 
@@ -451,7 +453,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hstrlen, 
 	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_RedisCluster_hvals arginfo_class_RedisCluster_hgetall
+#define arginfo_class_RedisCluster_hvals arginfo_class_RedisCluster_getWithMeta
 
 #define arginfo_class_RedisCluster_incr arginfo_class_RedisCluster_decr
 
@@ -754,7 +756,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_slowlog arginfo_class_RedisCluster_script
 
-#define arginfo_class_RedisCluster_smembers arginfo_class_RedisCluster_hgetall
+#define arginfo_class_RedisCluster_smembers arginfo_class_RedisCluster_getWithMeta
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_smove, 0, 3, RedisCluster, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, src, IS_STRING, 0)
@@ -1127,6 +1129,7 @@ ZEND_METHOD(RedisCluster, georadiusbymember_ro);
 ZEND_METHOD(RedisCluster, geosearch);
 ZEND_METHOD(RedisCluster, geosearchstore);
 ZEND_METHOD(RedisCluster, get);
+ZEND_METHOD(RedisCluster, getWithMeta);
 ZEND_METHOD(RedisCluster, getex);
 ZEND_METHOD(RedisCluster, getbit);
 ZEND_METHOD(RedisCluster, getlasterror);
@@ -1356,6 +1359,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, geosearch, arginfo_class_RedisCluster_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, geosearchstore, arginfo_class_RedisCluster_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, get, arginfo_class_RedisCluster_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, getWithMeta, arginfo_class_RedisCluster_getWithMeta, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getex, arginfo_class_RedisCluster_getex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getbit, arginfo_class_RedisCluster_getbit, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getlasterror, arginfo_class_RedisCluster_getlasterror, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b9310b607794caa862d509ba316a2a512d2736fe */
+ * Stub hash: 5966b99fd578eca94880e09539542edfbcbcdaed */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -294,6 +294,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_geosearchstore, 0, 0, 5)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_get arginfo_class_RedisCluster__prefix
+
+#define arginfo_class_RedisCluster_getWithMeta arginfo_class_RedisCluster__prefix
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_getex, 0, 0, 1)
 	ZEND_ARG_INFO(0, key)
@@ -969,6 +971,7 @@ ZEND_METHOD(RedisCluster, georadiusbymember_ro);
 ZEND_METHOD(RedisCluster, geosearch);
 ZEND_METHOD(RedisCluster, geosearchstore);
 ZEND_METHOD(RedisCluster, get);
+ZEND_METHOD(RedisCluster, getWithMeta);
 ZEND_METHOD(RedisCluster, getex);
 ZEND_METHOD(RedisCluster, getbit);
 ZEND_METHOD(RedisCluster, getlasterror);
@@ -1198,6 +1201,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, geosearch, arginfo_class_RedisCluster_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, geosearchstore, arginfo_class_RedisCluster_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, get, arginfo_class_RedisCluster_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, getWithMeta, arginfo_class_RedisCluster_getWithMeta, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getex, arginfo_class_RedisCluster_getex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getbit, arginfo_class_RedisCluster_getbit, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, getlasterror, arginfo_class_RedisCluster_getlasterror, ZEND_ACC_PUBLIC)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3c4051fdd9f860523bcd72aba260b1af823d1d9c */
+ * Stub hash: 6dd5a9e9d1d5ed8a78e248c99352232e30046f28 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -300,6 +300,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_geosearchstore, 0, 0, 5)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_get arginfo_class_Redis__prefix
+
+#define arginfo_class_Redis_getWithMeta arginfo_class_Redis__prefix
 
 #define arginfo_class_Redis_getAuth arginfo_class_Redis___destruct
 
@@ -1092,6 +1094,7 @@ ZEND_METHOD(Redis, georadiusbymember_ro);
 ZEND_METHOD(Redis, geosearch);
 ZEND_METHOD(Redis, geosearchstore);
 ZEND_METHOD(Redis, get);
+ZEND_METHOD(Redis, getWithMeta);
 ZEND_METHOD(Redis, getAuth);
 ZEND_METHOD(Redis, getBit);
 ZEND_METHOD(Redis, getEx);
@@ -1350,6 +1353,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, geosearch, arginfo_class_Redis_geosearch, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, geosearchstore, arginfo_class_Redis_geosearchstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, get, arginfo_class_Redis_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, getWithMeta, arginfo_class_Redis_getWithMeta, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getAuth, arginfo_class_Redis_getAuth, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getBit, arginfo_class_Redis_getBit, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getEx, arginfo_class_Redis_getEx, ZEND_ACC_PUBLIC)

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -248,6 +248,21 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue($this->redis->client($key, 'kill', $addr));
     }
 
+    public function testGetWithMeta() {
+        $this->redis->del('key');
+        $this->assertFalse($this->redis->get('key'));
+        $this->assertEquals([false, ['length' => -1]], $this->redis->getWithMeta('key'));
+
+        $this->assertEquals([true, ['value', ['length' => strlen('value')]]], $this->redis->multi()->set('key', 'value')->getWithMeta('key')->exec());
+
+        $serializer = $this->redis->getOption(Redis::OPT_SERIALIZER);
+        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+        $this->assertTrue($this->redis->set('key', false));
+        $this->assertEquals([false, ['length' => strlen(serialize(false))]], $this->redis->getWithMeta('key'));
+        $this->assertFalse($this->redis->get('key'));
+        $this->redis->setOption(Redis::OPT_SERIALIZER, $serializer);
+    }
+
     public function testTime() {
         [$sec, $usec] = $this->redis->time(uniqid());
         $this->assertEquals(strval(intval($sec)), strval($sec));

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5800,6 +5800,22 @@ class Redis_Test extends TestSuite {
         $this->redis->setOption(Redis::OPT_COMPRESSION, $oldcmp);
     }
 
+    public function testGetWithMeta() {
+        $this->redis->del('key');
+        $this->assertFalse($this->redis->get('key'));
+        $this->assertEquals([false, ['length' => -1]], $this->redis->getWithMeta('key'));
+
+        $this->assertEquals([false, [false, ['length' => -1]]], $this->redis->pipeline()->get('key')->getWithMeta('key')->exec());
+        $this->assertEquals([true, ['value', ['length' => strlen('value')]]], $this->redis->multi()->set('key', 'value')->getWithMeta('key')->exec());
+
+        $serializer = $this->redis->getOption(Redis::OPT_SERIALIZER);
+        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+        $this->assertTrue($this->redis->set('key', false));
+        $this->assertEquals([false, ['length' => strlen(serialize(false))]], $this->redis->getWithMeta('key'));
+        $this->assertFalse($this->redis->get('key'));
+        $this->redis->setOption(Redis::OPT_SERIALIZER, $serializer);
+    }
+
     public function testPrefix() {
         // no prefix
         $this->redis->setOption(Redis::OPT_PREFIX, '');

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5803,15 +5803,63 @@ class Redis_Test extends TestSuite {
     public function testGetWithMeta() {
         $this->redis->del('key');
         $this->assertFalse($this->redis->get('key'));
-        $this->assertEquals([false, ['length' => -1]], $this->redis->getWithMeta('key'));
 
-        $this->assertEquals([false, [false, ['length' => -1]]], $this->redis->pipeline()->get('key')->getWithMeta('key')->exec());
-        $this->assertEquals([true, ['value', ['length' => strlen('value')]]], $this->redis->multi()->set('key', 'value')->getWithMeta('key')->exec());
+        $result = $this->redis->getWithMeta('key');
+        $this->assertIsArray($result, 2);
+        $this->assertArrayKeyEquals($result, 0, false);
+        $this->assertArrayKey($result, 1, function ($metadata) {
+            $this->assertIsArray($metadata);
+            $this->assertArrayKeyEquals($metadata, 'length', -1);
+            return true;
+        });
+
+        $batch = $this->redis->pipeline()
+            ->get('key')
+            ->getWithMeta('key')
+            ->exec();
+        $this->assertIsArray($batch, 2);
+        $this->assertArrayKeyEquals($batch, 0, false);
+        $this->assertArrayKey($batch, 1, function ($result) {
+            $this->assertIsArray($result, 2);
+            $this->assertArrayKeyEquals($result, 0, false);
+            $this->assertArrayKey($result, 1, function ($metadata) {
+                $this->assertIsArray($metadata);
+                $this->assertArrayKeyEquals($metadata, 'length', -1);
+                return true;
+            });
+            return true;
+        });
+
+        $batch = $this->redis->multi()
+            ->set('key', 'value')
+            ->getWithMeta('key')
+            ->exec();
+        $this->assertIsArray($batch, 2);
+        $this->assertArrayKeyEquals($batch, 0, true);
+        $this->assertArrayKey($batch, 1, function ($result) {
+            $this->assertIsArray($result, 2);
+            $this->assertArrayKeyEquals($result, 0, 'value');
+            $this->assertArrayKey($result, 1, function ($metadata) {
+                $this->assertIsArray($metadata);
+                $this->assertArrayKeyEquals($metadata, 'length', strlen('value'));
+                return true;
+            });
+            return true;
+        });
 
         $serializer = $this->redis->getOption(Redis::OPT_SERIALIZER);
         $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
         $this->assertTrue($this->redis->set('key', false));
-        $this->assertEquals([false, ['length' => strlen(serialize(false))]], $this->redis->getWithMeta('key'));
+
+        $result = $this->redis->getWithMeta('key');
+        $this->assertIsArray($result, 2);
+        $this->assertArrayKeyEquals($result, 0, false);
+        $this->assertArrayKey($result, 1, function ($metadata) {
+            $this->assertIsArray($metadata);
+            $this->assertArrayKeyEquals($metadata, 'length', strlen(serialize(false)));
+            return true;
+        });
+
         $this->assertFalse($this->redis->get('key'));
         $this->redis->setOption(Redis::OPT_SERIALIZER, $serializer);
     }


### PR DESCRIPTION
When serializer is used it might be difficult to distinct that key doesn't exists or its value is serialized `false`.
This PR introduces new method `getWithMeta` which tries to solve this problem by attaching some metadata to returned value. Currently only `length` is in metadata but we may add something else in the future without changing response format.