### PR TITLE
Simplify redis_unpack method calling

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1684,9 +1684,7 @@ static int cluster_bulk_resp_to_zval(redisCluster *c, zval *zdst) {
         return FAILURE;
     }
 
-    if (!redis_unpack(c->flags, resp, c->reply_len, zdst)) {
-        ZVAL_STRINGL_FAST(zdst, resp, c->reply_len);
-    }
+    redis_unpack(c->flags, resp, c->reply_len, zdst);
 
     efree(resp);
 
@@ -2853,11 +2851,8 @@ int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
 
         if (line != NULL) {
             zval z_unpacked;
-            if (redis_unpack(redis_sock, line, line_len, &z_unpacked)) {
-                add_next_index_zval(z_result, &z_unpacked);
-            } else {
-                add_next_index_stringl(z_result, line, line_len);
-            }
+            redis_unpack(redis_sock, line, line_len, &z_unpacked);
+            add_next_index_zval(z_result, &z_unpacked);
             efree(line);
         } else {
             add_next_index_bool(z_result, 0);
@@ -2893,11 +2888,8 @@ int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
         } else {
             /* Attempt unpacking */
             zval z_unpacked;
-            if (redis_unpack(redis_sock, line, line_len, &z_unpacked)) {
-                add_assoc_zval(z_result, key, &z_unpacked);
-            } else {
-                add_assoc_stringl_ex(z_result, key, key_len, line, line_len);
-            }
+            redis_unpack(redis_sock, line, line_len, &z_unpacked);
+            add_assoc_zval(z_result, key, &z_unpacked);
 
             efree(line);
             efree(key);
@@ -2929,14 +2921,11 @@ int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
                 key_len = line_len;
             } else {
                 zval zv, *z = &zv;
-                if (redis_unpack(redis_sock,key,key_len, z)) {
-                    zend_string *zstr = zval_get_string(z);
-                    add_assoc_double_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), atof(line));
-                    zend_string_release(zstr);
-                    zval_dtor(z);
-                } else {
-                    add_assoc_double_ex(z_result, key, key_len, atof(line));
-                }
+                redis_unpack(redis_sock,key,key_len, z);
+                zend_string *zstr = zval_get_string(z);
+                add_assoc_double_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), atof(line));
+                zend_string_release(zstr);
+                zval_dtor(z);
 
                 /* Free our key and line */
                 efree(key);
@@ -2963,11 +2952,8 @@ int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
 
         if (line != NULL) {
             zval z_unpacked;
-            if (redis_unpack(redis_sock, line, line_len, &z_unpacked)) {
-                add_assoc_zval_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), &z_unpacked);
-            } else {
-                add_assoc_stringl_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), line, line_len);
-            }
+            redis_unpack(redis_sock, line, line_len, &z_unpacked);
+            add_assoc_zval_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), &z_unpacked);
             efree(line);
         } else {
             add_assoc_bool_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), 0);

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2922,9 +2922,9 @@ int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
             } else {
                 zval zv, *z = &zv;
                 redis_unpack(redis_sock,key,key_len, z);
-                zend_string *zstr = zval_get_string(z);
+                zend_string *tmp, *zstr = zval_get_tmp_string(z, &tmp);
                 add_assoc_double_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), atof(line));
-                zend_string_release(zstr);
+                zend_tmp_string_release(tmp);
                 zval_dtor(z);
 
                 /* Free our key and line */

--- a/library.c
+++ b/library.c
@@ -107,13 +107,6 @@ void redis_register_persistent_resource(zend_string *id, void *ptr, int le_id) {
     zend_register_persistent_resource(ZSTR_VAL(id), ZSTR_LEN(id), ptr, le_id);
 }
 
-/* Do not allocate empty string or string with one character */
-static zend_always_inline void redis_add_next_index_stringl(zval *arg, const char *str, size_t length) {
-    zval tmp;
-    ZVAL_STRINGL_FAST(&tmp, str, length);
-    zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp);
-}
-
 static ConnectionPool *
 redis_sock_get_connection_pool(RedisSock *redis_sock)
 {
@@ -2751,9 +2744,7 @@ static int redis_bulk_resp_to_zval(RedisSock *redis_sock, zval *zdst, int *dstle
         return FAILURE;
     }
 
-    if (!redis_unpack(redis_sock, resp, len, zdst)) {
-        ZVAL_STRINGL_FAST(zdst, resp, len);
-    }
+    redis_unpack(redis_sock, resp, len, zdst);
 
     efree(resp);
     return SUCCESS;
@@ -3503,7 +3494,7 @@ PHP_REDIS_API void
 redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count,
                        int unserialize)
 {
-    zval z_unpacked;
+    zval z_value;
     char *line;
     int i, len;
 
@@ -3522,11 +3513,13 @@ redis_mbulk_reply_loop(RedisSock *redis_sock, zval *z_tab, int count,
             (unserialize == UNSERIALIZE_VALS && i % 2 != 0)
         );
 
-        if (unwrap && redis_unpack(redis_sock, line, len, &z_unpacked)) {
-            add_next_index_zval(z_tab, &z_unpacked);
+        if (unwrap) {
+            redis_unpack(redis_sock, line, len, &z_value);
         } else {
-            redis_add_next_index_stringl(z_tab, line, len);
+            ZVAL_STRINGL_FAST(&z_value, line, len);
         }
+        zend_hash_next_index_insert_new(Z_ARRVAL_P(z_tab), &z_value);
+
         efree(line);
     }
 }
@@ -3611,9 +3604,7 @@ PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSoc
         response = redis_sock_read(redis_sock, &response_len);
         zval z_unpacked;
         if (response != NULL) {
-            if (!redis_unpack(redis_sock, response, response_len, &z_unpacked)) {
-                ZVAL_STRINGL(&z_unpacked, response, response_len);
-            }
+            redis_unpack(redis_sock, response, response_len, &z_unpacked);
             efree(response);
         } else {
             ZVAL_FALSE(&z_unpacked);
@@ -4020,6 +4011,12 @@ redis_unpack(RedisSock *redis_sock, const char *src, int srclen, zval *zdst) {
         }
     }
 
+    /* Input string is empty */
+    if (srclen == 0) {
+        ZVAL_STR(zdst, ZSTR_EMPTY_ALLOC());
+        return 1;
+    }
+
     /* Uncompress, then unserialize */
     if (redis_uncompress(redis_sock, &buf, &len, src, srclen)) {
         if (!redis_unserialize(redis_sock, buf, len, zdst)) {
@@ -4029,7 +4026,11 @@ redis_unpack(RedisSock *redis_sock, const char *src, int srclen, zval *zdst) {
         return 1;
     }
 
-    return redis_unserialize(redis_sock, buf, len, zdst);
+    if (!redis_unserialize(redis_sock, src, srclen, zdst)) {
+        ZVAL_STRINGL_FAST(zdst, src, srclen);
+    }
+
+    return 1;
 }
 
 PHP_REDIS_API int

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -6465,8 +6465,6 @@ void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
         RETURN_FALSE;
     }
 
-    if (redis_unpack(redis_sock, ZSTR_VAL(str), ZSTR_LEN(str), return_value) == 0) {
-        RETURN_STR_COPY(str);
-    }
+    redis_unpack(redis_sock, ZSTR_VAL(str), ZSTR_LEN(str), return_value);
 }
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */


### PR DESCRIPTION
This method always unpack given string to zval, so it is not necessary to check output value