### PR TITLE
Added 8.5 to Mac and Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
           phpize
           ./configure --enable-redis-lzf --enable-redis-zstd --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lz4 --with-liblz4
           sudo make install
+          sudo mkdir -p "$(php-config --ini-dir)"
           echo 'extension = redis.so' | sudo tee -a "$(php-config --ini-dir)/90-redis.ini"
 
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -261,7 +261,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         ts: [nts, ts]
     steps:
       - name: Checkout
@@ -269,7 +269,7 @@ jobs:
         with:
           submodules: true
       - name: Install PHP ${{ matrix.php }}
-        uses: php/setup-php-sdk@v0.10
+        uses: php/setup-php-sdk@v0.11
         id: setup-php-sdk
         with:
           version: ${{ matrix.php }}


### PR DESCRIPTION
There is no issue with the Windows build; however, the macOS build fails because the igbinary extension is installed via PECL, and it currently does not support PHP 8.5.

Until a compatible version of igbinary is released, this MR is draft.

Notes
- Windows build ✅
- macOS build ❌ due to PECL igbinary incompatibility

Waiting

- Igbinary new release https://github.com/igbinary/igbinary/pull/404