### PR TITLE
Refactor `getWithMeta` logic

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1678,6 +1678,8 @@ static int cluster_bulk_resp_to_zval(redisCluster *c, zval *zdst) {
     if (c->reply_type != TYPE_BULK ||
         (resp = redis_sock_read_bulk_reply(c->cmd_sock, c->reply_len)) == NULL)
     {
+        if (c->reply_type != TYPE_BULK)
+            c->reply_len = 0;
         ZVAL_FALSE(zdst);
         return FAILURE;
     }

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1672,37 +1672,54 @@ cluster_single_line_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ct
     }
 }
 
+static int cluster_bulk_resp_to_zval(redisCluster *c, zval *zdst) {
+    char *resp;
+
+    if (c->reply_type != TYPE_BULK ||
+        (resp = redis_sock_read_bulk_reply(c->cmd_sock, c->reply_len)) == NULL)
+    {
+        ZVAL_FALSE(zdst);
+        return FAILURE;
+    }
+
+    if (!redis_unpack(c->flags, resp, c->reply_len, zdst)) {
+        ZVAL_STRINGL_FAST(zdst, resp, c->reply_len);
+    }
+
+    efree(resp);
+
+    return SUCCESS;
+}
+
 /* BULK response handler */
 PHP_REDIS_API void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
-                              void *ctx)
+                                     void *ctx)
 {
-    char *resp;
-    zval z_unpacked, z_ret, *zv;
+    zval zret;
 
-    // Make sure we can read the response
-    if (c->reply_type != TYPE_BULK) {
-        ZVAL_FALSE(&z_unpacked);
-        c->reply_len = 0;
-    } else if ((resp = redis_sock_read_bulk_reply(c->cmd_sock, c->reply_len)) == NULL) {
-        ZVAL_FALSE(&z_unpacked);
-    } else {
-        if (!redis_unpack(c->flags, resp, c->reply_len, &z_unpacked)) {
-            ZVAL_STRINGL_FAST(&z_unpacked, resp, c->reply_len);
-        }
-        efree(resp);
-    }
-
-    if (c->flags->flags & PHPREDIS_WITH_METADATA) {
-        redis_with_metadata(&z_ret, &z_unpacked, c->reply_len);
-        zv = &z_ret;
-    } else {
-        zv = &z_unpacked;
-    }
+    cluster_bulk_resp_to_zval(c, &zret);
 
     if (CLUSTER_IS_ATOMIC(c)) {
-        RETVAL_ZVAL(zv, 0, 1);
+        RETVAL_ZVAL(&zret, 0, 1);
     } else {
-        add_next_index_zval(&c->multi_resp, zv);
+        add_next_index_zval(&c->multi_resp, &zret);
+    }
+}
+
+PHP_REDIS_API void
+cluster_bulk_withmeta_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+                           void *ctx)
+{
+    zval zbulk, zmeta;
+
+    cluster_bulk_resp_to_zval(c, &zbulk);
+
+    redis_with_metadata(&zmeta, &zbulk, c->reply_len);
+
+    if (CLUSTER_IS_ATOMIC(c)) {
+        RETVAL_ZVAL(&zmeta, 0, 1);
+    } else {
+        add_next_index_zval(&c->multi_resp, &zmeta);
     }
 }
 

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -432,6 +432,8 @@ PHP_REDIS_API void cluster_single_line_resp(INTERNAL_FUNCTION_PARAMETERS, redisC
     void *ctx);
 PHP_REDIS_API void cluster_bulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
+PHP_REDIS_API void cluster_bulk_withmeta_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    void *ctx);
 PHP_REDIS_API void cluster_bulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     void *ctx);
 PHP_REDIS_API void cluster_dbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,

--- a/common.h
+++ b/common.h
@@ -152,7 +152,6 @@ typedef enum {
 #define PIPELINE 2
 
 #define PHPREDIS_DEBUG_LOGGING 0
-#define PHPREDIS_WITH_METADATA 1
 
 #if PHP_VERSION_ID < 80000
 #define Z_PARAM_ARRAY_HT_OR_NULL(dest) \

--- a/library.c
+++ b/library.c
@@ -250,7 +250,6 @@ redis_sock_auth_cmd(RedisSock *redis_sock, int *cmdlen) {
 PHP_REDIS_API int redis_sock_auth(RedisSock *redis_sock) {
     char *cmd, inbuf[4096];
     int cmdlen;
-    size_t len;
 
     if ((cmd = redis_sock_auth_cmd(redis_sock, &cmdlen)) == NULL)
         return SUCCESS;
@@ -2740,35 +2739,59 @@ redis_1_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_ta
     return ret ? SUCCESS : FAILURE;
 }
 
-PHP_REDIS_API int redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx) {
+static int redis_bulk_resp_to_zval(RedisSock *redis_sock, zval *zdst, int *dstlen) {
+    char *resp;
+    int len;
 
-    char *response;
-    int response_len;
-    zval z_unpacked, z_ret, *zv;
-    zend_bool ret;
+    resp = redis_sock_read(redis_sock, &len);
+    if (dstlen) *dstlen = len;
 
-    if ((response = redis_sock_read(redis_sock, &response_len)) == NULL) {
-        ZVAL_FALSE(&z_unpacked);
-        ret = FAILURE;
-    } else {
-        if (!redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
-            ZVAL_STRINGL_FAST(&z_unpacked, response, response_len);
+    if (resp != NULL) {
+        if (!redis_unpack(redis_sock, resp, len, zdst)) {
+            ZVAL_STRINGL_FAST(zdst, resp, len);
         }
-        efree(response);
-        ret = SUCCESS;
+
+        efree(resp);
+        return SUCCESS;
     }
 
-    if (redis_sock->flags & PHPREDIS_WITH_METADATA) {
-        redis_with_metadata(&z_ret, &z_unpacked, response_len);
-        zv = &z_ret;
-    } else {
-        zv = &z_unpacked;
-    }
+    ZVAL_FALSE(zdst);
+    return FAILURE;
+}
+
+PHP_REDIS_API int
+redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                      zval *z_tab, void *ctx)
+{
+    zval zret;
+    int ret;
+
+    ret = redis_bulk_resp_to_zval(redis_sock, &zret, NULL);
 
     if (IS_ATOMIC(redis_sock)) {
-        RETVAL_ZVAL(zv, 0, 1);
+        RETVAL_ZVAL(&zret, 0, 1);
     } else {
-        add_next_index_zval(z_tab, zv);
+        add_next_index_zval(z_tab, &zret);
+    }
+
+    return ret;
+}
+
+PHP_REDIS_API int
+redis_bulk_withmeta_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                             zval *z_tab, void *ctx)
+{
+    zval zret, zbulk;
+    int len, ret;
+
+    ret = redis_bulk_resp_to_zval(redis_sock, &zbulk, &len);
+
+    redis_with_metadata(&zret, &zbulk, len);
+
+    if (IS_ATOMIC(redis_sock)) {
+        RETVAL_ZVAL(&zret, 0, 1);
+    } else {
+        add_next_index_zval(z_tab, &zret);
     }
 
     return ret;

--- a/library.c
+++ b/library.c
@@ -2746,17 +2746,17 @@ static int redis_bulk_resp_to_zval(RedisSock *redis_sock, zval *zdst, int *dstle
     resp = redis_sock_read(redis_sock, &len);
     if (dstlen) *dstlen = len;
 
-    if (resp != NULL) {
-        if (!redis_unpack(redis_sock, resp, len, zdst)) {
-            ZVAL_STRINGL_FAST(zdst, resp, len);
-        }
-
-        efree(resp);
-        return SUCCESS;
+    if (resp == NULL) {
+        ZVAL_FALSE(zdst);
+        return FAILURE;
     }
 
-    ZVAL_FALSE(zdst);
-    return FAILURE;
+    if (!redis_unpack(redis_sock, resp, len, zdst)) {
+        ZVAL_STRINGL_FAST(zdst, resp, len);
+    }
+
+    efree(resp);
+    return SUCCESS;
 }
 
 PHP_REDIS_API int

--- a/library.h
+++ b/library.h
@@ -73,6 +73,7 @@ PHP_REDIS_API int redis_boolean_response_impl(INTERNAL_FUNCTION_PARAMETERS, Redi
 PHP_REDIS_API int redis_boolean_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_bulk_double_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_string_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
+PHP_REDIS_API int redis_bulk_withmeta_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_ping_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_info_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
 PHP_REDIS_API int redis_config_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);

--- a/redis.c
+++ b/redis.c
@@ -778,17 +778,11 @@ PHP_METHOD(Redis, reset)
 }
 /* }}} */
 
-static void
-redis_get_passthru(INTERNAL_FUNCTION_PARAMETERS)
-{
-    REDIS_PROCESS_KW_CMD("GET", redis_key_cmd, redis_string_response);
-}
-
 /* {{{ proto string Redis::get(string key)
  */
 PHP_METHOD(Redis, get)
 {
-    redis_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+    REDIS_PROCESS_KW_CMD("GET", redis_key_cmd, redis_string_response);
 }
 /* }}} */
 
@@ -796,14 +790,7 @@ PHP_METHOD(Redis, get)
  */
 PHP_METHOD(Redis, getWithMeta)
 {
-    RedisSock *redis_sock;
-    if ((redis_sock = redis_sock_get_instance(getThis(), 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    REDIS_ENABLE_FLAG(redis_sock, PHPREDIS_WITH_METADATA);
-    redis_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    REDIS_DISABLE_FLAG(redis_sock, PHPREDIS_WITH_METADATA);
+    REDIS_PROCESS_KW_CMD("GET", redis_key_cmd, redis_bulk_withmeta_response);
 }
 /* }}} */
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -275,15 +275,9 @@ PHP_METHOD(RedisCluster, close) {
     RETURN_TRUE;
 }
 
-static void
-cluster_get_passthru(INTERNAL_FUNCTION_PARAMETERS)
-{
-    CLUSTER_PROCESS_KW_CMD("GET", redis_key_cmd, cluster_bulk_resp, 1);
-}
-
 /* {{{ proto string RedisCluster::get(string key) */
 PHP_METHOD(RedisCluster, get) {
-    cluster_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+    CLUSTER_PROCESS_KW_CMD("GET", redis_key_cmd, cluster_bulk_resp, 1);
 }
 /* }}} */
 
@@ -295,10 +289,7 @@ PHP_METHOD(RedisCluster, getdel) {
 
 /* {{{ proto array|false RedisCluster::getWithMeta(string key) */
 PHP_METHOD(RedisCluster, getWithMeta) {
-    redisCluster *c = GET_CONTEXT();
-    REDIS_ENABLE_FLAG(c->flags, PHPREDIS_WITH_METADATA);
-    cluster_get_passthru(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    REDIS_DISABLE_FLAG(c->flags, PHPREDIS_WITH_METADATA);
+    CLUSTER_PROCESS_KW_CMD("GET", redis_key_cmd, cluster_bulk_withmeta_resp, 1);
 }
 /* }}} */
 

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -250,53 +250,6 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertTrue($this->redis->client($key, 'kill', $addr));
     }
 
-    public function testGetWithMeta() {
-        $this->redis->del('key');
-        $this->assertFalse($this->redis->get('key'));
-
-        $result = $this->redis->getWithMeta('key');
-        $this->assertIsArray($result, 2);
-        $this->assertArrayKeyEquals($result, 0, false);
-        $this->assertArrayKey($result, 1, function ($metadata) {
-            $this->assertIsArray($metadata);
-            $this->assertArrayKeyEquals($metadata, 'length', -1);
-            return true;
-        });
-
-        $batch = $this->redis->multi()
-            ->set('key', 'value')
-            ->getWithMeta('key')
-            ->exec();
-        $this->assertIsArray($batch, 2);
-        $this->assertArrayKeyEquals($batch, 0, true);
-        $this->assertArrayKey($batch, 1, function ($result) {
-            $this->assertIsArray($result, 2);
-            $this->assertArrayKeyEquals($result, 0, 'value');
-            $this->assertArrayKey($result, 1, function ($metadata) {
-                $this->assertIsArray($metadata);
-                $this->assertArrayKeyEquals($metadata, 'length', strlen('value'));
-                return true;
-            });
-            return true;
-        });
-
-        $serializer = $this->redis->getOption(Redis::OPT_SERIALIZER);
-        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
-        $this->assertTrue($this->redis->set('key', false));
-
-        $result = $this->redis->getWithMeta('key');
-        $this->assertIsArray($result, 2);
-        $this->assertArrayKeyEquals($result, 0, false);
-        $this->assertArrayKey($result, 1, function ($metadata) {
-            $this->assertIsArray($metadata);
-            $this->assertArrayKeyEquals($metadata, 'length', strlen(serialize(false)));
-            return true;
-        });
-
-        $this->assertFalse($this->redis->get('key'));
-        $this->redis->setOption(Redis::OPT_SERIALIZER, $serializer);
-    }
-
     public function testTime() {
         [$sec, $usec] = $this->redis->time(uniqid());
         $this->assertEquals(strval(intval($sec)), strval($sec));

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -5869,22 +5869,24 @@ class Redis_Test extends TestSuite {
             return true;
         });
 
-        $batch = $this->redis->pipeline()
-            ->get('key')
-            ->getWithMeta('key')
-            ->exec();
-        $this->assertIsArray($batch, 2);
-        $this->assertArrayKeyEquals($batch, 0, false);
-        $this->assertArrayKey($batch, 1, function ($result) {
-            $this->assertIsArray($result, 2);
-            $this->assertArrayKeyEquals($result, 0, false);
-            $this->assertArrayKey($result, 1, function ($metadata) {
-                $this->assertIsArray($metadata);
-                $this->assertArrayKeyEquals($metadata, 'length', -1);
+        if ($this->havePipeline()) {
+            $batch = $this->redis->pipeline()
+                ->get('key')
+                ->getWithMeta('key')
+                ->exec();
+            $this->assertIsArray($batch, 2);
+            $this->assertArrayKeyEquals($batch, 0, false);
+            $this->assertArrayKey($batch, 1, function ($result) {
+                $this->assertIsArray($result, 2);
+                $this->assertArrayKeyEquals($result, 0, false);
+                $this->assertArrayKey($result, 1, function ($metadata) {
+                    $this->assertIsArray($metadata);
+                    $this->assertArrayKeyEquals($metadata, 'length', -1);
+                    return true;
+                });
                 return true;
             });
-            return true;
-        });
+        }
 
         $batch = $this->redis->multi()
             ->set('key', 'value')


### PR DESCRIPTION
Small refactor to the `getWithMeta` methods to use their own custom reply handlers instead of toggling flags before and after the call.