### PR TITLE
Broaden return type for Redis::hGetAll

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1733,7 +1733,7 @@ class Redis {
      * Read every field and value from a hash.
      *
      * @param string $key The hash to query.
-     * @return Redis|array<string, mixed>|false All fields and values or false if the key didn't exist.
+     * @return Redis|array<string|int, mixed>|false All fields and values or false if the key didn't exist.
      *
      * @see https://redis.io/commands/hgetall
      *


### PR DESCRIPTION
`Redis::hGetAll()` returns an array indexed by `string`s and/or `int`s depending on the field keys in the hash set.

The function in the PHP stub was annotated as though the array were keyed only by strings, which is tighter than reality.