### PR TITLE
Fix `zadd` truncation bug on Windows

### DIFF
--- a/library.c
+++ b/library.c
@@ -1072,8 +1072,15 @@ int redis_cmd_append_sstr_int(smart_string *str, int append) {
  * Append a long to a smart string command
  */
 int redis_cmd_append_sstr_long(smart_string *str, long append) {
+    return redis_cmd_append_sstr_zend_long(str, (zend_long) append);
+}
+
+/*
+ * Append a zend_long to a smart string command
+ */
+int redis_cmd_append_sstr_zend_long(smart_string *str, zend_long lval) {
     char long_buf[32];
-    char *result = zend_print_long_to_buf(long_buf + sizeof(long_buf) - 1, append);
+    char *result = zend_print_long_to_buf(long_buf + sizeof(long_buf) - 1, lval);
     int int_len = long_buf + sizeof(long_buf) - 1 - result;
     return redis_cmd_append_sstr(str, result, int_len);
 }

--- a/library.h
+++ b/library.h
@@ -50,6 +50,7 @@ int redis_cmd_init_sstr(smart_string *str, int num_args, char *keyword, int keyw
 int redis_cmd_append_sstr(smart_string *str, char *append, int append_len);
 int redis_cmd_append_sstr_int(smart_string *str, int append);
 int redis_cmd_append_sstr_long(smart_string *str, long append);
+int redis_cmd_append_sstr_zend_long(smart_string *str, zend_long append);
 int redis_cmd_append_sstr_i64(smart_string *str, int64_t append);
 int redis_cmd_append_sstr_u64(smart_string *str, uint64_t append);
 int redis_cmd_append_sstr_dbl(smart_string *str, double value);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -1208,7 +1208,7 @@ static int redis_cmd_append_sstr_score(smart_string *dst, zval *score) {
     cmdlen = dst->len;
 
     if (Z_TYPE_P(score) == IS_LONG) {
-        redis_cmd_append_sstr_long(dst, Z_LVAL_P(score));
+        redis_cmd_append_sstr_zend_long(dst, Z_LVAL_P(score));
     } else if (Z_TYPE_P(score) == IS_DOUBLE) {
         redis_cmd_append_sstr_dbl(dst, Z_DVAL_P(score));
     } else if (Z_TYPE_P(score) == IS_STRING) {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2658,9 +2658,10 @@ class Redis_Test extends TestSuite {
     }
 
     public function testZAddFirstArg() {
-        $this->redis->del('key');
-
         $zsetName = 100; // not a string!
+
+        $this->redis->del($zsetName);
+
         $this->assertEquals(1, $this->redis->zAdd($zsetName, 0, 'val0'));
         $this->assertEquals(1, $this->redis->zAdd($zsetName, 1, 'val1'));
 
@@ -2674,6 +2675,17 @@ class Redis_Test extends TestSuite {
         $this->assertEquals(20.0, $this->redis->zAdd('zset', ['incr'], 10, 'value'));
 
         $this->assertFalse($this->redis->zAdd('zset', ['incr'], 10, 'value', 20, 'value2'));
+    }
+
+    /* Regression test for GitHub issue #2697 */
+    public function testZAddLargeLong() {
+        $this->redis->del('key');
+
+        $val = 5000000000;
+
+        $this->assertEquals(1, $this->redis->zAdd('key', $val, 'val0'));
+
+        $this->assertEquals($this->redis->zscore('key', 'val0'), (float)$val);
     }
 
     public function testZX() {


### PR DESCRIPTION
Apparently `long` is 32 bits wide on Windows so we can't use it when adding a score that the user specified as an integer.

This commit just adds a new helper that takes a `zend_long` rather than `long` as the argument, and then updates the old helper to just pass through to the new one so as to minimize the chance for this to create other edge cases.

It was quite annoying but i was able to build this in a Windows VM and the fix does appear to work.