### PR TITLE
Support php 8.5.0 alpha 3 and newer

### DIFF
--- a/common.h
+++ b/common.h
@@ -11,12 +11,7 @@
 #include <ext/standard/php_var.h>
 #include <ext/standard/php_math.h>
 #include <zend_smart_str.h>
-#if PHP_VERSION_ID < 70200
-#include <ext/standard/php_smart_string.h>
-#else
-#include "Zend/zend_smart_string.h"
-#endif
-
+#include <zend_smart_string.h>
 
 #define PHPREDIS_GET_OBJECT(class_entry, o) (class_entry *)((char *)o - XtOffsetOf(class_entry, std))
 #define PHPREDIS_ZVAL_GET_OBJECT(class_entry, z) PHPREDIS_GET_OBJECT(class_entry, Z_OBJ_P(z))

--- a/common.h
+++ b/common.h
@@ -14,7 +14,7 @@
 #if PHP_VERSION_ID < 70200
 #include <ext/standard/php_smart_string.h>
 #else
-#include "zend_string.h"
+#include "Zend/zend_smart_string.h"
 #endif
 
 

--- a/common.h
+++ b/common.h
@@ -11,7 +11,12 @@
 #include <ext/standard/php_var.h>
 #include <ext/standard/php_math.h>
 #include <zend_smart_str.h>
+#if PHP_VERSION_ID < 70200
 #include <ext/standard/php_smart_string.h>
+#else
+#include "zend_string.h"
+#endif
+
 
 #define PHPREDIS_GET_OBJECT(class_entry, o) (class_entry *)((char *)o - XtOffsetOf(class_entry, std))
 #define PHPREDIS_ZVAL_GET_OBJECT(class_entry, z) PHPREDIS_GET_OBJECT(class_entry, Z_OBJ_P(z))


### PR DESCRIPTION
When compiling the develop branch it fails with PHP 8.5.0 alpha 3 and newer due to this commit: https://github.com/php/php-src/pull/19233

```
/loc/php-8.5.0alpha3/ext/phpredis/common.h:14:10: fatal error: ext/standard/php_smart_string.h: No such file or directory
   14 | #include <ext/standard/php_smart_string.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that issue (by including the non-deprecated header) while also being backward compatible with no longer supported versions of PHP (7.2 and older).