### PR TITLE
cleanup session temp file

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6185,6 +6185,7 @@ class Redis_Test extends TestSuite {
             // Use a unique ID so we can find our type keys
             $id = uniqid();
 
+            $keys = [];
             // Create some simple keys and lists
             for ($i = 0; $i < 3; $i++) {
                 $simple = "simple:{$id}:$i";

--- a/tests/SessionHelpers.php
+++ b/tests/SessionHelpers.php
@@ -80,7 +80,7 @@ class Runner {
     ];
 
     private $prefix = NULL;
-    private $output_file;
+    private $output_file = NULL;
     private $exit_code = -1;
     private $cmd = NULL;
     private $pid;
@@ -88,6 +88,12 @@ class Runner {
 
     public function __construct() {
         $this->args['id'] = $this->createId();
+    }
+
+    public function __destruct() {
+        if ($this->output_file) {
+            unlink($this->output_file);
+        }
     }
 
     public function getExitCode(): int {
@@ -183,7 +189,6 @@ class Runner {
     }
 
     private function getTmpFileName() {
-        return '/tmp/sessiontmp.txt';
         return tempnam(sys_get_temp_dir(), 'session');
     }
 


### PR DESCRIPTION
Avoid keeping temporary files created during the test suite

Locally, this creates failure when the test suite is run under different users
Removing the static name is enough, but it generates many temp files, so cleaning them.


