### PR TITLE
Fix SIGABRT in PHP 8.4 with RedisArray

### DIFF
--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -91,7 +91,7 @@ ra_init_function_table(RedisArray *ra)
     zend_hash_init(ra->pure_cmds, 0, NULL, NULL, 0);
 
     #define ra_add_pure_cmd(cmd) \
-        zend_hash_str_update_ptr(ra->pure_cmds, cmd, sizeof(cmd) - 1, NULL);
+        zend_hash_str_add_empty_element(ra->pure_cmds, cmd, sizeof(cmd) - 1);
 
     ra_add_pure_cmd("EXISTS");
     ra_add_pure_cmd("GET");


### PR DESCRIPTION
Same fix as 6e5360d1, with PHP switching from `ZEND_ASSUME` to `ZEND_ASSERT` in zend_hash_str_update_ptr.

Fixes #2648