### PR TITLE
Fix segfault during Redis Cluster failover

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1431,7 +1431,10 @@ static int cluster_update_slot(redisCluster *c) {
                 if (!CLUSTER_REDIR_CMP(c, slave->sock)) {
                     // Detected a failover, the redirected node was a replica
                     // Remap the cluster's keyspace
-                    cluster_map_keyspace(c);
+                    if (cluster_map_keyspace(c) == FAILURE) {
+                        CLUSTER_THROW_EXCEPTION("Failed to remap cluster keyspace after failover", 0);
+                        return FAILURE;
+                    }
                     return SUCCESS;
                 }
             } ZEND_HASH_FOREACH_END();
@@ -1610,9 +1613,19 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char
                    return -1;
                }
                c->cmd_sock = SLOT_SOCK(c, slot);
+               /* Verify slot is valid after update */
+               if (!c->cmd_sock) {
+                   CLUSTER_THROW_EXCEPTION("Socket for slot is NULL after MOVED redirection", 0);
+                   return -1;
+               }
            } else if (c->redir_type == REDIR_ASK) {
                /* For ASK redirection we want to redirect but not update slot mapping */
                c->cmd_sock = cluster_get_asking_sock(c);
+               /* Verify socket from ASK redirection */
+               if (!c->cmd_sock) {
+                   CLUSTER_THROW_EXCEPTION("Socket is NULL after ASK redirection", 0);
+                   return -1;
+               }
            }
         }
 


### PR DESCRIPTION
## Summary
- Fix segfault when `cluster_map_keyspace()` fails during Redis Cluster failover detection
- Add defense-in-depth NULL checks after MOVED and ASK redirections

## Root Cause
When a Redis Cluster failover occurs, the client detects that the redirected node was a replica of the old master and calls `cluster_map_keyspace()` to remap the cluster topology.

If `cluster_map_keyspace()` fails (e.g., due to network issues during the remap), it:
1. Frees all node objects via `zend_hash_clean(c->nodes)` 
2. Zeros the master array via `memset(c->master, 0, ...)`

The bug was that the return value of `cluster_map_keyspace()` was being ignored in the failover detection path at `cluster_library.c:1434`. This caused the code to continue with NULL socket pointers, leading to segfaults when dereferencing `c->cmd_sock` later.

## Changes
1. Check return value of `cluster_map_keyspace()` in failover detection path and return `FAILURE` if it fails
2. Add NULL checks after `SLOT_SOCK()` assignment following MOVED redirection
3. Add NULL check after `cluster_get_asking_sock()` assignment following ASK redirection

## Production Impact
This fixes production crashes observed during Redis Cluster failovers in phpredis 5.3.7 and 6.2.0.

### Example stack trace from production:
```
#0  cluster_send_command (c=0x7fa29428f680, slot=12586, cmd=0x7fa293c0c5d8 "*2\r\n$6\r\nEXISTS\r\n$58\r\n", cmd_len=78, type=TYPE_EOF) at /build/phpredis-m_0BGL/phpredis-6.2.0/cluster_library.c:1546
#1  redis_exists_cmd (ht=1, return_value=0x7fa2942b5d40, return_value_ptr=0x0, this_ptr=0x7fa2942b5ca0, return_value_used=1, c=0x7fa29428f680) at /build/phpredis-m_0BGL/phpredis-6.2.0/redis_cluster.c:1168
```

## Test Plan
- [ ] Verify the fix compiles without warnings
- [ ] Test normal Redis Cluster operations continue to work
- [ ] Test behavior during simulated failovers
- [ ] Verify proper error handling when cluster remapping fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)