### PR TITLE
Introduce `[[nodiscard]]` attribute where supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This release introduces support for dozens of new commands, including hash field
 
 ## Fixed
 
+- Fix a possible segfault during failover
+  [5ebb853e](https://github.com/phpredis/phpredis/commit/5ebb853e)
+  ([rlerdorf](https://github.com/rlerdorf))
 - Fix an overflow bug in ZADD on Windows
   [35df8ad7](https://github.com/phpredis/phpredis/commit/35df8ad7c2fc54fbf2a58d486cce49e712344bb2)
   ([michael-grunder](https://github.com/michael-grunder))
@@ -189,6 +192,9 @@ This release introduces support for dozens of new commands, including hash field
 
 ## Internal/Performance
 
+- Introduce `[[nodiscard]]` type attribute where supported.
+  [2d963e79](https://github.com/phpredis/phpredis/commit/2d963e79)
+  ([michael-grunder](https://github.com/michael-grunder))
 - Fix typo (s/sees/seeds/)
   [25e6d5fc](https://github.com/phpredis/phpredis/commit/25e6d5fcc2b7599907ec9571a12c1d5c8f9c0dcb)
   ([xabbuh](https://github.com/xabbuh))

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -378,7 +378,7 @@ PHP_REDIS_API redisCluster *cluster_create(double timeout, double read_timeout,
     int failover, int persistent);
 PHP_REDIS_API void cluster_free(redisCluster *c, int free_ctx);
 PHP_REDIS_API void cluster_init_seeds(redisCluster *c, zend_string **seeds, uint32_t nseeds);
-PHP_REDIS_API int cluster_map_keyspace(redisCluster *c);
+REDIS_NODISCARD PHP_REDIS_API int cluster_map_keyspace(redisCluster *c);
 PHP_REDIS_API void cluster_free_node(redisClusterNode *node);
 
 /* Functions for interacting with cached slots maps */

--- a/common.h
+++ b/common.h
@@ -41,6 +41,31 @@
 # error "Unknown endianness"
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#  define REDIS_MSVC 1
+#endif
+
+#ifndef REDIS_MSVC
+#  if defined(__has_c_attribute)
+#    if __has_c_attribute(nodiscard)
+#      define REDIS_NODISCARD [[nodiscard]]
+#    endif
+#  endif
+#  ifndef REDIS_NODISCARD
+#    if defined(__has_attribute)
+#      if __has_attribute(warn_unused_result)
+#        define REDIS_NODISCARD __attribute__((warn_unused_result))
+#      endif
+#    elif defined(__GNUC__) || defined(__clang__)
+#      define REDIS_NODISCARD __attribute__((warn_unused_result))
+#    else
+#      define REDIS_NODISCARD
+#    endif
+#  endif
+#else
+#  define REDIS_NODISCARD
+#endif
+
 #include "backoff.h"
 
 typedef enum {

--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
 
     Fixed:
 
+    Fix a possible segfault during failover [5ebb853e] (rlerdorf)
     Fix an overflow bug in ZADD on Windows [35df8ad7] (Michael Grunder)
     Fix errors and a warning [b8de91c9] (Michael Grunder)
     Fix `RedisCluster` segfault [f61e8cd7] (Michael Grunder)
@@ -105,6 +106,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
 
     Internal/Performance:
 
+    Introduce `[[nodiscard]]` type attribute where supported. [2d963e79] (Michael Grunder)
     Fix typo (s/sees/seeds/) [25e6d5fc] (xabbuh)
     Fix an unused variable warning [b48aa0d4] (Michael Grunder)
     Fix several issues surfaced by `gcc -fanalyze` [8be2306e] (Michael Grunder)


### PR DESCRIPTION
This commit just adds support for `[[nodiscard]]` or `__attribute__((warn_unused_result))` when we can detect the compiler supports it.

Initially I just added it to `cluster_map_keyspace` but in a future PR we can add it to every api method where it makes sense.