### PR TITLE
Add `Redis::REDIS_VECTORSET` type.

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1948,7 +1948,7 @@ PHP_REDIS_API void cluster_long_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
 
 /* TYPE response handler */
 PHP_REDIS_API void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
-                              void *ctx)
+                                     void *ctx)
 {
     // Make sure we got the right kind of response
     if (c->reply_type != TYPE_LINE) {
@@ -1968,7 +1968,10 @@ PHP_REDIS_API void cluster_type_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
         CLUSTER_RETURN_LONG(c, REDIS_ZSET);
     } else if (redis_strncmp(c->line_reply, ZEND_STRL("stream")) == 0) {
         CLUSTER_RETURN_LONG(c, REDIS_STREAM);
+    } else if (redis_strncmp(c->line_reply, ZEND_STRL("vectorset")) == 0) {
+        CLUSTER_RETURN_LONG(c, REDIS_VECTORSET);
     } else {
+
         CLUSTER_RETURN_LONG(c, REDIS_NOT_FOUND);
     }
 }

--- a/common.h
+++ b/common.h
@@ -61,6 +61,7 @@ typedef enum {
 #define REDIS_ZSET      4
 #define REDIS_HASH      5
 #define REDIS_STREAM    6
+#define REDIS_VECTORSET 7
 
 #ifdef PHP_WIN32
 #define PHP_REDIS_API __declspec(dllexport)

--- a/library.c
+++ b/library.c
@@ -1239,6 +1239,8 @@ PHP_REDIS_API int redis_type_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *r
         l = REDIS_HASH;
     } else if (redis_strncmp(response, ZEND_STRL("+stream")) == 0) {
         l = REDIS_STREAM;
+    } else if (redis_strncmp(response, ZEND_STRL("+vectorset")) == 0) {
+        l = REDIS_VECTORSET;
     } else {
         l = REDIS_NOT_FOUND;
     }

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -66,6 +66,14 @@ class Redis {
     /**
      *
      * @var int
+     * @cvalue REDIS_VECTORSET
+     *
+     */
+    public const REDIS_VECTORSET = UNKNOWN;
+
+    /**
+     *
+     * @var int
      * @cvalue ATOMIC
      *
      */
@@ -3733,6 +3741,7 @@ class Redis {
      *     Redis::REDIS_ZSET
      *     Redis::REDIS_HASH
      *     Redis::REDIS_STREAM
+     *     Redis::REDIS_VECTORSET
      *
      * @example
      * foreach ($redis->keys('*') as $key) {

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d5f56120b09dc6a8240d87efa53dc5749c031f38 */
+ * Stub hash: e1643951a097b7a2f1bb3c0b6afd2c29f746a0d6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -1855,6 +1855,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_REDIS_STREAM_name = zend_string_init_interned("REDIS_STREAM", sizeof("REDIS_STREAM") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_REDIS_STREAM_name, &const_REDIS_STREAM_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_REDIS_STREAM_name);
+
+	zval const_REDIS_VECTORSET_value;
+	ZVAL_LONG(&const_REDIS_VECTORSET_value, REDIS_VECTORSET);
+	zend_string *const_REDIS_VECTORSET_name = zend_string_init_interned("REDIS_VECTORSET", sizeof("REDIS_VECTORSET") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_REDIS_VECTORSET_name, &const_REDIS_VECTORSET_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_REDIS_VECTORSET_name);
 
 	zval const_ATOMIC_value;
 	ZVAL_LONG(&const_ATOMIC_value, ATOMIC);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d5f56120b09dc6a8240d87efa53dc5749c031f38 */
+ * Stub hash: e1643951a097b7a2f1bb3c0b6afd2c29f746a0d6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -1693,6 +1693,12 @@ static zend_class_entry *register_class_Redis(void)
 	zend_string *const_REDIS_STREAM_name = zend_string_init_interned("REDIS_STREAM", sizeof("REDIS_STREAM") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_REDIS_STREAM_name, &const_REDIS_STREAM_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_REDIS_STREAM_name);
+
+	zval const_REDIS_VECTORSET_value;
+	ZVAL_LONG(&const_REDIS_VECTORSET_value, REDIS_VECTORSET);
+	zend_string *const_REDIS_VECTORSET_name = zend_string_init_interned("REDIS_VECTORSET", sizeof("REDIS_VECTORSET") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_REDIS_VECTORSET_name, &const_REDIS_VECTORSET_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_REDIS_VECTORSET_name);
 
 	zval const_ATOMIC_value;
 	ZVAL_LONG(&const_ATOMIC_value, ATOMIC);

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -658,6 +658,8 @@ class Redis_Cluster_Test extends Redis_Test {
                 return "hash";
             case Redis::REDIS_STREAM:
                 return "stream";
+            case Redis::REDIS_VECTORSET:
+                return "vectorset";
             default:
                 return "unknown($key_type)";
         }

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1155,10 +1155,15 @@ class Redis_Test extends TestSuite {
             $this->assertEquals(Redis::REDIS_STREAM, $this->redis->type('stream'));
         }
 
+        if ($this->haveCommand('vadd')) {
+            $this->redis->del('vset');
+            $this->assertEquals(1, $this->redis->vadd('vset', [1.5, 2.5], 'foo'));
+            $this->assertEquals(Redis::REDIS_VECTORSET, $this->redis->type('vset'));
+        }
+
         // None
         $this->redis->del('keyNotExists');
         $this->assertEquals(Redis::REDIS_NOT_FOUND, $this->redis->type('keyNotExists'));
-
     }
 
     public function testStr() {


### PR DESCRIPTION
Redis >= 8.0 has a new type `vectorset` that we should support like all the other types.