### PR TITLE
Implement VADD command

### DIFF
--- a/common.h
+++ b/common.h
@@ -31,6 +31,16 @@
 #define NULL   ((void *) 0)
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+# define PHPREDIS_LITTLE_ENDIAN
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+# define PHPREDIS_BIG_ENDIAN
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+# define PHPREDIS_LITTLE_ENDIAN
+#else
+# error "Unknown endianness"
+#endif
+
 #include "backoff.h"
 
 typedef enum {

--- a/redis.c
+++ b/redis.c
@@ -3051,6 +3051,14 @@ PHP_METHOD(Redis, geosearchstore) {
 }
 
 /*
+ * Vectors
+ */
+
+PHP_METHOD(Redis, vadd) {
+    REDIS_PROCESS_CMD(vadd, redis_long_response);
+}
+
+/*
  * Streams
  */
 

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -4197,6 +4197,18 @@ class Redis {
     public function xrevrange(string $key, string $end, string $start, int $count = -1): Redis|array|bool;
 
     /**
+     * Add to a vector set
+     *
+     * @param string $key         The vector set to add to.
+     * @param array $values       A non-empty array of floating point values
+     * @param mixed $element      The element to add to the vector set.
+     * @param array|null $options An optional options array
+     *
+     * @return Redis|int|false One if the key was added zero if not.
+     */
+    public function vadd(string $key, array $values, mixed $element, array|null $options = null): Redis|int|false;
+
+    /**
      * Truncate a STREAM key in various ways.
      *
      * @param string $key       The STREAM key to trim.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec3421b68033c6299a4dc00ab0bbd31576a10961 */
+ * Stub hash: 63a08eee8fd89efe858ef57963e939e2095296c3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -1061,6 +1061,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xrevrange, 0, 3,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_vadd, 0, 3, Redis, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, element, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xtrim, 0, 2, Redis, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, threshold, IS_STRING, 0)
@@ -1471,6 +1478,7 @@ ZEND_METHOD(Redis, xrange);
 ZEND_METHOD(Redis, xread);
 ZEND_METHOD(Redis, xreadgroup);
 ZEND_METHOD(Redis, xrevrange);
+ZEND_METHOD(Redis, vadd);
 ZEND_METHOD(Redis, xtrim);
 ZEND_METHOD(Redis, zAdd);
 ZEND_METHOD(Redis, zCard);
@@ -1746,6 +1754,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, xread, arginfo_class_Redis_xread, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xreadgroup, arginfo_class_Redis_xreadgroup, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xrevrange, arginfo_class_Redis_xrevrange, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, vadd, arginfo_class_Redis_vadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xtrim, arginfo_class_Redis_xtrim, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zAdd, arginfo_class_Redis_zAdd, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zCard, arginfo_class_Redis_zCard, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -3062,6 +3062,10 @@ PHP_METHOD(RedisCluster, ping) {
 }
 /* }}} */
 
+PHP_METHOD(RedisCluster, vadd) {
+    CLUSTER_PROCESS_CMD(vadd, cluster_long_resp, 0);
+}
+
 /* {{{ proto long RedisCluster::xack(string key, string group, array ids) }}} */
 PHP_METHOD(RedisCluster, xack) {
     CLUSTER_PROCESS_CMD(xack, cluster_long_resp, 0);

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -1054,6 +1054,11 @@ class RedisCluster {
     public function watch(string $key, string ...$other_keys): RedisCluster|bool;
 
     /**
+     * @see Redis::vadd
+     */
+    public function vadd(string $key, array $values, mixed $element, array|null $options = null): RedisCluster|int|false;
+
+    /**
      * @see Redis::xack
      */
     public function xack(string $key, string $group, array $ids): RedisCluster|int|false;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8bef24632ec9819f53aa3bc9a52fe6e85b25b9 */
+ * Stub hash: bf0af294cda503416023a575efc55ea054fbb456 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -874,6 +874,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_watch, 0,
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, other_keys, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_vadd, 0, 3, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, element, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_xack, 0, 3, RedisCluster, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, group, IS_STRING, 0)
@@ -1308,6 +1315,7 @@ ZEND_METHOD(RedisCluster, unsubscribe);
 ZEND_METHOD(RedisCluster, unlink);
 ZEND_METHOD(RedisCluster, unwatch);
 ZEND_METHOD(RedisCluster, watch);
+ZEND_METHOD(RedisCluster, vadd);
 ZEND_METHOD(RedisCluster, xack);
 ZEND_METHOD(RedisCluster, xadd);
 ZEND_METHOD(RedisCluster, xclaim);
@@ -1551,6 +1559,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, unlink, arginfo_class_RedisCluster_unlink, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, unwatch, arginfo_class_RedisCluster_unwatch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, watch, arginfo_class_RedisCluster_watch, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, vadd, arginfo_class_RedisCluster_vadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xack, arginfo_class_RedisCluster_xack, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xadd, arginfo_class_RedisCluster_xadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xclaim, arginfo_class_RedisCluster_xclaim, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f8bef24632ec9819f53aa3bc9a52fe6e85b25b9 */
+ * Stub hash: bf0af294cda503416023a575efc55ea054fbb456 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -740,6 +740,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RedisCluster_watch arginfo_class_RedisCluster_del
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_vadd, 0, 0, 3)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, values)
+	ZEND_ARG_INFO(0, element)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_xack, 0, 0, 3)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, group)
@@ -1146,6 +1153,7 @@ ZEND_METHOD(RedisCluster, unsubscribe);
 ZEND_METHOD(RedisCluster, unlink);
 ZEND_METHOD(RedisCluster, unwatch);
 ZEND_METHOD(RedisCluster, watch);
+ZEND_METHOD(RedisCluster, vadd);
 ZEND_METHOD(RedisCluster, xack);
 ZEND_METHOD(RedisCluster, xadd);
 ZEND_METHOD(RedisCluster, xclaim);
@@ -1389,6 +1397,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, unlink, arginfo_class_RedisCluster_unlink, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, unwatch, arginfo_class_RedisCluster_unwatch, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, watch, arginfo_class_RedisCluster_watch, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, vadd, arginfo_class_RedisCluster_vadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xack, arginfo_class_RedisCluster_xack, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xadd, arginfo_class_RedisCluster_xadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, xclaim, arginfo_class_RedisCluster_xclaim, ZEND_ACC_PUBLIC)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -30,6 +30,10 @@
 #include <winsock.h>
 #endif
 
+#ifdef HAVE_REDIS_JSON
+#include <ext/json/php_json.h>
+#endif
+
 #include <zend_exceptions.h>
 
 /* Georadius sort type */
@@ -670,6 +674,34 @@ void redis_get_zcmd_options(redisZcmdOptions *dst, zval *src, int flags) {
                 dst->withscores = 1;
         }
     } ZEND_HASH_FOREACH_END();
+}
+
+#if defined(__clang__) || \
+    (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+#define PHPREDIS_HAVE_BSWAP32 1
+#endif
+
+static void redis_copy_fp32(char *dst, float src) {
+#ifdef PHPREDIS_BIG_ENDIAN
+#ifdef PHPREDIS_HAVE_BSWAP32
+    uint32_t val;
+    memcpy(&val, &src, sizeof(val));
+    val = __builtin_bswap32(val);
+    memcpy(dst, &val, sizeof(val));
+#else
+    union {
+        float f;
+        unsigned char b[4];
+    } u;
+    u.f = src;
+    dst[0] = u.b[3];
+    dst[1] = u.b[2];
+    dst[2] = u.b[1];
+    dst[3] = u.b[0];
+#endif
+#else
+    memcpy(dst, &src, sizeof(src));
+#endif
 }
 
 // + ZRANGE               key start stop [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]
@@ -6510,6 +6542,226 @@ redis_sentinel_str_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         return FAILURE;
     }
     *cmd_len = REDIS_CMD_SPPRINTF(cmd, "SENTINEL", "sS", kw, strlen(kw), name);
+    return SUCCESS;
+}
+
+typedef enum redisVAddQuant {
+    REDIS_QUANT_NONE,
+    REDIS_QUANT_NOQUANT,
+    REDIS_QUANT_Q8,
+    REDIS_QUANT_BIN,
+} redisVAddQuant;
+
+typedef struct redisVAddOptions {
+    enum redisVAddQuant quant;
+    zend_long reduce;
+    zend_bool values;
+    zend_bool cas;
+    zend_long ef;
+    zend_string *attributes;
+    zend_long numlinks;
+} redisVAddOptions;
+
+static zend_bool validate_vadd_integer(zend_string *name, zval *zv, zend_long min) {
+    if (Z_TYPE_P(zv) != IS_LONG || Z_LVAL_P(zv) < min) {
+        php_error_docref(NULL, E_WARNING, "%s must be >= "
+            ZEND_LONG_FMT, ZSTR_VAL(name), min);
+        return 0;
+    }
+
+    return 1;
+}
+
+static zend_string *get_vadd_attributes(zval *zv) {
+    if (Z_TYPE_P(zv) == IS_STRING) {
+        return zval_get_string(zv);
+#ifdef HAVE_REDIS_JSON
+    } else if (Z_TYPE_P(zv) == IS_ARRAY) {
+        smart_str aux = {0};
+        php_json_encode(&aux, zv, PHP_JSON_OBJECT_AS_ARRAY);
+        return aux.s;
+    } else {
+        php_error_docref(NULL, E_WARNING, "SETATTR must be a string or array");
+    }
+#else
+    } else {
+        php_error_docref(NULL, E_WARNING, "SETATTR must be a string");
+    }
+#endif
+
+    return NULL;
+}
+
+static void parse_vadd_options(redisVAddOptions *dst, HashTable *ht) {
+    zend_string *key;
+    zval *zv;
+
+    *dst = (redisVAddOptions){
+        .ef = -1,
+        .numlinks = -1,
+        .reduce = -1,
+    };
+
+    if (ht == NULL)
+        return;
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, zv) {
+        if (key != NULL) {
+            if (zend_string_equals_literal_ci(key, "REDUCE")) {
+                if (validate_vadd_integer(key, zv, 1))
+                    dst->reduce = Z_LVAL_P(zv);
+            } else if (zend_string_equals_literal_ci(key, "M")) {
+                if (validate_vadd_integer(key, zv, 1))
+                    dst->numlinks = Z_LVAL_P(zv);
+            } else if (zend_string_equals_literal_ci(key, "EF")) {
+                if (validate_vadd_integer(key, zv, 1))
+                    dst->ef = Z_LVAL_P(zv);
+            } else if (zend_string_equals_literal_ci(key, "CAS")) {
+                dst->cas = zval_is_true(zv);
+            } else if (zend_string_equals_literal_ci(key, "VALUES")) {
+                dst->values = zval_is_true(zv);
+            } else if (zend_string_equals_literal_ci(key, "SETATTR")) {
+                dst->attributes = get_vadd_attributes(zv);
+            }
+        } else if (Z_TYPE_P(zv) == IS_STRING) {
+            if (zend_string_equals_literal_ci(Z_STR_P(zv), "VALUES")) {
+                dst->values = 1;
+            } else if (zend_string_equals_literal_ci(Z_STR_P(zv), "FP32")) {
+                dst->values = 0;
+            } else if (zend_string_equals_literal_ci(Z_STR_P(zv), "NOQUANT")) {
+                dst->quant = REDIS_QUANT_NOQUANT;
+            } else if (zend_string_equals_literal_ci(Z_STR_P(zv), "Q8")) {
+                dst->quant = REDIS_QUANT_Q8;
+            } else if (zend_string_equals_literal_ci(Z_STR_P(zv), "BIN")) {
+                dst->quant = REDIS_QUANT_BIN;
+            }
+        }
+    } ZEND_HASH_FOREACH_END();
+}
+
+static void free_vadd_options(redisVAddOptions *o) {
+    if (o->attributes)
+        zend_string_release(o->attributes);
+}
+
+static void
+redis_cmd_append_sstr_fp32(smart_string *dst, HashTable *ht) {
+    uint32_t i = 0;
+    char *aux;
+    zval *zv;
+
+    aux = ecalloc(1, zend_hash_num_elements(ht) * sizeof(float));
+
+    ZEND_HASH_FOREACH_VAL(ht, zv) {
+        redis_copy_fp32(&aux[4 * i++], zval_get_double(zv));
+    } ZEND_HASH_FOREACH_END();
+
+    redis_cmd_append_sstr(dst, aux, 4 * i);
+
+    efree(aux);
+}
+
+static void redis_cmd_append_sstr_fp32_values(smart_string *dst, HashTable *ht) {
+    zval *zv;
+
+    ZEND_HASH_FOREACH_VAL(ht, zv) {
+        redis_cmd_append_sstr_dbl(dst, zval_get_double(zv));
+    } ZEND_HASH_FOREACH_END();
+}
+
+int
+redis_vadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+               char **cmd, int *cmd_len, short *slot, void **ctx)
+{
+    HashTable *options = NULL, *vector;
+    smart_string cmdstr = {0};
+    redisVAddOptions opts;
+    zend_string *key;
+    zval *element;
+    int argc;
+
+    ZEND_PARSE_PARAMETERS_START(3, 4)
+        Z_PARAM_STR(key)
+        Z_PARAM_ARRAY_HT(vector)
+        Z_PARAM_ZVAL(element)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ARRAY_HT_OR_NULL(options)
+    ZEND_PARSE_PARAMETERS_END_EX(return FAILURE);
+
+    if (zend_hash_num_elements(vector) < 1) {
+        php_error_docref(NULL, E_WARNING,
+            "At least one vector element is required");
+        return FAILURE;
+    }
+
+    parse_vadd_options(&opts, options);
+
+    // Two formulations:
+    //   VADD <key> FP32 [vector] <element>
+    //   VADD <key> VALUES <n> <v1>..<vn> <element>
+    // So <key> and <element> are always present and we need to calculate the
+    // other arguments dynamically.
+    argc = 2 +
+        (opts.reduce > -1 ? 2 : 0) +
+        (opts.values ? 2 + zend_hash_num_elements(vector) : 2) +
+        !!opts.cas +
+        (opts.attributes != NULL ? 2 : 0) +
+        (opts.numlinks > 0 ? 2 : 0) +
+        (opts.ef > 0 ? 2 : 0) +
+        !!(opts.quant != REDIS_QUANT_NONE);
+
+    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, argc, "VADD");
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+
+    if (opts.reduce > -1) {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "REDUCE");
+        redis_cmd_append_sstr_long(&cmdstr, opts.reduce);
+    }
+
+    if (opts.values) {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "VALUES");
+        redis_cmd_append_sstr_long(&cmdstr, zend_hash_num_elements(vector));
+        redis_cmd_append_sstr_fp32_values(&cmdstr, vector);
+    } else {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "FP32");
+        redis_cmd_append_sstr_fp32(&cmdstr, vector);
+    }
+
+    redis_cmd_append_sstr_zval(&cmdstr, element, redis_sock);
+
+    if (opts.cas)
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "CAS");
+
+    if (opts.quant != REDIS_QUANT_NONE) {
+        if (opts.quant == REDIS_QUANT_Q8) {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "Q8");
+        } else if (opts.quant == REDIS_QUANT_BIN) {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "BIN");
+        } else {
+            REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "NOQUANT");
+        }
+    }
+
+    if (opts.ef > -1) {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "EF");
+        redis_cmd_append_sstr_long(&cmdstr, opts.ef);
+    }
+
+    if (opts.attributes != NULL) {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "SETATTR");
+        redis_cmd_append_sstr_zstr(&cmdstr, opts.attributes);
+    }
+
+    if (opts.numlinks > -1) {
+        REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "M");
+        redis_cmd_append_sstr_long(&cmdstr, opts.numlinks);
+    }
+
+    free_vadd_options(&opts);
+
+    *cmd = cmdstr.c;
+    *cmd_len = cmdstr.len;
+
     return SUCCESS;
 }
 

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -329,6 +329,9 @@ int redis_geodist_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 int redis_migrate_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 
+int redis_vadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+    char **cmd, int *cmd_len, short *slot, void **ctx);
+
 int redis_xadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     char **cmd, int *cmd_len, short *slot, void **ctx);
 

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec3421b68033c6299a4dc00ab0bbd31576a10961 */
+ * Stub hash: 63a08eee8fd89efe858ef57963e939e2095296c3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -941,6 +941,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xrevrange, 0, 0, 3)
 	ZEND_ARG_INFO(0, count)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_vadd, 0, 0, 3)
+	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, values)
+	ZEND_ARG_INFO(0, element)
+	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xtrim, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
 	ZEND_ARG_INFO(0, threshold)
@@ -1309,6 +1316,7 @@ ZEND_METHOD(Redis, xrange);
 ZEND_METHOD(Redis, xread);
 ZEND_METHOD(Redis, xreadgroup);
 ZEND_METHOD(Redis, xrevrange);
+ZEND_METHOD(Redis, vadd);
 ZEND_METHOD(Redis, xtrim);
 ZEND_METHOD(Redis, zAdd);
 ZEND_METHOD(Redis, zCard);
@@ -1584,6 +1592,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, xread, arginfo_class_Redis_xread, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xreadgroup, arginfo_class_Redis_xreadgroup, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xrevrange, arginfo_class_Redis_xrevrange, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, vadd, arginfo_class_Redis_vadd, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, xtrim, arginfo_class_Redis_xtrim, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zAdd, arginfo_class_Redis_zAdd, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zCard, arginfo_class_Redis_zCard, ZEND_ACC_PUBLIC)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -7546,6 +7546,28 @@ class Redis_Test extends TestSuite {
         $this->assertNull($info['last-entry']);
     }
 
+    public function testVAdd() {
+        if ( ! $this->minVersionCheck('8.0'))
+            $this->markTestSkipped();
+
+        $this->assertIsInt($this->redis->del('v'));
+
+        foreach ([1, 0] as $expected) {
+            $this->assertEquals($expected, $this->redis->vadd('v', [0.5, 1.0], 'e'));
+        }
+
+        $this->assertEquals(1, $this->redis->del('v'));
+
+        foreach ([1, 0] as $expected) {
+            /* With tons of options */
+            $res = $this->redis->vadd('v', [3.14, 2.71], 'e', [
+                'REDUCE' => 2, 'EF' => 16, 'M' => 28, 'CAS', 'VALUES', 'Q8',
+                'SETATTR' => ['foo' => 'bar'],
+            ]);
+            $this->assertEquals($expected, $res);
+        }
+    }
+
     public function testInvalidAuthArgs() {
         $client = $this->newInstance();
 


### PR DESCRIPTION
This is for Redis 8.0's vector sets.

The command itself can be quite complex with all of the various options but pretty simple using all defaults.

```php
$redis->vadd('myvec', [3.14, 2.17], 'myelement');
```

The implementation takes a default argument `$options` which can be an array in order to specify the myriad of other knobs users can send. We just do a bit of validation on inputs (e.g. certain numeric options must be positive) and make sure the command is constructed in a valid way (e.g. REDUCE <dim> must come before the floating point values).

By default we deliver `FP32` blobs but allow the user to send `VALUES` in the options array which will cause PhpRedis to send N individual values. Sending values is slower but might be nice for debugging (e.g. watching monitor)

See #2543