### PR TITLE
Remove a "bad argument" assertion for `testWait`

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -2428,7 +2428,6 @@ class Redis_Test extends TestSuite {
 
         // Make sure when we pass with bad arguments we just get back false
         $this->assertFalse($this->redis->wait(-1, -1));
-        $this->assertEquals(0, $this->redis->wait(-1, 20));
     }
 
     public function testInfo() {


### PR DESCRIPTION
It seems like Redis changed what it will do when you send a negative number of events. Previously this would just return an error but it seems to return `1` now.

For this reason just remove that assertion so we don't have to use different logic depending on the version of the server.