### PR TITLE
Implement `HGETEX`, `HSETEX`, `HGETDEL`, and refactor `HMGET`

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2296,6 +2296,8 @@ cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
     if (c->reply_len == -1 && c->flags->null_mbulk_as_null) {
         ZVAL_NULL(&z_result);
+    } else if (c->reply_len <= 0) {
+        array_init(&z_result);
     } else {
         if (init_array)
             array_init(&z_result);

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -87,6 +87,22 @@ static void dump_reply(clusterReply *reply, int indent) {
 }
 */
 
+/* MULTI BULK processing callbacks */
+static int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+static int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+static int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+static int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+static int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+static int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
+    long long count, void *ctx);
+
+
+
 
 /* Recursively free our reply object.  If free_data is non-zero we'll also free
  * the payload data (strings) themselves.  If not, we just free the structs */
@@ -2267,8 +2283,9 @@ PHP_REDIS_API void cluster_variant_resp_strings(INTERNAL_FUNCTION_PARAMETERS, re
 }
 
 /* Generic MULTI BULK response processor */
-PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
-                                   redisCluster *c, mbulk_cb cb, void *ctx)
+static void
+cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+                       zend_bool init_array, mbulk_cb cb, void *ctx)
 {
     zval z_result;
 
@@ -2280,7 +2297,8 @@ PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
     if (c->reply_len == -1 && c->flags->null_mbulk_as_null) {
         ZVAL_NULL(&z_result);
     } else {
-        array_init(&z_result);
+        if (init_array)
+            array_init(&z_result);
 
         if (c->reply_len > 0) {
             /* Push serialization settings from the cluster into our socket */
@@ -2745,7 +2763,7 @@ PHP_REDIS_API void
 cluster_mbulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop_raw, NULL);
+                           1, mbulk_resp_loop_raw, NULL);
 }
 
 /* Unserialize all the things */
@@ -2753,7 +2771,7 @@ PHP_REDIS_API void
 cluster_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop, NULL);
+                           1, mbulk_resp_loop, NULL);
 }
 
 /* For handling responses where we get key, value, key, value that
@@ -2763,7 +2781,7 @@ cluster_mbulk_zipstr_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                           void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop_zipstr, NULL);
+                           1, mbulk_resp_loop_zipstr, NULL);
 }
 
 /* Handling key,value to key=>value where the values are doubles */
@@ -2772,7 +2790,7 @@ cluster_mbulk_zipdbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                           void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop_zipdbl, NULL);
+                           1, mbulk_resp_loop_zipdbl, NULL);
 }
 
 PHP_REDIS_API void
@@ -2780,7 +2798,7 @@ cluster_mbulk_dbl_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                        void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop_dbl, ctx);
+                           1, mbulk_resp_loop_dbl, ctx);
 }
 
 /* Associate multi bulk response (for HMGET really) */
@@ -2789,15 +2807,15 @@ cluster_mbulk_assoc_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                          void *ctx)
 {
     cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c,
-        mbulk_resp_loop_assoc, ctx);
+                           0, mbulk_resp_loop_assoc, ctx);
 }
 
 /*
  * Various MULTI BULK reply callback functions
  */
 
-int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
-                        long long count, void *ctx)
+static int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
+                               long long count, void *ctx)
 {
     char *line;
     int line_len;
@@ -2816,8 +2834,8 @@ int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
 }
 
 /* MULTI BULK response where we don't touch the values (e.g. KEYS) */
-int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
-                        long long count, void *ctx)
+static int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
+                               long long count, void *ctx)
 {
     char *line;
     int line_len;
@@ -2838,8 +2856,8 @@ int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
 }
 
 /* MULTI BULK response where we unserialize everything */
-int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
-                    long long count, void *ctx)
+static int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
+                           long long count, void *ctx)
 {
     char *line;
     int line_len;
@@ -2863,8 +2881,8 @@ int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
 }
 
 /* MULTI BULK response where we turn key1,value1 into key1=>value1 */
-int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
-                           long long count, void *ctx)
+static int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
+                                  long long count, void *ctx)
 {
     char *line, *key = NULL;
     long long idx = 0;
@@ -2899,8 +2917,8 @@ int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
 }
 
 /* MULTI BULK loop processor where we expect key,score key, score */
-int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
-                           long long count, void *ctx)
+static int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
+                                  long long count, void *ctx)
 {
     char *line, *key = NULL;
     int line_len, key_len = 0;
@@ -2937,36 +2955,28 @@ int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
 }
 
 /* MULTI BULK where we're passed the keys, and we attach vals */
-int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
-                          long long count, void *ctx)
+static int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
+                                 long long count, void *ctx)
 {
+    zval *zfield, z_unpacked;
+    HashTable *htctx = ctx;
+    int line_len;
     char *line;
-    int line_len, i;
-    zval *z_keys = ctx;
 
-    // Loop while we've got replies
-    for (i = 0; i < count; ++i) {
-        zend_string *zstr = zval_get_string(&z_keys[i]);
+    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
         line = redis_sock_read(redis_sock, &line_len);
-
         if (line != NULL) {
-            zval z_unpacked;
             redis_unpack(redis_sock, line, line_len, &z_unpacked);
-            add_assoc_zval_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), &z_unpacked);
             efree(line);
         } else {
-            add_assoc_bool_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), 0);
+            ZVAL_FALSE(&z_unpacked);
         }
 
-        // Clean up key context
-        zend_string_release(zstr);
-        zval_dtor(&z_keys[i]);
-    }
+        ZVAL_COPY_VALUE(zfield, &z_unpacked);
+    } ZEND_HASH_FOREACH_END();
 
-    // Clean up our keys overall
-    efree(z_keys);
+    ZVAL_ARR(z_result, htctx);
 
-    // Success!
     return SUCCESS;
 }
 

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2302,16 +2302,14 @@ cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
         if (init_array)
             array_init(&z_result);
 
-        if (c->reply_len > 0) {
-            /* Push serialization settings from the cluster into our socket */
-            c->cmd_sock->serializer = c->flags->serializer;
-            c->cmd_sock->compression = c->flags->compression;
+        /* Push serialization settings from the cluster into our socket */
+        c->cmd_sock->serializer = c->flags->serializer;
+        c->cmd_sock->compression = c->flags->compression;
 
-            /* Call our specified callback */
-            if (cb(c->cmd_sock, &z_result, c->reply_len, ctx) == FAILURE) {
-                zval_dtor(&z_result);
-                CLUSTER_RETURN_FALSE(c);
-            }
+        /* Call our specified callback */
+        if (cb(c->cmd_sock, &z_result, c->reply_len, ctx) == FAILURE) {
+            zval_dtor(&z_result);
+            CLUSTER_RETURN_FALSE(c);
         }
     }
 

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -462,8 +462,6 @@ PHP_REDIS_API void cluster_variant_resp_strings(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c, void *ctx);
 
 /* MULTI BULK response functions */
-PHP_REDIS_API void cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
-    redisCluster *c, mbulk_cb func, void *ctx);
 PHP_REDIS_API void cluster_mbulk_raw_resp(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c, void *ctx);
 PHP_REDIS_API void cluster_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
@@ -519,20 +517,6 @@ PHP_REDIS_API void cluster_mpop_resp(INTERNAL_FUNCTION_PARAMETERS,
 /* Custom ACL handlers */
 PHP_REDIS_API void cluster_acl_getuser_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx);
 PHP_REDIS_API void cluster_acl_log_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx);
-
-/* MULTI BULK processing callbacks */
-int mbulk_resp_loop(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
-int mbulk_resp_loop_raw(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
-int mbulk_resp_loop_zipstr(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
-int mbulk_resp_loop_dbl(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
-int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
-int mbulk_resp_loop_assoc(RedisSock *redis_sock, zval *z_result,
-    long long count, void *ctx);
 
 #endif
 

--- a/library.c
+++ b/library.c
@@ -3480,29 +3480,31 @@ PHP_REDIS_API int
 redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                         zval *z_tab, void *ctx)
 {
+    zend_string *zkey;
     HashTable *htctx;
-    int len, retval;
     int numElems;
     zval *zfield;
     char *rresp;
+    int len;
 
     htctx = ctx;
 
     if (read_mbulk_header(redis_sock, &numElems) < 0 ||
         zend_hash_num_elements(htctx) != numElems)
     {
+        zend_hash_destroy(htctx);
+        FREE_HASHTABLE(htctx);
         REDIS_RESPONSE_ERROR(redis_sock, z_tab);
-        retval = FAILURE;
-        goto end;
+        return FAILURE;
     }
 
     zval z_multi_result, zunpacked;
-    array_init_size(&z_multi_result, numElems);
 
-    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
-        zend_string *tmp, *field;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(htctx, zkey, zfield) {
+        /* Should never happen */
+        if (zkey == NULL)
+            continue;
 
-        field = zval_get_tmp_string(zfield, &tmp);
         rresp = redis_sock_read(redis_sock, &len);
 
         if (rresp != NULL) {
@@ -3512,19 +3514,13 @@ redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             ZVAL_FALSE(&zunpacked);
         }
 
-        zend_symtable_update(Z_ARRVAL(z_multi_result), field, &zunpacked);
-        zend_tmp_string_release(tmp);
+        ZVAL_COPY_VALUE(zfield, &zunpacked);
     } ZEND_HASH_FOREACH_END();
 
+    ZVAL_ARR(&z_multi_result, htctx);
     REDIS_RETURN_ZVAL(redis_sock, z_tab, z_multi_result);
 
-    retval = SUCCESS;
-
-end:
-    zend_hash_destroy(htctx);
-    FREE_HASHTABLE(htctx);
-
-    return retval;
+    return SUCCESS;
 }
 
 /**

--- a/library.c
+++ b/library.c
@@ -3480,7 +3480,6 @@ PHP_REDIS_API int
 redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                         zval *z_tab, void *ctx)
 {
-    zend_string *zkey;
     HashTable *htctx;
     int numElems;
     zval *zfield;
@@ -3500,11 +3499,7 @@ redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     zval z_multi_result, zunpacked;
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(htctx, zkey, zfield) {
-        /* Should never happen */
-        if (zkey == NULL)
-            continue;
-
+    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
         rresp = redis_sock_read(redis_sock, &len);
 
         if (rresp != NULL) {

--- a/library.c
+++ b/library.c
@@ -3476,48 +3476,53 @@ redis_mbulk_reply_zipped_raw_variant(RedisSock *redis_sock, zval *zret, int coun
 
 /* Specialized multibulk processing for HMGET where we need to pair requested
  * keys with their returned values */
-PHP_REDIS_API int redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx)
+PHP_REDIS_API int
+redis_mbulk_reply_assoc(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                        zval *z_tab, void *ctx)
 {
-    char *response;
-    int response_len, retval;
-    int i, numElems;
+    HashTable *htctx;
+    int len, retval;
+    int numElems;
+    zval *zfield;
+    char *rresp;
 
-    zval *z_keys = ctx;
+    htctx = ctx;
 
-    if (read_mbulk_header(redis_sock, &numElems) < 0) {
+    if (read_mbulk_header(redis_sock, &numElems) < 0 ||
+        zend_hash_num_elements(htctx) != numElems)
+    {
         REDIS_RESPONSE_ERROR(redis_sock, z_tab);
         retval = FAILURE;
         goto end;
     }
 
-    zval z_multi_result;
-    array_init_size(&z_multi_result, numElems); /* pre-allocate array for multi's results. */
+    zval z_multi_result, zunpacked;
+    array_init_size(&z_multi_result, numElems);
 
-    for(i = 0; i < numElems; ++i) {
-        zend_string *tmp_str;
-        zend_string *zstr = zval_get_tmp_string(&z_keys[i], &tmp_str);
-        response = redis_sock_read(redis_sock, &response_len);
-        zval z_unpacked;
-        if (response != NULL) {
-            redis_unpack(redis_sock, response, response_len, &z_unpacked);
-            efree(response);
+    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
+        zend_string *tmp, *field;
+
+        field = zval_get_tmp_string(zfield, &tmp);
+        rresp = redis_sock_read(redis_sock, &len);
+
+        if (rresp != NULL) {
+            redis_unpack(redis_sock, rresp, len, &zunpacked);
+            efree(rresp);
         } else {
-            ZVAL_FALSE(&z_unpacked);
+            ZVAL_FALSE(&zunpacked);
         }
-        zend_symtable_update(Z_ARRVAL(z_multi_result), zstr, &z_unpacked);
-        zend_tmp_string_release(tmp_str);
-    }
+
+        zend_symtable_update(Z_ARRVAL(z_multi_result), field, &zunpacked);
+        zend_tmp_string_release(tmp);
+    } ZEND_HASH_FOREACH_END();
 
     REDIS_RETURN_ZVAL(redis_sock, z_tab, z_multi_result);
 
     retval = SUCCESS;
 
 end:
-    // Cleanup z_keys
-    for (i = 0; Z_TYPE(z_keys[i]) != IS_NULL; ++i) {
-        zval_dtor(&z_keys[i]);
-    }
-    efree(z_keys);
+    zend_hash_destroy(htctx);
+    FREE_HASHTABLE(htctx);
 
     return retval;
 }

--- a/redis.c
+++ b/redis.c
@@ -1876,6 +1876,10 @@ PHP_METHOD(Redis, hgetex) {
     REDIS_PROCESS_CMD(hgetex, redis_mbulk_reply_assoc);
 }
 
+PHP_METHOD(Redis, hsetex) {
+    REDIS_PROCESS_CMD(hsetex, redis_long_response);
+}
+
 PHP_METHOD(Redis, hgetdel) {
     REDIS_PROCESS_CMD(hgetdel, redis_mbulk_reply_assoc);
 }

--- a/redis.c
+++ b/redis.c
@@ -1872,6 +1872,10 @@ PHP_METHOD(Redis, hMget) {
 }
 /* }}} */
 
+PHP_METHOD(Redis, hgetex) {
+    REDIS_PROCESS_CMD(hgetex, redis_mbulk_reply_assoc);
+}
+
 /* {{{ proto bool Redis::hmset(string key, array keyvals) */
 PHP_METHOD(Redis, hMset)
 {

--- a/redis.c
+++ b/redis.c
@@ -1876,6 +1876,10 @@ PHP_METHOD(Redis, hgetex) {
     REDIS_PROCESS_CMD(hgetex, redis_mbulk_reply_assoc);
 }
 
+PHP_METHOD(Redis, hgetdel) {
+    REDIS_PROCESS_CMD(hgetdel, redis_mbulk_reply_assoc);
+}
+
 /* {{{ proto bool Redis::hmset(string key, array keyvals) */
 PHP_METHOD(Redis, hMset)
 {

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1827,6 +1827,17 @@ class Redis {
     public function hgetex(string $key, array $fields, string|array|null $expiry = null): Redis|array|false;
 
     /**
+     * Set one or more fields in a hash with optional expiration information.
+     *
+     * @param string $key         The hash to create/update.
+     * @param array $fields       An array with fields values.
+     * @param array|null $expiry  Info about the expiration
+     *
+     * @return Redis|int|false One if fields were set zero if not.
+     */
+    public function hsetex(string $key, array $fields, ?array $expiry = null): Redis|int|false;
+
+    /**
      * Get one or more fields and delete them
      *
      * @param string $key         The hash in question

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1815,6 +1815,18 @@ class Redis {
     public function hMget(string $key, array $fields): Redis|array|false;
 
     /**
+     * Get one or more fields of a hash while optionally setting expiration
+     * information
+     *
+     * @param string $key          The hash to query.
+     * @param array $fields        One or more fields to query in the hash.
+     * @param string|array $expiry Info about the expiration
+     *
+     * @return Redis|array|false The fields and values or false if the key didn't exist.
+     */
+    public function hgetex(string $key, array $fields, string|array|null $expiry = null): Redis|array|false;
+
+    /**
      * Add or update one or more hash fields and values
      *
      * @param string $key        The hash to create/update

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -1827,6 +1827,16 @@ class Redis {
     public function hgetex(string $key, array $fields, string|array|null $expiry = null): Redis|array|false;
 
     /**
+     * Get one or more fields and delete them
+     *
+     * @param string $key         The hash in question
+     * @param array $fields       One or more fields
+     *
+     * @return Redis|array|false  The field and values or false on failure
+     */
+    public function hgetdel(string $key, array $fields): Redis|array|false;
+
+    /**
      * Add or update one or more hash fields and values
      *
      * @param string $key        The hash to create/update

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c6205649cd23ff2b9fcc63a034b601ee566ef236 */
+ * Stub hash: adc2be7c374cce1155e6eeef3b98e2bb60feb277 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -434,6 +434,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMget, 0, 2, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hgetex, 0, 2, Redis, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, expiry, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Redis, MAY_BE_BOOL)
@@ -1319,6 +1325,7 @@ ZEND_METHOD(Redis, hIncrByFloat);
 ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
+ZEND_METHOD(Redis, hgetex);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1589,6 +1596,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hKeys, arginfo_class_Redis_hKeys, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: adc2be7c374cce1155e6eeef3b98e2bb60feb277 */
+ * Stub hash: d4804349b4f9077bdcffa97bc770d168d9944ddd */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -441,6 +441,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hgetex, 0, 2, Re
 	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_MASK(0, expiry, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -1326,6 +1328,7 @@ ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
+ZEND_METHOD(Redis, hgetdel);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1597,6 +1600,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d4804349b4f9077bdcffa97bc770d168d9944ddd */
+ * Stub hash: ec3421b68033c6299a4dc00ab0bbd31576a10961 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -440,6 +440,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hgetex, 0, 2, Re
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_MASK(0, expiry, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hsetex, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, expiry, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
@@ -1328,6 +1334,7 @@ ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
+ZEND_METHOD(Redis, hsetex);
 ZEND_METHOD(Redis, hgetdel);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
@@ -1600,6 +1607,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hsetex, arginfo_class_Redis_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1268,6 +1268,10 @@ PHP_METHOD(RedisCluster, hgetex) {
     CLUSTER_PROCESS_CMD(hgetex, cluster_mbulk_assoc_resp, 0);
 }
 
+PHP_METHOD(RedisCluster, hsetex) {
+    CLUSTER_PROCESS_CMD(hsetex, cluster_long_resp, 0);
+}
+
 PHP_METHOD(RedisCluster, hgetdel) {
     CLUSTER_PROCESS_CMD(hgetdel, cluster_mbulk_assoc_resp, 0);
 }

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1264,6 +1264,14 @@ PHP_METHOD(RedisCluster, hmget) {
 }
 /* }}} */
 
+PHP_METHOD(RedisCluster, hgetex) {
+    CLUSTER_PROCESS_CMD(hgetex, cluster_mbulk_assoc_resp, 0);
+}
+
+PHP_METHOD(RedisCluster, hgetdel) {
+    CLUSTER_PROCESS_CMD(hgetdel, cluster_mbulk_assoc_resp, 0);
+}
+
 /* {{{ proto array RedisCluster::hstrlen(string key, string field) */
 PHP_METHOD(RedisCluster, hstrlen) {
     CLUSTER_PROCESS_CMD(hstrlen, cluster_long_resp, 1);

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -501,6 +501,11 @@ class RedisCluster {
     public function hgetex(string $key, array $fields, string|array|null $expiry = null): RedisCluster|array|false;
 
     /**
+     * @see Redis::hsetex
+     */
+    public function hsetex(string $key, array $fields, ?array $expiry = null): RedisCluster|int|false;
+
+    /**
      * @see Redis::hgetdel
      */
     public function hgetdel(string $key, array $fields): RedisCluster|array|false;

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -496,6 +496,16 @@ class RedisCluster {
     public function hmget(string $key, array $keys): RedisCluster|array|false;
 
     /**
+     * @see Redis::hgetex
+     */
+    public function hgetex(string $key, array $fields, string|array|null $expiry = null): RedisCluster|array|false;
+
+    /**
+     * @see Redis::hgetdel
+     */
+    public function hgetdel(string $key, array $fields): RedisCluster|array|false;
+
+    /**
      * @see Redis::hmset
      */
     public function hmset(string $key, array $key_values): RedisCluster|bool;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5788cd1d12611ef1ff5747efe07b99f66f07fa05 */
+ * Stub hash: 1660110af25a3ba9fd353c6dbb5b0132e33bcd77 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -408,6 +408,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hmget, 0,
 	ZEND_ARG_TYPE_INFO(0, keys, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetex, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_MASK(0, expiry, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetdel, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hmset, 0, 2, RedisCluster, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key_values, IS_ARRAY, 0)
@@ -478,18 +489,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hpexpirea
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_STRING, 1, "NULL")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_httl, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_RedisCluster_httl arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpttl arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpttl arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hexpiretime arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hexpiretime arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpexpiretime arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpexpiretime arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpersist arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpersist arginfo_class_RedisCluster_hgetdel
 
 #define arginfo_class_RedisCluster_hvals arginfo_class_RedisCluster_getWithMeta
 
@@ -1188,6 +1196,8 @@ ZEND_METHOD(RedisCluster, hincrbyfloat);
 ZEND_METHOD(RedisCluster, hkeys);
 ZEND_METHOD(RedisCluster, hlen);
 ZEND_METHOD(RedisCluster, hmget);
+ZEND_METHOD(RedisCluster, hgetex);
+ZEND_METHOD(RedisCluster, hgetdel);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
 ZEND_METHOD(RedisCluster, expiremember);
@@ -1428,6 +1438,8 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hkeys, arginfo_class_RedisCluster_hkeys, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hlen, arginfo_class_RedisCluster_hlen, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmget, arginfo_class_RedisCluster_hmget, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiremember, arginfo_class_RedisCluster_expiremember, ZEND_ACC_PUBLIC)

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1660110af25a3ba9fd353c6dbb5b0132e33bcd77 */
+ * Stub hash: 1f8bef24632ec9819f53aa3bc9a52fe6e85b25b9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -412,6 +412,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetex, 0
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_MASK(0, expiry, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hsetex, 0, 2, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, expiry, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetdel, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -1197,6 +1203,7 @@ ZEND_METHOD(RedisCluster, hkeys);
 ZEND_METHOD(RedisCluster, hlen);
 ZEND_METHOD(RedisCluster, hmget);
 ZEND_METHOD(RedisCluster, hgetex);
+ZEND_METHOD(RedisCluster, hsetex);
 ZEND_METHOD(RedisCluster, hgetdel);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
@@ -1439,6 +1446,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hlen, arginfo_class_RedisCluster_hlen, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmget, arginfo_class_RedisCluster_hmget, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hsetex, arginfo_class_RedisCluster_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1660110af25a3ba9fd353c6dbb5b0132e33bcd77 */
+ * Stub hash: 1f8bef24632ec9819f53aa3bc9a52fe6e85b25b9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -365,6 +365,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hgetex, 0, 0, 2)
 	ZEND_ARG_INFO(0, fields)
 	ZEND_ARG_INFO(0, expiry)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_RedisCluster_hsetex arginfo_class_RedisCluster_hgetex
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hgetdel, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -1039,6 +1041,7 @@ ZEND_METHOD(RedisCluster, hkeys);
 ZEND_METHOD(RedisCluster, hlen);
 ZEND_METHOD(RedisCluster, hmget);
 ZEND_METHOD(RedisCluster, hgetex);
+ZEND_METHOD(RedisCluster, hsetex);
 ZEND_METHOD(RedisCluster, hgetdel);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
@@ -1281,6 +1284,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hlen, arginfo_class_RedisCluster_hlen, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmget, arginfo_class_RedisCluster_hmget, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hsetex, arginfo_class_RedisCluster_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5788cd1d12611ef1ff5747efe07b99f66f07fa05 */
+ * Stub hash: 1660110af25a3ba9fd353c6dbb5b0132e33bcd77 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -360,6 +360,17 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hmget, 0, 0, 2)
 	ZEND_ARG_INFO(0, keys)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hgetex, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, fields)
+	ZEND_ARG_INFO(0, expiry)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hgetdel, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, fields)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hmset, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, key_values)
@@ -419,18 +430,15 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hpexpireat, 0, 0, 3)
 	ZEND_ARG_INFO(0, mode)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_httl, 0, 0, 2)
-	ZEND_ARG_INFO(0, key)
-	ZEND_ARG_INFO(0, fields)
-ZEND_END_ARG_INFO()
+#define arginfo_class_RedisCluster_httl arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpttl arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpttl arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hexpiretime arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hexpiretime arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpexpiretime arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpexpiretime arginfo_class_RedisCluster_hgetdel
 
-#define arginfo_class_RedisCluster_hpersist arginfo_class_RedisCluster_httl
+#define arginfo_class_RedisCluster_hpersist arginfo_class_RedisCluster_hgetdel
 
 #define arginfo_class_RedisCluster_hvals arginfo_class_RedisCluster__prefix
 
@@ -1030,6 +1038,8 @@ ZEND_METHOD(RedisCluster, hincrbyfloat);
 ZEND_METHOD(RedisCluster, hkeys);
 ZEND_METHOD(RedisCluster, hlen);
 ZEND_METHOD(RedisCluster, hmget);
+ZEND_METHOD(RedisCluster, hgetex);
+ZEND_METHOD(RedisCluster, hgetdel);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
 ZEND_METHOD(RedisCluster, expiremember);
@@ -1270,6 +1280,8 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hkeys, arginfo_class_RedisCluster_hkeys, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hlen, arginfo_class_RedisCluster_hlen, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmget, arginfo_class_RedisCluster_hmget, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiremember, arginfo_class_RedisCluster_expiremember, ZEND_ACC_PUBLIC)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4836,6 +4836,109 @@ int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
+typedef struct redisHSetExOptions {
+    zend_string *set_mode;
+    zend_string *exp_type;
+    zend_long exp_arg;
+} redisHSetExOptions;
+
+void get_hsetex_expiry_options(redisHSetExOptions *dst, zval *zsrc) {
+    zend_string *key;
+    zend_long lval;
+    zval *zv;
+
+    *dst = (redisHSetExOptions) {
+        .exp_arg = -1,
+    };
+
+    if (zsrc == NULL)
+        return;
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(zsrc), key, zv) {
+        if (key == NULL) {
+            if (Z_TYPE_P(zv) == IS_STRING) {
+                key = Z_STR_P(zv);
+                if (zend_string_equals_literal_ci(key, "FNX") ||
+                    zend_string_equals_literal_ci(key, "FXX"))
+                {
+                    dst->set_mode = Z_STR_P(zv);
+                } else if (zend_string_equals_literal_ci(key, "KEEPTTL")) {
+                    dst->exp_type = key;
+                    dst->exp_arg = -1;
+                }
+            }
+        } else if (zend_string_equals_literal_ci(key, "EX") ||
+                   zend_string_equals_literal_ci(key, "PX") ||
+                   zend_string_equals_literal_ci(key, "EXAT") ||
+                   zend_string_equals_literal_ci(key, "PXAT"))
+        {
+            lval = zval_get_long(zv);
+            if (lval >= 0) {
+                dst->exp_type = key;
+                dst->exp_arg = lval;
+            } else {
+                php_error_docref(NULL, E_WARNING, "Timeouts must be >= 0");
+            }
+        }
+    } ZEND_HASH_FOREACH_END();
+}
+
+int redis_hsetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    redisHSetExOptions opts = {0};
+    zval *zexpiry = NULL, *zv;
+    smart_string cmdstr = {0};
+    HashTable *fields;
+    zend_string *key;
+    zend_ulong idx;
+    int argc;
+
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STR(key)
+        Z_PARAM_ARRAY_HT(fields)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ZVAL_OR_NULL(zexpiry);
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
+
+    if (zend_hash_num_elements(fields) == 0) {
+        php_error_docref(NULL, E_WARNING, "Must pass at least one field");
+        return FAILURE;
+    }
+
+    get_hsetex_expiry_options(&opts, zexpiry);
+
+    argc = 3 + !!opts.set_mode + !!opts.exp_type + (opts.exp_arg >= 0) +
+           zend_hash_num_elements(fields) * 2;
+
+    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "HSETEX");
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+    if (opts.set_mode)
+        redis_cmd_append_sstr_zstr(&cmdstr, opts.set_mode);
+    if (opts.exp_type) {
+        redis_cmd_append_sstr_zstr(&cmdstr, opts.exp_type);
+        if (opts.exp_arg >= 0)
+            redis_cmd_append_sstr_long(&cmdstr, opts.exp_arg);
+    }
+
+    REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
+    redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(fields));
+
+    ZEND_HASH_FOREACH_KEY_VAL(fields, idx, key, zv)
+        if (key) {
+            redis_cmd_append_sstr_zstr(&cmdstr, key);
+        } else {
+            redis_cmd_append_sstr_long(&cmdstr, idx);
+        }
+        redis_cmd_append_sstr_zval(&cmdstr, zv, redis_sock);
+    ZEND_HASH_FOREACH_END();
+
+    *cmd = cmdstr.c;
+    *cmd_len = cmdstr.len;
+
+    return SUCCESS;
+}
+
 int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                       char **cmd, int *cmd_len, short *slot, void **ctx)
 {
@@ -4861,7 +4964,6 @@ int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         return FAILURE;
     }
 
-    // HGETDEL <hash> FIELDS <numfields> <field1>...
     argc = 3 + zend_hash_num_elements(htctx);
 
     redis_cmd_init_sstr(&cmdstr, argc, ZEND_STRL("HGETDEL"));

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2647,15 +2647,50 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
+/* A helper function to build HMGET, HGETEX, HGETDEL context arrays we curry
+ * to the reply side to return to the user fields and values */
+static HashTable *
+build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
+    HashTable *ht;
+    zval *zv;
+
+    ALLOC_HASHTABLE(ht);
+    zend_hash_init(ht, zend_hash_num_elements(htsrc),
+                   NULL, ZVAL_PTR_DTOR, 0);
+
+    ZEND_HASH_FOREACH_VAL(htsrc, zv)
+        ZVAL_DEREF(zv);
+        if (cb && !cb(zv))
+            continue;
+
+        zend_hash_next_index_insert(ht, zv);
+    ZEND_HASH_FOREACH_END();
+
+    /* Sanity check that we have at least one value */
+    if (zend_hash_num_elements(ht) == 0) {
+        zend_hash_destroy(ht);
+        FREE_HASHTABLE(ht);
+        return NULL;
+    }
+
+    return ht;
+}
+
+/* Legacy HMGET behavior predicate */
+static zend_bool hmget_filter(zval *zv) {
+    return (Z_TYPE_P(zv) == IS_STRING && Z_STRLEN_P(zv) > 0) ||
+           (Z_TYPE_P(zv) == IS_LONG);
+}
+
 /* HMGET */
 int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     char **cmd, int *cmd_len, short *slot, void **ctx)
 {
-    zval *field = NULL, *zctx = NULL;
+    HashTable *fields = NULL, *htctx = NULL;
     smart_string cmdstr = {0};
-    HashTable *fields = NULL;
     zend_string *key = NULL;
-    zend_ulong valid = 0, i;
+    zval *field = NULL;
+    int argc;
 
     ZEND_PARSE_PARAMETERS_START(2, 2)
         Z_PARAM_STR(key)
@@ -2665,34 +2700,24 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     if (zend_hash_num_elements(fields) == 0)
         return FAILURE;
 
-    zctx = ecalloc(1 + zend_hash_num_elements(fields), sizeof(*zctx));
-
-    ZEND_HASH_FOREACH_VAL(fields, field) {
-        ZVAL_DEREF(field);
-        if (!((Z_TYPE_P(field) == IS_STRING && Z_STRLEN_P(field) > 0) || Z_TYPE_P(field) == IS_LONG))
-            continue;
-
-        ZVAL_COPY(&zctx[valid++], field);
-    } ZEND_HASH_FOREACH_END();
-
-    if (valid == 0) {
-        efree(zctx);
+    htctx = build_hash_context_ht(fields, hmget_filter);
+    if (htctx == NULL) {
+        php_error_docref(NULL, E_WARNING, "No valid fields provided");
         return FAILURE;
     }
 
-    ZVAL_NULL(&zctx[valid]);
-
-    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, 1 + valid, "HMGET");
+    argc = 1 + zend_hash_num_elements(htctx);
+    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "HMGET");
     redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
 
-    for (i = 0; i < valid; i++) {
-        redis_cmd_append_sstr_zval(&cmdstr, &zctx[i], NULL);
-    }
+    ZEND_HASH_FOREACH_VAL(htctx, field) {
+        redis_cmd_append_sstr_zval(&cmdstr, field, redis_sock);
+    } ZEND_HASH_FOREACH_END();
 
     // Push out command, length, and key context
     *cmd     = cmdstr.c;
     *cmd_len = cmdstr.len;
-    *ctx     = zctx;
+    *ctx     = htctx;
 
     return SUCCESS;
 }
@@ -4669,6 +4694,111 @@ int redis_httl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, char *kw
 
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;
+
+    return SUCCESS;
+}
+
+typedef struct redisHGetExOptions {
+    zend_string *exp_type;
+    zend_long exp_arg;
+} redisHGetExOptions;
+
+static int get_hgetex_expiry_opts(redisHGetExOptions *dst, zval *zv) {
+    zend_string *zkey;
+    HashTable *ht;
+    zval *zexp;
+
+    *dst = (redisHGetExOptions) {
+        .exp_type = NULL,
+        .exp_arg = -1
+    };
+
+    if (zv == NULL)
+        return SUCCESS;
+
+    if (Z_TYPE_P(zv) != IS_STRING && Z_TYPE_P(zv) != IS_ARRAY) {
+        php_error_docref(NULL, E_WARNING,
+            "Expiry value must be a string or an array of strings");
+        return FAILURE;
+    }
+
+    if (Z_TYPE_P(zv) == IS_STRING) {
+        dst->exp_type = Z_STR_P(zv);
+        dst->exp_arg = -1;
+        return SUCCESS;
+    }
+
+    ht = Z_ARRVAL_P(zv);
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, zkey, zexp)
+        if (zkey == NULL)
+            continue;
+
+        if (Z_TYPE_P(zexp) != IS_LONG || Z_LVAL_P(zexp) < 0) {
+            php_error_docref(NULL, E_WARNING,
+                "Expiry must be an integer >= 0");
+            return FAILURE;
+        }
+
+        dst->exp_type = zkey;
+        dst->exp_arg = Z_LVAL_P(zexp);
+    ZEND_HASH_FOREACH_END();
+
+    return SUCCESS;
+}
+
+int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    zval *zexpiry = NULL, *zfield;
+    redisHGetExOptions opts = {0};
+    smart_string cmdstr = {0};
+    HashTable *fields, *htctx;
+    zend_string *key;
+    int argc;
+
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STR(key)
+        Z_PARAM_ARRAY_HT(fields)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ZVAL_OR_NULL(zexpiry);
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
+
+    if (zend_hash_num_elements(fields) == 0) {
+        php_error_docref(NULL, E_WARNING, "Must pass at least one field");
+        return FAILURE;
+    } else if (get_hgetex_expiry_opts(&opts, zexpiry) == FAILURE) {
+        return FAILURE;
+    }
+
+    htctx = build_hash_context_ht(fields, hmget_filter);
+    if (htctx == NULL) {
+        php_error_docref(NULL, E_WARNING,
+            "Failed to build context hash table");
+        return FAILURE;
+    }
+
+    argc = 3 + (opts.exp_type != NULL) + (opts.exp_arg >= 0) +
+           zend_hash_num_elements(fields);
+
+    redis_cmd_init_sstr(&cmdstr, argc, ZEND_STRL("HGETEX"));
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+    if (opts.exp_type) {
+        redis_cmd_append_sstr_zstr(&cmdstr, opts.exp_type);
+        if (opts.exp_arg >= 0)
+            redis_cmd_append_sstr_long(&cmdstr, opts.exp_arg);
+    }
+
+    REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
+    redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(fields));
+
+    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
+        redis_cmd_append_sstr_zval(&cmdstr, zfield, redis_sock);
+    } ZEND_HASH_FOREACH_END();
+
+    *cmd = cmdstr.c;
+    *cmd_len = cmdstr.len;
+    *ctx = htctx;
 
     return SUCCESS;
 }

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4793,7 +4793,53 @@ int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     }
 
     REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
-    redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(fields));
+    redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(htctx));
+
+    /* Invariant: All keys are strings */
+    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
+        redis_cmd_append_sstr_zstr(&cmdstr, key);
+    } ZEND_HASH_FOREACH_END();
+
+    *cmd = cmdstr.c;
+    *cmd_len = cmdstr.len;
+    *ctx = htctx;
+
+    return SUCCESS;
+}
+
+int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                      char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    HashTable *fields, *htctx;
+    smart_string cmdstr = {0};
+    zend_string *key;
+    int argc;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STR(key);
+        Z_PARAM_ARRAY_HT(fields);
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
+
+    if (zend_hash_num_elements(fields) == 0) {
+        php_error_docref(NULL, E_WARNING, "Must pass at least one field");
+        return FAILURE;
+    }
+
+    htctx = build_hash_context_ht(fields, hmget_filter);
+    if (htctx == NULL) {
+        php_error_docref(NULL, E_WARNING,
+            "Failed to build context hash table");
+        return FAILURE;
+    }
+
+    // HGETDEL <hash> FIELDS <numfields> <field1>...
+    argc = 3 + zend_hash_num_elements(htctx);
+
+    redis_cmd_init_sstr(&cmdstr, argc, ZEND_STRL("HGETDEL"));
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+
+    REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
+    redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(htctx));
 
     /* Invariant: All keys are strings */
     ZEND_HASH_FOREACH_STR_KEY(htctx, key) {

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2651,6 +2651,7 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
  * to the reply side to return to the user fields and values */
 static HashTable *
 build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
+    zend_string *key;
     HashTable *ht;
     zval *zv;
 
@@ -2663,7 +2664,9 @@ build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
         if (cb && !cb(zv))
             continue;
 
-        zend_hash_next_index_insert(ht, zv);
+        key = zval_get_string(zv);
+        zend_hash_add_empty_element(ht, key);
+        zend_string_release(key);
     ZEND_HASH_FOREACH_END();
 
     /* Sanity check that we have at least one value */
@@ -2689,7 +2692,6 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     HashTable *fields = NULL, *htctx = NULL;
     smart_string cmdstr = {0};
     zend_string *key = NULL;
-    zval *field = NULL;
     int argc;
 
     ZEND_PARSE_PARAMETERS_START(2, 2)
@@ -2710,8 +2712,9 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "HMGET");
     redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
 
-    ZEND_HASH_FOREACH_VAL(htctx, field) {
-        redis_cmd_append_sstr_zval(&cmdstr, field, redis_sock);
+    /* Invariant: All keys are strings */
+    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
+        redis_cmd_append_sstr_zstr(&cmdstr, key);
     } ZEND_HASH_FOREACH_END();
 
     // Push out command, length, and key context
@@ -4750,10 +4753,10 @@ static int get_hgetex_expiry_opts(redisHGetExOptions *dst, zval *zv) {
 int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                      char **cmd, int *cmd_len, short *slot, void **ctx)
 {
-    zval *zexpiry = NULL, *zfield;
     redisHGetExOptions opts = {0};
     smart_string cmdstr = {0};
     HashTable *fields, *htctx;
+    zval *zexpiry = NULL;
     zend_string *key;
     int argc;
 
@@ -4792,8 +4795,9 @@ int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
     redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(fields));
 
-    ZEND_HASH_FOREACH_VAL(htctx, zfield) {
-        redis_cmd_append_sstr_zval(&cmdstr, zfield, redis_sock);
+    /* Invariant: All keys are strings */
+    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
+        redis_cmd_append_sstr_zstr(&cmdstr, key);
     } ZEND_HASH_FOREACH_END();
 
     *cmd = cmdstr.c;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2665,7 +2665,7 @@ static inline zval *coerce_hash_field(zval *zv, zval *aux) {
  * to the reply side to return to the user fields and values */
 static HashTable *
 build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
-    zend_string *key;
+    zend_string *key, *tmp;
     HashTable *ht;
     zval *zv, aux;
 
@@ -2684,9 +2684,9 @@ build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
         if (Z_TYPE_P(zv) == IS_LONG) {
             zend_hash_index_add_empty_element(ht, Z_LVAL_P(zv));
         } else {
-            key = zval_get_string(zv);
+            key = zval_get_tmp_string(zv, &tmp);
             zend_hash_add_empty_element(ht, key);
-            zend_string_release(key);
+            zend_tmp_string_release(tmp);
         }
     ZEND_HASH_FOREACH_END();
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2647,13 +2647,27 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 }
 
+static inline zval *coerce_hash_field(zval *zv, zval *aux) {
+    zend_long lv;
+
+    if (UNEXPECTED(Z_TYPE_P(zv) == IS_STRING &&
+                   is_numeric_string(Z_STRVAL_P(zv),
+                                     Z_STRLEN_P(zv), &lv, NULL, 1) == IS_LONG))
+    {
+        ZVAL_LONG(aux, lv);
+        return aux;
+    }
+
+    return zv;
+}
+
 /* A helper function to build HMGET, HGETEX, HGETDEL context arrays we curry
  * to the reply side to return to the user fields and values */
 static HashTable *
 build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
     zend_string *key;
     HashTable *ht;
-    zval *zv;
+    zval *zv, aux;
 
     ALLOC_HASHTABLE(ht);
     zend_hash_init(ht, zend_hash_num_elements(htsrc),
@@ -2664,9 +2678,16 @@ build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
         if (cb && !cb(zv))
             continue;
 
-        key = zval_get_string(zv);
-        zend_hash_add_empty_element(ht, key);
-        zend_string_release(key);
+        /* Legacy behavior: Integer strings become integer keys */
+        zv = coerce_hash_field(zv, &aux);
+
+        if (Z_TYPE_P(zv) == IS_LONG) {
+            zend_hash_index_add_empty_element(ht, Z_LVAL_P(zv));
+        } else {
+            key = zval_get_string(zv);
+            zend_hash_add_empty_element(ht, key);
+            zend_string_release(key);
+        }
     ZEND_HASH_FOREACH_END();
 
     /* Sanity check that we have at least one value */
@@ -2683,6 +2704,21 @@ build_hash_context_ht(HashTable *htsrc, zend_bool (*cb)(zval*)) {
 static zend_bool hmget_filter(zval *zv) {
     return (Z_TYPE_P(zv) == IS_STRING && Z_STRLEN_P(zv) > 0) ||
            (Z_TYPE_P(zv) == IS_LONG);
+}
+
+static void
+redis_cmd_append_sstr_hash_fields(smart_string *cmdstr, HashTable *ht) {
+    zend_string *key;
+    zend_ulong idx;
+
+    ZEND_HASH_FOREACH_KEY(ht, idx, key) {
+        if (key) {
+            redis_cmd_append_sstr_zstr(cmdstr, key);
+        } else {
+            redis_cmd_append_sstr_long(cmdstr, idx);
+        }
+    } ZEND_HASH_FOREACH_END();
+
 }
 
 /* HMGET */
@@ -2712,10 +2748,7 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "HMGET");
     redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
 
-    /* Invariant: All keys are strings */
-    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
-        redis_cmd_append_sstr_zstr(&cmdstr, key);
-    } ZEND_HASH_FOREACH_END();
+    redis_cmd_append_sstr_hash_fields(&cmdstr, htctx);
 
     // Push out command, length, and key context
     *cmd     = cmdstr.c;
@@ -4794,11 +4827,7 @@ int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
     redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(htctx));
-
-    /* Invariant: All keys are strings */
-    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
-        redis_cmd_append_sstr_zstr(&cmdstr, key);
-    } ZEND_HASH_FOREACH_END();
+    redis_cmd_append_sstr_hash_fields(&cmdstr, htctx);
 
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;
@@ -4840,11 +4869,7 @@ int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FIELDS");
     redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(htctx));
-
-    /* Invariant: All keys are strings */
-    ZEND_HASH_FOREACH_STR_KEY(htctx, key) {
-        redis_cmd_append_sstr_zstr(&cmdstr, key);
-    } ZEND_HASH_FOREACH_END();
+    redis_cmd_append_sstr_hash_fields(&cmdstr, htctx);
 
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -230,6 +230,9 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                      char **cmd, int *cmd_len, short *slot, void **ctx);
 
+int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                      char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_mget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -230,6 +230,9 @@ int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                      char **cmd, int *cmd_len, short *slot, void **ctx);
 
+int redis_hsetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                       char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -227,6 +227,9 @@ int redis_hincrbyfloat_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
+int redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                     char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_mget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c6205649cd23ff2b9fcc63a034b601ee566ef236 */
+ * Stub hash: adc2be7c374cce1155e6eeef3b98e2bb60feb277 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -392,6 +392,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hMget, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, fields)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hgetex, 0, 0, 2)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, fields)
+	ZEND_ARG_INFO(0, expiry)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hMset, 0, 0, 2)
@@ -1161,6 +1167,7 @@ ZEND_METHOD(Redis, hIncrByFloat);
 ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
+ZEND_METHOD(Redis, hgetex);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1431,6 +1438,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hKeys, arginfo_class_Redis_hKeys, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: adc2be7c374cce1155e6eeef3b98e2bb60feb277 */
+ * Stub hash: d4804349b4f9077bdcffa97bc770d168d9944ddd */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -399,6 +399,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hgetex, 0, 0, 2)
 	ZEND_ARG_INFO(0, fields)
 	ZEND_ARG_INFO(0, expiry)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hMset, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -1168,6 +1170,7 @@ ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
+ZEND_METHOD(Redis, hgetdel);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1439,6 +1442,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d4804349b4f9077bdcffa97bc770d168d9944ddd */
+ * Stub hash: ec3421b68033c6299a4dc00ab0bbd31576a10961 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -399,6 +399,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hgetex, 0, 0, 2)
 	ZEND_ARG_INFO(0, fields)
 	ZEND_ARG_INFO(0, expiry)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Redis_hsetex arginfo_class_Redis_hgetex
 
 #define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
 
@@ -1170,6 +1172,7 @@ ZEND_METHOD(Redis, hKeys);
 ZEND_METHOD(Redis, hLen);
 ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
+ZEND_METHOD(Redis, hsetex);
 ZEND_METHOD(Redis, hgetdel);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
@@ -1442,6 +1445,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hLen, arginfo_class_Redis_hLen, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMget, arginfo_class_Redis_hMget, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, hsetex, arginfo_class_Redis_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6383,6 +6383,72 @@ class Redis_Test extends TestSuite {
         }
     }
 
+    public function testHSetEx(): void {
+        if ( ! $this->minVersionCheck('8.0')) {
+            $this->markTestSkipped('HSETEX requires Redis 8+');
+        }
+
+        $now  = time();
+        $nowMs = $now * 1000;
+        $hash = ['a' => 'foo', 'b' => 'bar'];
+
+        $cases = [
+            [['EX', 5], 'httl'],
+            [['PX', 1234], 'hpttl'],
+            [['EXAT', $now + 5], 'hexpiretime'],
+            [['PXAT', $nowMs + 5000], 'hpexpiretime'],
+        ];
+
+        foreach ($cases as [[$ex, $n], $ttlFn]) {
+            $this->redis->del('hash');
+            $this->assertTrue($this->redis->hMSet('hash', $hash));
+
+            $expireArg = [$ex => $n];
+            $result = $this->redis->hsetex('hash', $hash, $expireArg);
+            $this->assertLTE(count($hash), $result);
+
+            $got = $this->redis->hMGet('hash', array_keys($hash));
+            $this->assertEquals($hash, $got);
+
+            $ttls = $this->redis->{$ttlFn}('hash', array_keys($hash));
+            $this->assertIsArray($ttls);
+
+            foreach ($ttls as $ttl) {
+                $this->assertLTE($n, $ttl);
+            }
+        }
+
+        $this->assertIsInt($this->redis->del('hash'));
+        $this->assertEquals(
+            1, $this->redis->hsetex('hash', ['a' => 'v'], ['EX' => 20])
+        );
+        $this->assertEquals(
+            1, $this->redis->hsetex('hash', ['a' => 'v2'], ['KEEPTTL'])
+        );
+
+        $ttl = $this->redis->httl('hash', ['a']);
+        $this->assertLTE(20, $ttl[0]);
+
+        $this->assertIsInt($this->redis->del('hash'));
+
+        // FNX - Only if none exist
+        foreach ([1, 0] as $expected) {
+            $ex = ['EX' => 20, 'FNX'];
+            $result = $this->redis->hsetex('hash', $hash, $ex);
+            $this->assertEquals($expected, $result);
+        }
+
+        // FXX - Only if they all exist
+        foreach ([1, 0] as $expected) {
+            $ex = ['EX' => 20, 'FXX'];
+            $result = $this->redis->hsetex('hash', $hash, $ex);
+            $this->assertEquals($expected, $result);
+
+            $k = array_rand($hash);
+            $this->redis->hdel('hash', $k);
+        }
+    }
+
     public function testHGetDel() {
         if ( ! $this->minVersionCheck('8.0'))
             $this->markTestSkipped();

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6350,6 +6350,53 @@ class Redis_Test extends TestSuite {
         }
     }
 
+    public function testHGetEx() {
+        if ( ! $this->minVersionCheck('8.0'))
+            $this->markTestSkipped();
+
+        $now = time();
+
+        $tests = [
+            [['EX' => 10], 'httl', 0, 10],
+            [['PX' => 10000], 'hpttl', 0, 10000],
+            [['EXAT' => $now + 10], 'hexpiretime', $now, $now + 10],
+            [['PXAT' => $now * 1000 + 10000], 'hpexpiretime', $now * 1000, $now * 1000 + 10000],
+            ['PERSIST', 'httl', -1, -1],
+            [['PERSIST'], 'httl', -1,-1],
+        ];
+
+        $hash = ['ship' => 'Defiant', 'captain' => 'Sisko'];
+
+        foreach ($tests as [$expireArg, $ttlFn, $minTtl, $maxTtl]) {
+            $this->redis->del('hash');
+            $this->assertTrue($this->redis->hmset('hash', $hash));
+
+            $v = $this->redis->hgetex('hash', ['ship', 'captain'], $expireArg);
+            $this->assertEquals($hash, $v);
+
+            $ttls = $this->redis->{$ttlFn}('hash', ['ship', 'captain']);
+            $this->assertIsArray($ttls);
+
+            foreach ($ttls as $val) {
+                $this->assertBetween($val, $minTtl, $maxTtl);
+            }
+        }
+    }
+
+    public function testHGetDel() {
+        if ( ! $this->minVersionCheck('8.0'))
+            $this->markTestSkipped();
+
+        $this->assertIsInt($this->redis->del('hash'));
+        $hash = ['ship' => 'Defiant', 'captain' => 'Sisko'];
+
+        $this->assertTrue($this->redis->hmset('hash', $hash));
+        $this->assertEquals($hash, $this->redis->hgetall('hash'));
+
+        $this->assertEquals(['captain' => 'Sisko'], $this->redis->hgetdel('hash', ['captain']));
+        $this->assertEquals(['ship' => 'Defiant'], $this->redis->hgetall('hash'));
+    }
+
     public function testHScan() {
         if (version_compare($this->version, '2.8.0') < 0)
             $this->markTestSkipped();


### PR DESCRIPTION
This PR implements `HGETEX`, `HSETEX`, `HGETDEL` for both `Redis` and `RedisCluster` and also refactors how we curry context for the fields in these commands and `HMGET`.

Instead of using a `NULL` terminated array of `zval` fields we use a `HashTable` of keys that we then update in-place with the corresponding values.