### PR TITLE
Update xpending method to include idle-time parameter

### DIFF
--- a/redis.stub.php
+++ b/redis.stub.php
@@ -4104,13 +4104,14 @@ class Redis {
      * @param string $group    The user group we want to see pending messages from.
      * @param string $start    The minimum ID to consider.
      * @param string $string   The maximum ID to consider.
-     * @param string $count    Optional maximum number of messages to return.
+     * @param int $count       Optional maximum number of messages to return.
      * @param string $consumer If provided, limit the returned messages to a specific consumer.
+     * @param int $idle        Optional idle-time in milliseconds to filter pending messages.
      *
      * @return Redis|array|false The pending messages belonging to the stream or false on failure.
      *
      */
-    public function xpending(string $key, string $group, ?string $start = null, ?string $end = null, int $count = -1, ?string $consumer = null): Redis|array|false;
+    public function xpending(string $key, string $group, ?string $start = null, ?string $end = null, int $count = -1, ?string $consumer = null, int $idle = 0): Redis|array|false;
 
     /**
      * Get a range of entries from a STREAM key.

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d5f56120b09dc6a8240d87efa53dc5749c031f38 */
+ * Stub hash: 17311f750995902e9c69f1289dbc72feecc3695d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -1033,6 +1033,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xpending, 0, 2, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, consumer, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, idle, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_xrange, 0, 3, Redis, MAY_BE_ARRAY|MAY_BE_BOOL)

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -1118,7 +1118,7 @@ class RedisCluster {
     /**
      * @see Redis::xpending
      */
-    public function xpending(string $key, string $group, ?string $start = null, ?string $end = null, int $count = -1, ?string $consumer = null): RedisCluster|array|false;
+    public function xpending(string $key, string $group, ?string $start = null, ?string $end = null, int $count = -1, ?string $consumer = null, int $idle = 0): RedisCluster|array|false;
 
     /**
      * @see Redis::xrange

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0f01437681bc6df1d6e2b39e6a0c7c5c77f6237e */
+ * Stub hash: 7ac98647c48842c7a53249001d0600763f375305 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -955,6 +955,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_xpending,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, end, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, count, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, consumer, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, idle, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_xrange, 0, 3, RedisCluster, MAY_BE_BOOL|MAY_BE_ARRAY)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0f01437681bc6df1d6e2b39e6a0c7c5c77f6237e */
+ * Stub hash: 7ac98647c48842c7a53249001d0600763f375305 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -818,6 +818,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_xpending, 0, 0, 2)
 	ZEND_ARG_INFO(0, end)
 	ZEND_ARG_INFO(0, count)
 	ZEND_ARG_INFO(0, consumer)
+	ZEND_ARG_INFO(0, idle)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_xrange, 0, 0, 3)

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d5f56120b09dc6a8240d87efa53dc5749c031f38 */
+ * Stub hash: 17311f750995902e9c69f1289dbc72feecc3695d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -913,6 +913,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xpending, 0, 0, 2)
 	ZEND_ARG_INFO(0, end)
 	ZEND_ARG_INFO(0, count)
 	ZEND_ARG_INFO(0, consumer)
+	ZEND_ARG_INFO(0, idle)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_xrange, 0, 0, 3)


### PR DESCRIPTION
This commit modifies the xpending method in both redis.stub.php and redis_cluster.stub.php to add an optional idle-time parameter. This allows users to filter pending messages based on idle time, enhancing the functionality and flexibility of the method.