### PR TITLE
Rework command wrapper macros

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1970,7 +1970,7 @@ PHP_REDIS_API void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
 PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                              void *ctx)
 {
-    subscribeContext *sctx = (subscribeContext*)ctx;
+    subscribeContext *sctx = ctx;
     zval z_tab, *z_tmp;
     int pull = 0;
 
@@ -2080,7 +2080,7 @@ PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
 PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
                                redisCluster *c, void *ctx)
 {
-    subscribeContext *sctx = (subscribeContext*)ctx;
+    subscribeContext *sctx = ctx;
     zval z_tab = {0}, *z_chan, *z_flag;
     int pull = 0, argc = sctx->argc;
 
@@ -2631,7 +2631,7 @@ PHP_REDIS_API void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
                                     redisCluster *c, void *ctx)
 {
-    clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
+    clusterMultiCtx *mctx = ctx;
 
     /* Protect against an invalid response type, -1 response length, and failure
      * to consume the responses. */
@@ -2667,7 +2667,7 @@ PHP_REDIS_API void cluster_mbulk_mget_resp(INTERNAL_FUNCTION_PARAMETERS,
 PHP_REDIS_API void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                                 void *ctx)
 {
-    clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
+    clusterMultiCtx *mctx = ctx;
     int real_argc = mctx->count/2;
 
     // Protect against an invalid response type
@@ -2703,7 +2703,7 @@ PHP_REDIS_API void cluster_msetnx_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluste
 PHP_REDIS_API void cluster_del_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                              void *ctx)
 {
-    clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
+    clusterMultiCtx *mctx = ctx;
 
     // If we get an invalid reply, inform the client
     if (c->reply_type != TYPE_INT) {
@@ -2732,7 +2732,7 @@ PHP_REDIS_API void cluster_del_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
 PHP_REDIS_API void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                               void *ctx)
 {
-    clusterMultiCtx *mctx = (clusterMultiCtx*)ctx;
+    clusterMultiCtx *mctx = ctx;
 
     // If we get an invalid reply type something very wrong has happened,
     // and we have to abort.

--- a/common.h
+++ b/common.h
@@ -220,22 +220,6 @@ typedef enum {
     REDIS_PROCESS_RESPONSE_CLOSURE(function, NULL) \
 }
 
-/* Process a command assuming our command where our command building
- * function is redis_<cmdname>_cmd */
-#define REDIS_PROCESS_CMD(cmdname, resp_func) \
-    RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
-    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL || \
-       redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,redis_sock, \
-                             &cmd, &cmd_len, NULL, &ctx)==FAILURE) { \
-            RETURN_FALSE; \
-    } \
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len); \
-    if (IS_ATOMIC(redis_sock)) { \
-        resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx); \
-    } else { \
-        REDIS_PROCESS_RESPONSE_CLOSURE(resp_func, ctx) \
-    }
-
 /* Process a command but with a specific command building function
  * and keyword which is passed to us*/
 #define REDIS_PROCESS_KW_CMD(kw, cmdfunc, resp_func) \

--- a/common.h
+++ b/common.h
@@ -187,22 +187,6 @@ typedef enum {
 #define IS_MULTI(redis_sock) (redis_sock->mode & MULTI)
 #define IS_PIPELINE(redis_sock) (redis_sock->mode & PIPELINE)
 
-#define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
-    fold_item *fi = redis_add_reply_callback(redis_sock); \
-    fi->fun = callback; \
-    fi->flags = redis_sock->flags; \
-    fi->ctx = closure_context; \
-} while (0)
-
-#define REDIS_PROCESS_RESPONSE_CLOSURE(function, closure_context) \
-    if (!IS_PIPELINE(redis_sock)) { \
-        if (redis_response_enqueued(redis_sock) != SUCCESS) { \
-            RETURN_FALSE; \
-        } \
-    } \
-    REDIS_SAVE_CALLBACK(function, closure_context); \
-    RETURN_ZVAL(getThis(), 1, 0); \
-
 /* Case sensitive compare against compile-time static string */
 #define REDIS_STRCMP_STATIC(s, len, sstr) \
     (len == sizeof(sstr) - 1 && !strncmp(s, sstr, len))

--- a/common.h
+++ b/common.h
@@ -244,8 +244,8 @@ typedef struct {
     int                 max_retries;
     struct RedisBackoff backoff;
     redis_sock_status   status;
-    int                 persistent;
-    int                 watching;
+    zend_bool           persistent;
+    zend_bool           watching;
     zend_string         *persistent_id;
     HashTable           *subs[REDIS_SUBS_BUCKETS];
     redis_serializer    serializer;
@@ -264,11 +264,11 @@ typedef struct {
     zend_string         *err;
     int                 scan;
 
-    int                 readonly;
-    int                 reply_literal;
-    int                 null_mbulk_as_null;
-    int                 tcp_keepalive;
-    int                 sentinel;
+    zend_bool           readonly;
+    zend_bool           reply_literal;
+    zend_bool           null_mbulk_as_null;
+    zend_bool           tcp_keepalive;
+    zend_bool           sentinel;
     size_t              txBytes;
     size_t              rxBytes;
     uint8_t             flags;

--- a/common.h
+++ b/common.h
@@ -276,8 +276,10 @@ typedef struct {
 /* }}} */
 
 /* Redis response handler function callback prototype */
-typedef void (*ResultCallback)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, void *ctx);
-typedef int (*FailableResultCallback)(INTERNAL_FUNCTION_PARAMETERS, RedisSock*, zval*, void*);
+typedef void (*ResultCallback)(INTERNAL_FUNCTION_PARAMETERS,
+    RedisSock *redis_sock, zval *z_tab, void *ctx);
+typedef int (*FailableResultCallback)(INTERNAL_FUNCTION_PARAMETERS,
+    RedisSock*, zval*, void*);
 
 typedef struct fold_item {
     FailableResultCallback fun;

--- a/common.h
+++ b/common.h
@@ -203,10 +203,6 @@ typedef enum {
     REDIS_SAVE_CALLBACK(function, closure_context); \
     RETURN_ZVAL(getThis(), 1, 0); \
 
-#define REDIS_PROCESS_RESPONSE(function) else { \
-    REDIS_PROCESS_RESPONSE_CLOSURE(function, NULL) \
-}
-
 /* Case sensitive compare against compile-time static string */
 #define REDIS_STRCMP_STATIC(s, len, sstr) \
     (len == sizeof(sstr) - 1 && !strncmp(s, sstr, len))

--- a/common.h
+++ b/common.h
@@ -187,25 +187,12 @@ typedef enum {
 #define IS_MULTI(redis_sock) (redis_sock->mode & MULTI)
 #define IS_PIPELINE(redis_sock) (redis_sock->mode & PIPELINE)
 
-#define PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len) do { \
-    smart_string_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len); \
-} while (0)
-
 #define REDIS_SAVE_CALLBACK(callback, closure_context) do { \
     fold_item *fi = redis_add_reply_callback(redis_sock); \
     fi->fun = callback; \
     fi->flags = redis_sock->flags; \
     fi->ctx = closure_context; \
 } while (0)
-
-#define REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len) \
-    if (IS_PIPELINE(redis_sock)) { \
-        PIPELINE_ENQUEUE_COMMAND(cmd, cmd_len); \
-    } else if (redis_sock_write(redis_sock, cmd, cmd_len) < 0) { \
-        efree(cmd); \
-        RETURN_FALSE; \
-    } \
-    efree(cmd);
 
 #define REDIS_PROCESS_RESPONSE_CLOSURE(function, closure_context) \
     if (!IS_PIPELINE(redis_sock)) { \

--- a/common.h
+++ b/common.h
@@ -220,22 +220,6 @@ typedef enum {
     REDIS_PROCESS_RESPONSE_CLOSURE(function, NULL) \
 }
 
-/* Process a command but with a specific command building function
- * and keyword which is passed to us*/
-#define REDIS_PROCESS_KW_CMD_OLD(kw, cmdfunc, resp_func) \
-    RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
-    if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL || \
-       cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, kw, &cmd, \
-               &cmd_len, NULL, &ctx)==FAILURE) { \
-            RETURN_FALSE; \
-    } \
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len); \
-    if (IS_ATOMIC(redis_sock)) { \
-        resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx); \
-    } else { \
-        REDIS_PROCESS_RESPONSE_CLOSURE(resp_func, ctx) \
-    }
-
 /* Case sensitive compare against compile-time static string */
 #define REDIS_STRCMP_STATIC(s, len, sstr) \
     (len == sizeof(sstr) - 1 && !strncmp(s, sstr, len))

--- a/common.h
+++ b/common.h
@@ -222,7 +222,7 @@ typedef enum {
 
 /* Process a command but with a specific command building function
  * and keyword which is passed to us*/
-#define REDIS_PROCESS_KW_CMD(kw, cmdfunc, resp_func) \
+#define REDIS_PROCESS_KW_CMD_OLD(kw, cmdfunc, resp_func) \
     RedisSock *redis_sock; char *cmd; int cmd_len; void *ctx=NULL; \
     if ((redis_sock = redis_sock_get(getThis(), 0)) == NULL || \
        cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, kw, &cmd, \

--- a/library.c
+++ b/library.c
@@ -509,7 +509,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
 {
     HashTable *subs;
     subscribeCallback *cb;
-    subscribeContext *sctx = (subscribeContext*)ctx;
+    subscribeContext *sctx = ctx;
     zval *z_tmp, z_resp;
     int i;
 
@@ -663,7 +663,7 @@ PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
                                       RedisSock *redis_sock, zval *z_tab,
                                       void *ctx)
 {
-    subscribeContext *sctx = (subscribeContext*)ctx;
+    subscribeContext *sctx = ctx;
     zval *z_chan, z_ret, z_resp;
     int i;
 

--- a/redis.c
+++ b/redis.c
@@ -629,6 +629,39 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
     return SUCCESS;
 }
 
+static void
+redis_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redis_cmd_cb cmd_cb,
+                  FailableResultCallback resp_cb)
+{
+    RedisSock *redis_sock;
+    void *ctx = NULL;
+    int cmd_len;
+    char *cmd;
+
+    redis_sock = redis_sock_get(getThis(), 0);
+    if (UNEXPECTED(redis_sock == NULL)) {
+        RETURN_FALSE;
+    }
+
+    if (UNEXPECTED(cmd_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &cmd,
+                   &cmd_len, NULL, &ctx) == FAILURE))
+    {
+        RETURN_FALSE;
+    }
+
+    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
+
+    if (IS_ATOMIC(redis_sock)) {
+        resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx);
+    } else {
+        REDIS_PROCESS_RESPONSE_CLOSURE(resp_cb, ctx);
+    }
+}
+
+#define REDIS_PROCESS_CMD(cmdname, resp_func) \
+    redis_process_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, \
+                      redis_##cmdname##_cmd, resp_func)
+
 /* {{{ proto long Redis::bitop(string op, string key, ...) */
 PHP_METHOD(Redis, bitop) {
     REDIS_PROCESS_CMD(bitop, redis_long_response);
@@ -1467,7 +1500,7 @@ PHP_METHOD(Redis, flushAll)
 /* {{{ proto mixed Redis::function(string op, mixed ...args) */
 PHP_METHOD(Redis, function)
 {
-    REDIS_PROCESS_CMD(function, redis_function_response)
+    REDIS_PROCESS_CMD(function, redis_function_response);
 }
 
 /* {{{ proto int Redis::dbSize() */
@@ -2806,7 +2839,7 @@ PHP_METHOD(Redis, command) {
 
 /* {{{ proto array Redis::copy(string $source, string $destination, array $options = null) */
 PHP_METHOD(Redis, copy) {
-    REDIS_PROCESS_CMD(copy, redis_1_response)
+    REDIS_PROCESS_CMD(copy, redis_1_response);
 }
 /* }}} */
 

--- a/redis.c
+++ b/redis.c
@@ -662,6 +662,34 @@ redis_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redis_cmd_cb cmd_cb,
     redis_process_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, \
                       redis_##cmdname##_cmd, resp_func)
 
+void
+redis_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, const char *kw,
+                     redis_kw_cmd_cb cmd_cb, FailableResultCallback resp_cb,
+                     void *ctx)
+{
+    RedisSock *redis_sock;
+    int cmd_len;
+    char *cmd;
+
+    redis_sock = redis_sock_get(getThis(), 0);
+    if (UNEXPECTED(redis_sock == NULL)) {
+        RETURN_FALSE;
+    }
+
+    if (UNEXPECTED(cmd_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, (char*)kw, &cmd,
+                   &cmd_len, NULL, &ctx) == FAILURE))
+    {
+        RETURN_FALSE;
+    }
+
+    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
+    if (IS_ATOMIC(redis_sock)) {
+        resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx);
+    } else {
+        REDIS_PROCESS_RESPONSE_CLOSURE(resp_cb, ctx);
+    }
+}
+
 /* {{{ proto long Redis::bitop(string op, string key, ...) */
 PHP_METHOD(Redis, bitop) {
     REDIS_PROCESS_CMD(bitop, redis_long_response);

--- a/redis.c
+++ b/redis.c
@@ -1424,8 +1424,9 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
         {
             RETURN_FALSE;
         }
+    } else {
+        REDIS_PROCESS_RESPONSE_CLOSURE(redis_read_variant_reply, NULL);
     }
-    REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
 }
 
 /* {{{ proto array Redis::sortAsc(string key, string pattern, string get,
@@ -2883,9 +2884,9 @@ PHP_METHOD(Redis, rawcommand) {
     if (IS_ATOMIC(redis_sock)) {
         redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,
                                      redis_sock,NULL,NULL);
+    } else {
+        REDIS_PROCESS_RESPONSE_CLOSURE(redis_read_variant_reply, NULL);
     }
-
-    REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
 }
 /* }}} */
 

--- a/redis.c
+++ b/redis.c
@@ -634,6 +634,27 @@ pipeline_enqueue_command(RedisSock *redis_sock, const char *cmd, int cmd_len) {
     smart_string_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len);
 }
 
+static void
+redis_save_callback(RedisSock *redis_sock, FailableResultCallback cb, void *ctx)
+{
+    fold_item *fi;
+
+    fi = redis_add_reply_callback(redis_sock);
+    fi->fun = cb;
+    fi->flags = redis_sock->flags;
+    fi->ctx = ctx;
+}
+
+#define REDIS_PROCESS_RESPONSE_CLOSURE(function, closure_context) \
+    if (!IS_PIPELINE(redis_sock)) { \
+        if (redis_response_enqueued(redis_sock) != SUCCESS) { \
+            RETURN_FALSE; \
+        } \
+    } \
+    redis_save_callback(redis_sock, function, closure_context); \
+    RETURN_ZVAL(getThis(), 1, 0); \
+
+
 static int redis_process_request(RedisSock *redis_sock, char *cmd, int cmdlen) {
     int res = SUCCESS;
 
@@ -2080,7 +2101,7 @@ PHP_METHOD(Redis, multi)
         if (!IS_MULTI(redis_sock)) {
             if (IS_PIPELINE(redis_sock)) {
                 pipeline_enqueue_command(redis_sock, ZEND_STRL(RESP_MULTI_CMD));
-                REDIS_SAVE_CALLBACK(NULL, NULL);
+                redis_save_callback(redis_sock, NULL, NULL);
                 redis_sock->mode |= MULTI;
             } else {
                 if (redis_sock_write(redis_sock, ZEND_STRL(RESP_MULTI_CMD)) < 0) {
@@ -2180,7 +2201,7 @@ PHP_METHOD(Redis, exec)
     if (IS_MULTI(redis_sock)) {
         if (IS_PIPELINE(redis_sock)) {
             pipeline_enqueue_command(redis_sock, ZEND_STRL(RESP_EXEC_CMD));
-            REDIS_SAVE_CALLBACK(NULL, NULL);
+            redis_save_callback(redis_sock, NULL, NULL);
             redis_sock->mode &= ~MULTI;
             RETURN_ZVAL(getThis(), 1, 0);
         }

--- a/redis.c
+++ b/redis.c
@@ -629,6 +629,24 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
     return SUCCESS;
 }
 
+static inline void
+pipeline_enqueue_command(RedisSock *redis_sock, const char *cmd, int cmd_len) {
+    smart_string_appendl(&redis_sock->pipeline_cmd, cmd, cmd_len);
+}
+
+static int redis_process_request(RedisSock *redis_sock, char *cmd, int cmdlen) {
+    int res = SUCCESS;
+
+    if (IS_PIPELINE(redis_sock)) {
+        pipeline_enqueue_command(redis_sock, cmd, cmdlen);
+    } else if (UNEXPECTED(redis_sock_write(redis_sock, cmd, cmdlen) < 0)) {
+        res = FAILURE;
+    }
+
+    efree(cmd);
+    return res;
+}
+
 static void
 redis_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redis_cmd_cb cmd_cb,
                   FailableResultCallback resp_cb)
@@ -649,7 +667,9 @@ redis_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redis_cmd_cb cmd_cb,
         RETURN_FALSE;
     }
 
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
+    if (redis_process_request(redis_sock, cmd, cmd_len) != SUCCESS) {
+        RETURN_FALSE;
+    }
 
     if (IS_ATOMIC(redis_sock)) {
         resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx);
@@ -682,7 +702,10 @@ redis_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, const char *kw,
         RETURN_FALSE;
     }
 
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
+    if (redis_process_request(redis_sock, cmd, cmd_len) != SUCCESS) {
+        RETURN_FALSE;
+    }
+
     if (IS_ATOMIC(redis_sock)) {
         resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, NULL, ctx);
     } else {
@@ -813,9 +836,11 @@ PHP_METHOD(Redis, reset)
         RETURN_FALSE;
     }
 
-    redis_cmd_init_sstr(&cmd, 0, "RESET", 5);
+    redis_cmd_init_sstr(&cmd, 0, ZEND_STRL("RESET"));
 
-    REDIS_PROCESS_REQUEST(redis_sock, cmd.c, cmd.len);
+    if (redis_process_request(redis_sock, cmd.c, cmd.len) != SUCCESS) {
+        RETURN_FALSE;
+    }
 
     if ((response = redis_sock_read(redis_sock, &response_len)) != NULL) {
         ret = REDIS_STRCMP_STATIC(response, response_len, "+RESET");
@@ -1389,7 +1414,10 @@ generic_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, int desc, int alpha)
         redis_cmd_append_sstr_key(&cmd, store, storelen, redis_sock, NULL);
     }
 
-    REDIS_PROCESS_REQUEST(redis_sock, cmd.c, cmd.len);
+    if (redis_process_request(redis_sock, cmd.c, cmd.len) != SUCCESS) {
+        RETURN_FALSE;
+    }
+
     if (IS_ATOMIC(redis_sock)) {
         if (redis_read_variant_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,
                                      redis_sock, NULL, NULL) < 0)
@@ -2050,7 +2078,7 @@ PHP_METHOD(Redis, multi)
         /* Don't want to do anything if we're already in MULTI mode */
         if (!IS_MULTI(redis_sock)) {
             if (IS_PIPELINE(redis_sock)) {
-                PIPELINE_ENQUEUE_COMMAND(RESP_MULTI_CMD, sizeof(RESP_MULTI_CMD) - 1);
+                pipeline_enqueue_command(redis_sock, ZEND_STRL(RESP_MULTI_CMD));
                 REDIS_SAVE_CALLBACK(NULL, NULL);
                 redis_sock->mode |= MULTI;
             } else {
@@ -2150,7 +2178,7 @@ PHP_METHOD(Redis, exec)
 
     if (IS_MULTI(redis_sock)) {
         if (IS_PIPELINE(redis_sock)) {
-            PIPELINE_ENQUEUE_COMMAND(RESP_EXEC_CMD, sizeof(RESP_EXEC_CMD) - 1);
+            pipeline_enqueue_command(redis_sock, ZEND_STRL(RESP_EXEC_CMD));
             REDIS_SAVE_CALLBACK(NULL, NULL);
             redis_sock->mode &= ~MULTI;
             RETURN_ZVAL(getThis(), 1, 0);
@@ -2848,11 +2876,15 @@ PHP_METHOD(Redis, rawcommand) {
         RETURN_FALSE;
     }
 
-    /* Execute our command */
-    REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
-    if (IS_ATOMIC(redis_sock)) {
-        redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,redis_sock,NULL,NULL);
+    if (redis_process_request(redis_sock, cmd, cmd_len) != SUCCESS) {
+        RETURN_FALSE;
     }
+
+    if (IS_ATOMIC(redis_sock)) {
+        redis_read_raw_variant_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+                                     redis_sock,NULL,NULL);
+    }
+
     REDIS_PROCESS_RESPONSE(redis_read_variant_reply);
 }
 /* }}} */
@@ -3010,8 +3042,10 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
         cmd_len = redis_build_scan_cmd(&cmd, type, key, key_len, cursor,
                                        pattern, pattern_len, count, match_type);
 
-        /* Execute our command getting our new cursor value */
-        REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
+        if (redis_process_request(redis_sock, cmd, cmd_len) != SUCCESS) {
+            RETURN_FALSE;
+        }
+
         if(redis_sock_read_scan_reply(INTERNAL_FUNCTION_PARAM_PASSTHRU,
                                       redis_sock,type, &cursor) < 0)
         {

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -437,7 +437,7 @@ distcmd_resp_handler(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, short slot,
 
     if (CLUSTER_IS_ATOMIC(c)) {
         // Process response now
-        cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, (void*)ctx);
+        cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
     } else {
         cluster_enqueue_response(c, slot, cb, ctx);
     }

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -64,6 +64,19 @@ cluster_enqueue_response(redisCluster *c, short slot, cluster_cb cb, void *ctx)
     }
 }
 
+static void cluster_free_queue(redisCluster *c) {
+    clusterFoldItem *item = c->multi_head, *tmp;
+
+    while (item) {
+        tmp = item->next;
+        efree(item);
+        item = tmp;
+    }
+
+    c->multi_head = NULL;
+    c->multi_curr = NULL;
+}
+
 void
 cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                     redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly)
@@ -2187,7 +2200,7 @@ PHP_METHOD(RedisCluster, exec) {
                 CLUSTER_THROW_EXCEPTION("Error processing EXEC across the cluster", 0);
 
                 // Free our queue, reset MULTI state
-                CLUSTER_FREE_QUEUE(c);
+                cluster_free_queue(c);
                 CLUSTER_RESET_MULTI(c);
 
                 RETURN_FALSE;
@@ -2203,7 +2216,7 @@ PHP_METHOD(RedisCluster, exec) {
 
     // Free our callback queue, any enqueued distributed command context items
     // and reset our MULTI state.
-    CLUSTER_FREE_QUEUE(c);
+    cluster_free_queue(c);
     CLUSTER_RESET_MULTI(c);
 }
 
@@ -2220,7 +2233,7 @@ PHP_METHOD(RedisCluster, discard) {
         CLUSTER_RESET_MULTI(c);
     }
 
-    CLUSTER_FREE_QUEUE(c);
+    cluster_free_queue(c);
 
     RETURN_TRUE;
 }

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -43,6 +43,38 @@ zend_class_entry *redis_cluster_exception_ce;
 #include "redis_cluster_arginfo.h"
 #endif
 
+void
+cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+                    redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly)
+{
+    void *ctx = NULL;
+    int cmd_len;
+    short slot;
+    char *cmd;
+
+    c->readonly = readonly && CLUSTER_IS_ATOMIC(c);
+
+    if (cmd_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, &cmd, &cmd_len, &slot,
+               &ctx) == FAILURE)
+    {
+        RETURN_FALSE;
+    }
+
+    if (cluster_send_command(c, slot, cmd, cmd_len) < 0 || c->err != NULL) {
+        efree(cmd);
+        RETURN_FALSE;
+    }
+
+    efree(cmd);
+
+    if (c->flags->mode == MULTI) {
+        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_cb, ctx);
+        RETURN_ZVAL(getThis(), 1, 0);
+    }
+
+    resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
+}
+
 PHP_MINIT_FUNCTION(redis_cluster)
 {
     redis_cluster_ce = register_class_RedisCluster();
@@ -3245,7 +3277,7 @@ PHP_METHOD(RedisCluster, command) {
 }
 
 PHP_METHOD(RedisCluster, copy) {
-    CLUSTER_PROCESS_CMD(copy, cluster_1_resp, 0)
+    CLUSTER_PROCESS_CMD(copy, cluster_1_resp, 0);
 }
 
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -81,7 +81,7 @@ static void cluster_reset_multi(redisCluster *c) {
     redisClusterNode *node;
     ZEND_HASH_FOREACH_PTR(c->nodes, node) {
         if (node == NULL)
-            break;
+            continue;
         node->sock->watching = 0;
         node->sock->mode = ATOMIC;
     } ZEND_HASH_FOREACH_END();

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -43,6 +43,27 @@ zend_class_entry *redis_cluster_exception_ce;
 #include "redis_cluster_arginfo.h"
 #endif
 
+static void
+cluster_enqueue_response(redisCluster *c, short slot, cluster_cb cb, void *ctx)
+{
+    clusterFoldItem *item;
+
+    item = emalloc(sizeof(clusterFoldItem));
+    item->callback = cb;
+    item->slot = slot;
+    item->ctx = ctx;
+    item->next = NULL;
+    item->flags = c->flags->flags;
+
+    if (UNEXPECTED(c->multi_head == NULL)) {
+        c->multi_head = item;
+        c->multi_curr = item;
+    } else {
+        c->multi_curr->next = item;
+        c->multi_curr = item;
+    }
+}
+
 void
 cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                     redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly)
@@ -68,7 +89,7 @@ cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     efree(cmd);
 
     if (c->flags->mode == MULTI) {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_cb, ctx);
+        cluster_enqueue_response(c, slot, resp_cb, ctx);
         RETURN_ZVAL(getThis(), 1, 0);
     }
 
@@ -87,7 +108,7 @@ cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
     c->readonly = readonly && CLUSTER_IS_ATOMIC(c);
 
-    /* TODO: Update kw commands to take a const char * */
+    /* TODO: Update kw commands to take a const char * (and len to avoid strlen) */
     if (cmd_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, (char*)kw, &cmd, &cmd_len,
                &slot, &ctx) == FAILURE)
     {
@@ -102,7 +123,7 @@ cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     efree(cmd);
 
     if (c->flags->mode == MULTI) {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_cb, ctx);
+        cluster_enqueue_response(c, slot, resp_cb, ctx);
         RETURN_ZVAL(getThis(), 1, 0);
     }
 
@@ -392,7 +413,7 @@ distcmd_resp_handler(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, short slot,
         // Process response now
         cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, (void*)ctx);
     } else {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cb, ctx);
+        cluster_enqueue_response(c, slot, cb, ctx);
     }
 
     // Clear out our command but retain allocated memory
@@ -2573,7 +2594,7 @@ PHP_METHOD(RedisCluster, acl) {
     if (CLUSTER_IS_ATOMIC(c)) {
         cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cb, ctx);
+        cluster_enqueue_response(c, slot, cb, ctx);
     }
 
     efree(cmdstr.c);
@@ -2778,7 +2799,7 @@ PHP_METHOD(RedisCluster, info) {
     if (CLUSTER_IS_ATOMIC(c)) {
         cluster_info_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_info_resp, ctx);
+        cluster_enqueue_response(c, slot, cluster_info_resp, ctx);
     }
 
     efree(cmdstr.c);
@@ -2853,7 +2874,7 @@ PHP_METHOD(RedisCluster, client) {
         cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
         void *ctx = NULL;
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cb, ctx);
+        cluster_enqueue_response(c, slot, cb, ctx);
     }
 
     efree(cmd);
@@ -3056,7 +3077,7 @@ PHP_METHOD(RedisCluster, waitaof) {
     if (CLUSTER_IS_ATOMIC(c)) {
         cluster_variant_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_variant_resp, ctx);
+        cluster_enqueue_response(c, slot, cluster_variant_resp, ctx);
     }
 
     smart_string_free(&cmdstr);
@@ -3118,9 +3139,9 @@ PHP_METHOD(RedisCluster, ping) {
         }
     } else {
         if (arg != NULL) {
-            CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_bulk_resp, ctx);
+            cluster_enqueue_response(c, slot, cluster_bulk_resp, ctx);
         } else {
-            CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_variant_resp, ctx);
+            cluster_enqueue_response(c, slot, cluster_variant_resp, ctx);
         }
 
         RETURN_ZVAL(getThis(), 1, 0);
@@ -3243,7 +3264,7 @@ PHP_METHOD(RedisCluster, echo) {
         cluster_bulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
         void *ctx = NULL;
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_bulk_resp, ctx);
+        cluster_enqueue_response(c, slot, cluster_bulk_resp, ctx);
     }
 
     efree(cmd);
@@ -3296,7 +3317,7 @@ PHP_METHOD(RedisCluster, rawcommand) {
         cluster_variant_raw_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, NULL);
     } else {
         void *ctx = NULL;
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, cluster_variant_raw_resp, ctx);
+        cluster_enqueue_response(c, slot, cluster_variant_raw_resp, ctx);
     }
 
     efree(cmd);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -77,6 +77,19 @@ static void cluster_free_queue(redisCluster *c) {
     c->multi_curr = NULL;
 }
 
+static void cluster_reset_multi(redisCluster *c) {
+    redisClusterNode *node;
+    ZEND_HASH_FOREACH_PTR(c->nodes, node) {
+        if (node == NULL)
+            break;
+        node->sock->watching = 0;
+        node->sock->mode = ATOMIC;
+    } ZEND_HASH_FOREACH_END();
+
+    c->flags->watching = 0;
+    c->flags->mode = ATOMIC;
+}
+
 void
 cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
                     redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly)
@@ -2201,7 +2214,7 @@ PHP_METHOD(RedisCluster, exec) {
 
                 // Free our queue, reset MULTI state
                 cluster_free_queue(c);
-                CLUSTER_RESET_MULTI(c);
+                cluster_reset_multi(c);
 
                 RETURN_FALSE;
             }
@@ -2217,7 +2230,7 @@ PHP_METHOD(RedisCluster, exec) {
     // Free our callback queue, any enqueued distributed command context items
     // and reset our MULTI state.
     cluster_free_queue(c);
-    CLUSTER_RESET_MULTI(c);
+    cluster_reset_multi(c);
 }
 
 /* {{{ proto bool RedisCluster::discard() */
@@ -2230,7 +2243,7 @@ PHP_METHOD(RedisCluster, discard) {
     }
 
     if (cluster_abort_exec(c) < 0) {
-        CLUSTER_RESET_MULTI(c);
+        cluster_reset_multi(c);
     }
 
     cluster_free_queue(c);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -75,6 +75,40 @@ cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
 }
 
+void
+cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+                       const char *kw, redis_kw_cmd_cb cmd_cb, cluster_cb resp_cb,
+                       int readonly)
+{
+    void *ctx = NULL;
+    int cmd_len;
+    short slot;
+    char *cmd;
+
+    c->readonly = readonly && CLUSTER_IS_ATOMIC(c);
+
+    /* TODO: Update kw commands to take a const char * */
+    if (cmd_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, (char*)kw, &cmd, &cmd_len,
+               &slot, &ctx) == FAILURE)
+    {
+        RETURN_FALSE;
+    }
+
+    if (cluster_send_command(c, slot, cmd, cmd_len) < 0 || c->err != NULL) {
+        efree(cmd);
+        RETURN_FALSE;
+    }
+
+    efree(cmd);
+
+    if (c->flags->mode == MULTI) {
+        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_cb, ctx);
+        RETURN_ZVAL(getThis(), 1, 0);
+    }
+
+    resp_cb(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
+}
+
 PHP_MINIT_FUNCTION(redis_cluster)
 {
     redis_cluster_ce = register_class_RedisCluster();

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -9,11 +9,6 @@
 /* Get attached object context */
 #define GET_CONTEXT() PHPREDIS_ZVAL_GET_OBJECT(redisCluster, getThis())
 
-/* Command building/processing is identical for every command */
-#define CLUSTER_BUILD_CMD(name, c, cmd, cmd_len, slot) \
-    redis_##name##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, &cmd, \
-                       &cmd_len, &slot)
-
 /* Simple macro to free our enqueued callbacks after we EXEC */
 #define CLUSTER_FREE_QUEUE(c) \
     clusterFoldItem *_item = c->multi_head, *_tmp; \

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -9,16 +9,6 @@
 /* Get attached object context */
 #define GET_CONTEXT() PHPREDIS_ZVAL_GET_OBJECT(redisCluster, getThis())
 
-/* Simple macro to free our enqueued callbacks after we EXEC */
-#define CLUSTER_FREE_QUEUE(c) \
-    clusterFoldItem *_item = c->multi_head, *_tmp; \
-    while(_item) { \
-        _tmp = _item->next; \
-        efree(_item); \
-        _item = _tmp; \
-    } \
-    c->multi_head = c->multi_curr = NULL; \
-
 /* Reset anything flagged as MULTI */
 #define CLUSTER_RESET_MULTI(c) \
     redisClusterNode *_node; \

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -14,24 +14,6 @@
     redis_##name##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, &cmd, \
                        &cmd_len, &slot)
 
-/* Append information required to handle MULTI commands to the tail of our MULTI
- * linked list. */
-#define CLUSTER_ENQUEUE_RESPONSE(c, slot, cb, ctx) \
-    clusterFoldItem *_item; \
-    _item = emalloc(sizeof(clusterFoldItem)); \
-    _item->callback = cb; \
-    _item->slot = slot; \
-    _item->ctx = ctx; \
-    _item->next = NULL; \
-    _item->flags = c->flags->flags; \
-    if(c->multi_head == NULL) { \
-        c->multi_head = _item; \
-        c->multi_curr = _item; \
-    } else { \
-        c->multi_curr->next = _item; \
-        c->multi_curr = _item; \
-    } \
-
 /* Simple macro to free our enqueued callbacks after we EXEC */
 #define CLUSTER_FREE_QUEUE(c) \
     clusterFoldItem *_item = c->multi_head, *_tmp; \

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -9,17 +9,6 @@
 /* Get attached object context */
 #define GET_CONTEXT() PHPREDIS_ZVAL_GET_OBJECT(redisCluster, getThis())
 
-/* Reset anything flagged as MULTI */
-#define CLUSTER_RESET_MULTI(c) \
-    redisClusterNode *_node; \
-    ZEND_HASH_FOREACH_PTR(c->nodes, _node) { \
-        if (_node == NULL) break; \
-        _node->sock->watching = 0; \
-        _node->sock->mode = ATOMIC; \
-    } ZEND_HASH_FOREACH_END(); \
-    c->flags->watching = 0; \
-    c->flags->mode     = ATOMIC; \
-
 void cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly);
 

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -60,25 +60,12 @@ void cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     cluster_process_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, GET_CONTEXT(), \
                         redis_##cmdname##_cmd, resp_func, readcmd)
 
-/* More generic processing, where only the keyword differs */
-#define CLUSTER_PROCESS_KW_CMD(kw, cmdfunc, resp_func, readcmd) \
-    redisCluster *c = GET_CONTEXT(); \
-    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
-    char *cmd; int cmd_len; short slot; void *ctx=NULL; \
-    if(cmdfunc(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags, kw, &cmd, &cmd_len,\
-               &slot,&ctx)==FAILURE) { \
-        RETURN_FALSE; \
-    } \
-    if(cluster_send_command(c,slot,cmd,cmd_len)<0 || c->err!=NULL) { \
-        efree(cmd); \
-        RETURN_FALSE; \
-    } \
-    efree(cmd); \
-    if(c->flags->mode == MULTI) { \
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_func, ctx); \
-        RETURN_ZVAL(getThis(), 1, 0); \
-    } \
-    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
+void cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    const char *kw, redis_kw_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly);
+
+#define CLUSTER_PROCESS_KW_CMD(kw, cmd_cb, resp_cb, readonly) \
+    cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, GET_CONTEXT(), \
+                           kw, cmd_cb, resp_cb, readonly)
 
 extern zend_class_entry *redis_cluster_ce;
 extern zend_class_entry *redis_cluster_exception_ce;

--- a/redis_cluster.h
+++ b/redis_cluster.h
@@ -2,6 +2,7 @@
 #define REDIS_CLUSTER_H
 
 #include "cluster_library.h"
+#include "redis_commands.h"
 #include <php.h>
 #include <stddef.h>
 
@@ -52,25 +53,12 @@
     c->flags->watching = 0; \
     c->flags->mode     = ATOMIC; \
 
-/* Simple 1-1 command -> response macro */
+void cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    redis_cmd_cb cmd_cb, cluster_cb resp_cb, int readonly);
+
 #define CLUSTER_PROCESS_CMD(cmdname, resp_func, readcmd) \
-    redisCluster *c = GET_CONTEXT(); \
-    c->readonly = CLUSTER_IS_ATOMIC(c) && readcmd; \
-    char *cmd; int cmd_len; short slot; void *ctx=NULL; \
-    if(redis_##cmdname##_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU,c->flags, &cmd, \
-                             &cmd_len, &slot, &ctx)==FAILURE) { \
-        RETURN_FALSE; \
-    } \
-    if(cluster_send_command(c,slot,cmd,cmd_len)<0 || c->err!=NULL) {\
-        efree(cmd); \
-        RETURN_FALSE; \
-    } \
-    efree(cmd); \
-    if(c->flags->mode == MULTI) { \
-        CLUSTER_ENQUEUE_RESPONSE(c, slot, resp_func, ctx); \
-        RETURN_ZVAL(getThis(), 1, 0); \
-    } \
-    resp_func(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, ctx);
+    cluster_process_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, GET_CONTEXT(), \
+                        redis_##cmdname##_cmd, resp_func, readcmd)
 
 /* More generic processing, where only the keyword differs */
 #define CLUSTER_PROCESS_KW_CMD(kw, cmdfunc, resp_func, readcmd) \

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2407,7 +2407,7 @@ int redis_set_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         (keep_ttl != 0) + get;
 
     /* Initial SET <key> <value> */
-    redis_cmd_init_sstr(&cmdstr, argc, "SET", 3);
+    redis_cmd_init_sstr(&cmdstr, argc, ZEND_STRL("SET"));
     redis_cmd_append_sstr_key(&cmdstr, key, key_len, redis_sock, slot);
     redis_cmd_append_sstr_zval(&cmdstr, z_value, redis_sock);
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1622,7 +1622,7 @@ int redis_subscribe_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     // Push values out
     *cmd_len = cmdstr.len;
     *cmd     = cmdstr.c;
-    *ctx     = (void*)sctx;
+    *ctx     = sctx;
 
     if (shardslot != REDIS_CLUSTER_SLOTS) {
         if (slot) *slot = shardslot;

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4583,7 +4583,7 @@ redis_geosearch_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         }
     }
 
-    if ((argc = gopts.withcoord + gopts.withdist + gopts.withhash) > 0) {
+    if (gopts.withcoord + gopts.withdist + gopts.withhash > 0) {
         *ctx = PHPREDIS_CTX_PTR;
     }
 

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -38,6 +38,16 @@ typedef int (*redis_kw_cmd_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_so
                                char *kw, char **cmd, int *cmd_len, short *slot,
                                void **ctx);
 
+/* Process a command but with a specific command building function
+ * and keyword which is passed to us*/
+void redis_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, const char *kw,
+    redis_kw_cmd_cb cmd_cb, FailableResultCallback resp_cb,
+    void *ctx);
+
+#define REDIS_PROCESS_KW_CMD(kw, cmdfunc, resp_func) \
+    redis_process_kw_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, kw, \
+                         cmdfunc, resp_func, NULL)
+
 /* Redis command generics.  Many commands share common prototypes meaning that
  * we can write one function to handle all of them.  For example, there are
  * many COMMAND key value commands, or COMMAND key commands. */

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -35,8 +35,8 @@ typedef int (*redis_cmd_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                             char **cmd, int *cmd_len, short *slot, void **ctx);
 
 typedef int (*redis_kw_cmd_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
-                            char *kw, char **cmd, int *cmd_len, short *slot,
-                            void **ctx);
+                               char *kw, char **cmd, int *cmd_len, short *slot,
+                               void **ctx);
 
 /* Redis command generics.  Many commands share common prototypes meaning that
  * we can write one function to handle all of them.  For example, there are

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -31,6 +31,13 @@ int redis_build_raw_cmd(zval *z_args, int argc, char **cmd, int *cmd_len);
 /* Construct a script command */
 smart_string *redis_build_script_cmd(smart_string *cmd, int argc, zval *z_args);
 
+typedef int (*redis_cmd_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                            char **cmd, int *cmd_len, short *slot, void **ctx);
+
+typedef int (*redis_kw_cmd_cb)(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                            char *kw, char **cmd, int *cmd_len, short *slot,
+                            void **ctx);
+
 /* Redis command generics.  Many commands share common prototypes meaning that
  * we can write one function to handle all of them.  For example, there are
  * many COMMAND key value commands, or COMMAND key commands. */


### PR DESCRIPTION
This commit reworks the `Redis` and `RedisCluster` command wrapper macros into static functions.

The changes result in around a ~30% reduction in binary size and either no change in performance or a slight improvement depending on workload.