### PR TITLE
Fix HSetEx expiry argument handling

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4842,7 +4842,7 @@ typedef struct redisHSetExOptions {
     zend_long exp_arg;
 } redisHSetExOptions;
 
-void get_hsetex_expiry_options(redisHSetExOptions *dst, zval *zsrc) {
+void get_hsetex_expiry_options(redisHSetExOptions *dst, HashTable *src) {
     zend_string *key;
     zend_long lval;
     zval *zv;
@@ -4851,10 +4851,10 @@ void get_hsetex_expiry_options(redisHSetExOptions *dst, zval *zsrc) {
         .exp_arg = -1,
     };
 
-    if (zsrc == NULL)
+    if (src == NULL)
         return;
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(zsrc), key, zv) {
+    ZEND_HASH_FOREACH_STR_KEY_VAL(src, key, zv) {
         if (key == NULL) {
             if (Z_TYPE_P(zv) == IS_STRING) {
                 key = Z_STR_P(zv);
@@ -4887,18 +4887,18 @@ int redis_hsetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                      char **cmd, int *cmd_len, short *slot, void **ctx)
 {
     redisHSetExOptions opts = {0};
-    zval *zexpiry = NULL, *zv;
     smart_string cmdstr = {0};
-    HashTable *fields;
+    HashTable *fields, *expiry = NULL;
     zend_string *key;
     zend_ulong idx;
+    zval *zv;
     int argc;
 
     ZEND_PARSE_PARAMETERS_START(2, 3)
         Z_PARAM_STR(key)
         Z_PARAM_ARRAY_HT(fields)
         Z_PARAM_OPTIONAL
-        Z_PARAM_ZVAL_OR_NULL(zexpiry);
+        Z_PARAM_ARRAY_HT_OR_NULL(expiry);
     ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
 
     if (zend_hash_num_elements(fields) == 0) {
@@ -4906,7 +4906,7 @@ int redis_hsetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         return FAILURE;
     }
 
-    get_hsetex_expiry_options(&opts, zexpiry);
+    get_hsetex_expiry_options(&opts, expiry);
 
     argc = 3 + !!opts.set_mode + !!opts.exp_type + (opts.exp_arg >= 0) +
            zend_hash_num_elements(fields) * 2;


### PR DESCRIPTION
Following code leads zpp mismatch error
```php
$redis = new Redis();
var_dump($redis->hsetex("hash", [], 42));
```
```
PHP Warning:  Redis::hsetex(): Must pass at least one field in Command line code on line 1
PHP Fatal error:  Arginfo / zpp mismatch during call of Redis::hsetex() in Command line code on line 1
```
Or even segfault
```php
$redis = new Redis();
var_dump($redis->hsetex("hash", ["a" => 1, "b" => 2], 42));
```

```
(gdb) bt
#0  0x00007fea0aba1897 in get_hsetex_expiry_options (dst=0x7ffe46c3df00, src=0x7fea0c6131a0) at /home/pyatsukhnenko/code/phpredis/redis_commands.c:4857
#1  0x00007fea0aba20e3 in redis_hsetex_cmd (execute_data=0x7fea0c613130, return_value=0x7fea0c6130b0, redis_sock=0x7fea0c66b300, cmd=0x7ffe46c3df98, 
    cmd_len=0x7ffe46c3df8c, slot=0x0, ctx=0x7ffe46c3dfa0) at /home/pyatsukhnenko/code/phpredis/redis_commands.c:4905
#2  0x00007fea0ab73ee1 in zim_Redis_hsetex (execute_data=0x7fea0c613130, return_value=0x7fea0c6130b0) at /home/pyatsukhnenko/code/phpredis/redis.c:1880
#3  0x0000556da126fdc6 in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER () at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_vm_execute.h:1976
#4  0x0000556da12ef142 in execute_ex (ex=0x7fea0c613020) at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_vm_execute.h:57303
#5  0x0000556da12f4974 in zend_execute (op_array=0x7fea0c67b140, return_value=0x7ffe46c3e320)
    at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_vm_execute.h:61655
#6  0x0000556da120b6ac in zend_eval_stringl (str=0x556dabdcffe0 "$redis = new Redis(); var_dump($redis->hsetex(\"hash\", [\"a\" => 1, \"b\" => 2], 42));", str_len=81, 
    retval_ptr=0x0, string_name=0x556da1dbba54 "Command line code") at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_execute_API.c:1316
#7  0x0000556da120b8d5 in zend_eval_stringl_ex (str=0x556dabdcffe0 "$redis = new Redis(); var_dump($redis->hsetex(\"hash\", [\"a\" => 1, \"b\" => 2], 42));", str_len=81, 
    retval_ptr=0x0, string_name=0x556da1dbba54 "Command line code", handle_exceptions=true)
    at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_execute_API.c:1358
#8  0x0000556da120b95c in zend_eval_string_ex (str=0x556dabdcffe0 "$redis = new Redis(); var_dump($redis->hsetex(\"hash\", [\"a\" => 1, \"b\" => 2], 42));", 
    retval_ptr=0x0, string_name=0x556da1dbba54 "Command line code", handle_exceptions=true)
    at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/Zend/zend_execute_API.c:1368
#9  0x0000556da13b8762 in do_cli (argc=3, argv=0x556dabdcff70) at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/sapi/cli/php_cli.c:996
#10 0x0000556da13b94ab in main (argc=3, argv=0x556dabdcff70) at /var/tmp/portage/dev-lang/php-8.3.23/work/sapis-build/cli/sapi/cli/php_cli.c:1341
```

So I changed `expiry` param from `Z_PARAM_ZVAL_OR_NULL` to `Z_PARAM_ARRAY_HT_OR_NULL`