### PR TITLE
Introduce `Redis::serverName` and `Redis::serverVersion` methods

### DIFF
--- a/common.h
+++ b/common.h
@@ -287,6 +287,11 @@ static inline int redis_strncmp(const char *s1, const char *s2, size_t n) {
 #define RESP_EXEC_CMD          "*1\r\n$4\r\nEXEC\r\n"
 #define RESP_DISCARD_CMD       "*1\r\n$7\r\nDISCARD\r\n"
 
+typedef struct RedisHello {
+    zend_string *server;
+    zend_string *version;
+} RedisHello;
+
 /* {{{ struct RedisSock */
 typedef struct {
     php_stream          *stream;
@@ -310,9 +315,8 @@ typedef struct {
     int                 compression;
     int                 compression_level;
     long                dbNumber;
-
     zend_string         *prefix;
-
+    struct RedisHello   hello;
     short               mode;
     struct fold_item    *reply_callback;
     size_t              reply_callback_count;
@@ -320,7 +324,6 @@ typedef struct {
     smart_string        pipeline_cmd;
 
     zend_string         *err;
-
     int                 scan;
 
     int                 readonly;

--- a/library.c
+++ b/library.c
@@ -2077,16 +2077,15 @@ redis_hello_response(INTERNAL_FUNCTION_PARAMETERS,
     zv = zend_hash_str_find(Z_ARRVAL(z_ret), ZEND_STRL("version"));
     redis_sock->hello.version = zv ? zval_get_string(zv) : ZSTR_EMPTY_ALLOC();
 
-    if (ctx != NULL) {
-        zval_dtor(&z_ret);
-        if (ctx == PHPREDIS_CTX_PTR) {
-            ZVAL_STR_COPY(&z_ret, redis_sock->hello.server);
-        } else if (ctx == PHPREDIS_CTX_PTR + 1) {
-            ZVAL_STR_COPY(&z_ret, redis_sock->hello.version);
-        } else {
-            ZEND_ASSERT(!"memory corruption?");
-            return FAILURE;
-        }
+    zval_dtor(&z_ret);
+
+    if (ctx == PHPREDIS_CTX_PTR) {
+        ZVAL_STR_COPY(&z_ret, redis_sock->hello.server);
+    } else if (ctx == PHPREDIS_CTX_PTR + 1) {
+        ZVAL_STR_COPY(&z_ret, redis_sock->hello.version);
+    } else {
+        ZEND_ASSERT(!"memory corruption?");
+        return FAILURE;
     }
 
     if (IS_ATOMIC(redis_sock)) {

--- a/library.h
+++ b/library.h
@@ -211,6 +211,9 @@ PHP_REDIS_API int redis_function_response(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
 PHP_REDIS_API int redis_command_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_select_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 
+PHP_REDIS_API int redis_hello_server_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+PHP_REDIS_API int redis_hello_version_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+
 /* Helper methods to get configuration values from a HashTable. */
 
 #define REDIS_HASH_STR_FIND_STATIC(ht, sstr) \

--- a/redis.c
+++ b/redis.c
@@ -2580,7 +2580,11 @@ PHP_METHOD(Redis, getPort) {
 PHP_METHOD(Redis, serverName) {
     RedisSock *rs;
 
-    if ((rs = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU)) == NULL) {
+    if ((rs = redis_sock_get_instance(getThis(), 1)) == NULL) {
+        RETURN_FALSE;
+    } else if (!IS_ATOMIC(rs)) {
+        php_error_docref(NULL, E_ERROR,
+            "Can't call serverName in multi or pipeline mode!");
         RETURN_FALSE;
     } else if (rs->hello.server != NULL) {
         RETURN_STR_COPY(rs->hello.server);
@@ -2592,7 +2596,11 @@ PHP_METHOD(Redis, serverName) {
 PHP_METHOD(Redis, serverVersion) {
     RedisSock *rs;
 
-    if ((rs = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU)) == NULL) {
+    if ((rs = redis_sock_get_instance(getThis(), 1)) == NULL) {
+        RETURN_FALSE;
+    } else if (!IS_ATOMIC(rs)) {
+        php_error_docref(NULL, E_ERROR,
+            "Can't call serverVersion in multi or pipeline mode!");
         RETURN_FALSE;
     } else if (rs->hello.version != NULL) {
         RETURN_STR_COPY(rs->hello.version);

--- a/redis.c
+++ b/redis.c
@@ -2577,6 +2577,30 @@ PHP_METHOD(Redis, getPort) {
     }
 }
 
+PHP_METHOD(Redis, serverName) {
+    RedisSock *rs;
+
+    if ((rs = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU)) == NULL) {
+        RETURN_FALSE;
+    } else if (rs->hello.server != NULL) {
+        RETURN_STR_COPY(rs->hello.server);
+    }
+
+    REDIS_PROCESS_KW_CMD("HELLO", redis_empty_cmd, redis_hello_server_response);
+}
+
+PHP_METHOD(Redis, serverVersion) {
+    RedisSock *rs;
+
+    if ((rs = redis_sock_get_connected(INTERNAL_FUNCTION_PARAM_PASSTHRU)) == NULL) {
+        RETURN_FALSE;
+    } else if (rs->hello.version != NULL) {
+        RETURN_STR_COPY(rs->hello.version);
+    }
+
+    REDIS_PROCESS_KW_CMD("HELLO", redis_empty_cmd, redis_hello_version_response);
+}
+
 /* {{{ proto Redis::getDBNum */
 PHP_METHOD(Redis, getDBNum) {
     RedisSock *redis_sock;

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1595,14 +1595,14 @@ class Redis {
      *
      * @return string|false
      */
-    public function serverName(): Redis|string|false;
+    public function serverName(): string|false;
 
     /**
      * Get the server version as reported by the `HELLO` response.
      *
      * @return string|false
      */
-    public function serverVersion(): Redis|string|false;
+    public function serverVersion(): string|false;
 
     /**
      * Retrieve a substring of a string by index.

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1591,6 +1591,20 @@ class Redis {
     public function getPort(): int;
 
     /**
+     * Get the server name as reported by the `HELLO` response.
+     *
+     * @return string|false
+     */
+    public function serverName(): Redis|string|false;
+
+    /**
+     * Get the server version as reported by the `HELLO` response.
+     *
+     * @return string|false
+     */
+    public function serverVersion(): Redis|string|false;
+
+    /**
      * Retrieve a substring of a string by index.
      *
      * @param string $key   The string to query.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6dd5a9e9d1d5ed8a78e248c99352232e30046f28 */
+ * Stub hash: 79376d7ada29d6f9bb873e7c59e64e22af3ca559 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -363,6 +363,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_getPort arginfo_class_Redis_getDBNum
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_serverName, 0, 0, Redis, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Redis_serverVersion arginfo_class_Redis_serverName
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_getRange, 0, 3, Redis, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, start, IS_LONG, 0)
@@ -681,8 +686,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_rPop, 0, 1, Redi
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_randomKey, 0, 0, Redis, MAY_BE_STRING|MAY_BE_FALSE)
-ZEND_END_ARG_INFO()
+#define arginfo_class_Redis_randomKey arginfo_class_Redis_serverName
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_rawcommand, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, command, IS_STRING, 0)
@@ -1263,6 +1267,8 @@ ZEND_METHOD(Redis, getMode);
 ZEND_METHOD(Redis, getOption);
 ZEND_METHOD(Redis, getPersistentID);
 ZEND_METHOD(Redis, getPort);
+ZEND_METHOD(Redis, serverName);
+ZEND_METHOD(Redis, serverVersion);
 ZEND_METHOD(Redis, getRange);
 ZEND_METHOD(Redis, lcs);
 ZEND_METHOD(Redis, getReadTimeout);
@@ -1522,6 +1528,8 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, getOption, arginfo_class_Redis_getOption, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getPersistentID, arginfo_class_Redis_getPersistentID, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getPort, arginfo_class_Redis_getPort, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, serverName, arginfo_class_Redis_serverName, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, serverVersion, arginfo_class_Redis_serverVersion, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getRange, arginfo_class_Redis_getRange, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, lcs, arginfo_class_Redis_lcs, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getReadTimeout, arginfo_class_Redis_getReadTimeout, ZEND_ACC_PUBLIC)

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 79376d7ada29d6f9bb873e7c59e64e22af3ca559 */
+ * Stub hash: 805a66c17b7c9972c73a979bdd67f98f7c1f6c74 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -363,7 +363,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_getPort arginfo_class_Redis_getDBNum
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_serverName, 0, 0, Redis, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Redis_serverName, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_serverVersion arginfo_class_Redis_serverName
@@ -686,7 +686,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_rPop, 0, 1, Redi
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Redis_randomKey arginfo_class_Redis_serverName
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_randomKey, 0, 0, Redis, MAY_BE_STRING|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis_rawcommand, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, command, IS_STRING, 0)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 79376d7ada29d6f9bb873e7c59e64e22af3ca559 */
+ * Stub hash: 805a66c17b7c9972c73a979bdd67f98f7c1f6c74 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6dd5a9e9d1d5ed8a78e248c99352232e30046f28 */
+ * Stub hash: 79376d7ada29d6f9bb873e7c59e64e22af3ca559 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -332,6 +332,10 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Redis_getPersistentID arginfo_class_Redis___destruct
 
 #define arginfo_class_Redis_getPort arginfo_class_Redis___destruct
+
+#define arginfo_class_Redis_serverName arginfo_class_Redis___destruct
+
+#define arginfo_class_Redis_serverVersion arginfo_class_Redis___destruct
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_getRange, 0, 0, 3)
 	ZEND_ARG_INFO(0, key)
@@ -1106,6 +1110,8 @@ ZEND_METHOD(Redis, getMode);
 ZEND_METHOD(Redis, getOption);
 ZEND_METHOD(Redis, getPersistentID);
 ZEND_METHOD(Redis, getPort);
+ZEND_METHOD(Redis, serverName);
+ZEND_METHOD(Redis, serverVersion);
 ZEND_METHOD(Redis, getRange);
 ZEND_METHOD(Redis, lcs);
 ZEND_METHOD(Redis, getReadTimeout);
@@ -1365,6 +1371,8 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, getOption, arginfo_class_Redis_getOption, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getPersistentID, arginfo_class_Redis_getPersistentID, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getPort, arginfo_class_Redis_getPort, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, serverName, arginfo_class_Redis_serverName, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, serverVersion, arginfo_class_Redis_serverVersion, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getRange, arginfo_class_Redis_getRange, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, lcs, arginfo_class_Redis_lcs, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, getReadTimeout, arginfo_class_Redis_getReadTimeout, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
Right now we can't implement `HELLO` command to switch protocol because we don't support new reply types that come with RESP3. But we can use `HELLO` reply to expose some server information.