### PR TITLE
Rework `HEXPIRE` test inclusion + bump Valkey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install ValKey
         if: matrix.server == 'valkey'
         run: |
-          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
+          git clone --depth 1 --branch 8.1.3 https://github.com/valkey-io/valkey.git
           cd valkey && BUILD_TLS=yes sudo make install
 
       - name: Build phpredis

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -81,9 +81,9 @@ class Redis_Test extends TestSuite {
 
     protected function haveCommand(string $cmd): bool {
         $info = $this->redis->command('info', $cmd);
-        $cmd  = $info[0][0] ?? null;
+        $name = $info[0][0] ?? null;
 
-        return $cmd && strcasecmp($cmd, $cmd) === 0;
+        return $name && strcasecmp($cmd, $name) === 0;
     }
 
     protected function minVersionCheck($version) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -79,6 +79,11 @@ class Redis_Test extends TestSuite {
         $this->is_valkey = $this->detectValKey($info);
     }
 
+    protected function haveCommand(string $cmd): bool {
+        $info = $this->redis->command('info', $cmd);
+        return !empty(array_filter($info));
+    }
+
     protected function minVersionCheck($version) {
         return version_compare($this->version, $version) >= 0;
     }
@@ -6298,13 +6303,13 @@ class Redis_Test extends TestSuite {
     }
 
     public function testHashExpiration() {
-        if ( ! $this->minVersionCheck('7.4.0'))
+        if ( ! $this->haveCommand('HEXPIRE'))
             $this->markTestSkipped();
 
         $hexpire_cmds = [
-            'hexpire' => 10,
-            'hpexpire' => 10000,
-            'hexpireat' => time() + 10,
+            'hexpire'    => 10,
+            'hpexpire'   => 10000,
+            'hexpireat'  => time() + 10,
             'hpexpireat' => time() * 1000 + 10000,
         ];
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -81,7 +81,9 @@ class Redis_Test extends TestSuite {
 
     protected function haveCommand(string $cmd): bool {
         $info = $this->redis->command('info', $cmd);
-        return !empty(array_filter($info));
+        $cmd  = $info[0][0] ?? null;
+
+        return $cmd && strcasecmp($cmd, $cmd) === 0;
     }
 
     protected function minVersionCheck($version) {


### PR DESCRIPTION
* Add a little `haveCommand` helper which uses `COMMAND INFO` to check if a given server has a specific command. This way when we bump valkey to an official release that supports the commands we will start testing.
* Bump Valkey from 7.2.5 to 8.1.3 which is much newer.