### PR TITLE
Fix/sentinel persistent connections

### DIFF
--- a/common.h
+++ b/common.h
@@ -264,12 +264,6 @@ static inline int redis_strncmp(const char *s1, const char *s2, size_t n) {
 #define ZSTR_STRICMP_STATIC(zs, sstr) \
     REDIS_STRICMP_STATIC(ZSTR_VAL(zs), ZSTR_LEN(zs), sstr)
 
-#define REDIS_ENABLE_MODE(redis_sock, m) (redis_sock->mode |= m)
-#define REDIS_DISABLE_MODE(redis_sock, m) (redis_sock->mode &= ~m)
-
-#define REDIS_ENABLE_FLAG(redis_sock, f) (redis_sock->flags |= f)
-#define REDIS_DISABLE_FLAG(redis_sock, f) (redis_sock->flags &= ~f)
-
 /* HOST_NAME_MAX doesn't exist everywhere */
 #ifndef HOST_NAME_MAX
     #if defined(_POSIX_HOST_NAME_MAX)

--- a/library.c
+++ b/library.c
@@ -2946,10 +2946,30 @@ static int redis_stream_detect_dirty(php_stream *stream) {
     return rv == 0 ? SUCCESS : FAILURE;
 }
 
+static inline zend_bool
+redis_check_echo_response(RedisSock *redis_sock, char *hdr, const char *id,
+                          size_t idlen)
+{
+    char buf[256] = {0};
+    size_t len;
+
+    /* Sentinel doesn't have ECHO but it will contain the ID in the error
+     * message so just check that */
+    if (redis_sock->sentinel) {
+        return redis_strncmp(hdr, ZEND_STRL("-ERR unknown command")) == 0 &&
+               strstr(hdr, id) != NULL;
+    }
+
+    /* Non-sentinel: Read and verify the ID */
+    return *hdr == TYPE_BULK && atoi(hdr + 1) == idlen &&
+           redis_sock_gets(redis_sock, buf, sizeof(buf) - 1, &len) == 0 &&
+           redis_strncmp(buf, id, idlen) == 0;
+}
+
 static int
 redis_sock_check_liveness(RedisSock *redis_sock)
 {
-    char id[64], inbuf[4096];
+    char id[64], inbuf[256] = {0};
     int idlen, auth;
     smart_string cmd = {0};
     size_t len;
@@ -3015,18 +3035,10 @@ redis_sock_check_liveness(RedisSock *redis_sock)
         }
     }
 
-    /* check echo response */
-    if ((redis_sock->sentinel && (
-        redis_strncmp(inbuf, ZEND_STRL("-ERR unknown command")) != 0 ||
-        strstr(inbuf, id) == NULL
-    )) || *inbuf != TYPE_BULK || atoi(inbuf + 1) != idlen ||
-        redis_sock_gets(redis_sock, inbuf, sizeof(inbuf) - 1, &len) < 0 ||
-        redis_strncmp(inbuf, id, idlen) != 0
-    ) {
-        goto failure;
+    if (redis_check_echo_response(redis_sock, inbuf, id, idlen)) {
+        return SUCCESS;
     }
 
-    return SUCCESS;
 failure:
     redis_sock->status = REDIS_SOCK_STATUS_DISCONNECTED;
     if (redis_sock->stream) {

--- a/redis.c
+++ b/redis.c
@@ -1983,7 +1983,7 @@ PHP_METHOD(Redis, multi)
 
         /* Enable PIPELINE if we're not already in one */
         if (IS_ATOMIC(redis_sock)) {
-            REDIS_ENABLE_MODE(redis_sock, PIPELINE);
+            redis_sock->mode |= PIPELINE;
         }
     } else if (multi_value == MULTI) {
         /* Don't want to do anything if we're already in MULTI mode */
@@ -1991,7 +1991,7 @@ PHP_METHOD(Redis, multi)
             if (IS_PIPELINE(redis_sock)) {
                 PIPELINE_ENQUEUE_COMMAND(RESP_MULTI_CMD, sizeof(RESP_MULTI_CMD) - 1);
                 REDIS_SAVE_CALLBACK(NULL, NULL);
-                REDIS_ENABLE_MODE(redis_sock, MULTI);
+                redis_sock->mode |= MULTI;
             } else {
                 if (redis_sock_write(redis_sock, ZEND_STRL(RESP_MULTI_CMD)) < 0) {
                     RETURN_FALSE;
@@ -2003,7 +2003,7 @@ PHP_METHOD(Redis, multi)
                     RETURN_FALSE;
                 }
                 efree(resp);
-                REDIS_ENABLE_MODE(redis_sock, MULTI);
+                redis_sock->mode |= MULTI;
             }
         }
     } else {
@@ -2091,7 +2091,7 @@ PHP_METHOD(Redis, exec)
         if (IS_PIPELINE(redis_sock)) {
             PIPELINE_ENQUEUE_COMMAND(RESP_EXEC_CMD, sizeof(RESP_EXEC_CMD) - 1);
             REDIS_SAVE_CALLBACK(NULL, NULL);
-            REDIS_DISABLE_MODE(redis_sock, MULTI);
+            redis_sock->mode &= ~MULTI;
             RETURN_ZVAL(getThis(), 1, 0);
         }
         if (redis_sock_write(redis_sock, ZEND_STRL(RESP_EXEC_CMD)) < 0) {
@@ -2100,7 +2100,7 @@ PHP_METHOD(Redis, exec)
         ret = redis_sock_read_multibulk_multi_reply(
             INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &z_ret);
         redis_free_reply_callbacks(redis_sock);
-        REDIS_DISABLE_MODE(redis_sock, MULTI);
+        redis_sock->mode &= ~MULTI;
         redis_sock->watching = 0;
         if (ret < 0) {
             zval_dtor(&z_ret);
@@ -2127,7 +2127,7 @@ PHP_METHOD(Redis, exec)
             smart_string_free(&redis_sock->pipeline_cmd);
         }
         redis_free_reply_callbacks(redis_sock);
-        REDIS_DISABLE_MODE(redis_sock, PIPELINE);
+        redis_sock->mode &= ~PIPELINE;
     }
     RETURN_ZVAL(&z_ret, 0, 1);
 }
@@ -2217,10 +2217,7 @@ PHP_METHOD(Redis, pipeline)
     /* Enable pipeline mode unless we're already in that mode in which case this
      * is just a NO OP */
     if (IS_ATOMIC(redis_sock)) {
-        /* NB : we keep the function fold, to detect the last function.
-         * We need the response format of the n - 1 command. So, we can delete
-         * when n > 2, the { 1 .. n - 2} commands */
-        REDIS_ENABLE_MODE(redis_sock, PIPELINE);
+        redis_sock->mode |= PIPELINE;
     }
 
     RETURN_ZVAL(getThis(), 1, 0);

--- a/tests/RedisSentinelTest.php
+++ b/tests/RedisSentinelTest.php
@@ -116,4 +116,45 @@ class Redis_Sentinel_Test extends TestSuite
             $this->checkFields($slave);
         }
     }
+
+    protected function getClients(Redis $redis, string $cmd)
+    {
+        $result = [];
+
+        foreach ($redis->client('list') as $client) {
+            if ($client['cmd'] !== $cmd)
+                continue;
+
+            $result[] = $client['id'];
+        }
+
+        return $result;
+    }
+
+    public function testPersistent() {
+        /* I think the tests just use the default port */
+        $redis = new Redis;
+        $redis->connect($this->getHost(), 26379);
+
+        $id = null;
+
+        for ($i = 0; $i < 3; $i++) {
+            $sentinel = new RedisSentinel([
+                'host' => $this->getHost(),
+                'persistent' => 'sentinel',
+            ]);
+
+            $this->assertTrue($sentinel->ping());
+
+            $clients = $this->getClients($redis, 'ping');
+
+            /* Capture the ping client */
+            $id ??= $clients[0];
+
+            unset($sentinel);
+        }
+
+        /* The same client should have been reused */
+        $this->assertEquals($id, $clients[0]);
+    }
 }


### PR DESCRIPTION
This PR fixes persistent connections for `RedisSentinel` by disabling the echo liveness check when we detect the socket is a sentinel connection.

It also adds a simple test to confirm that we reuse the same persistent connection. I've also tested it locally with a password protected sentinel.