### PR TITLE
Fix `HMGET` where hash fields have an integer prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This release introduces support for dozens of new commands, including hash field
 
 ## Fixed
 
+- Fix possible hash field name truncation
+  [834d2b37](https://github.com/phpredis/phpredis/commit/834d2b37)
+  ([michael-grunder](https://github.com/michael-grunder))
 - Fix a possible segfault during failover
   [5ebb853e](https://github.com/phpredis/phpredis/commit/5ebb853e)
   ([rlerdorf](https://github.com/rlerdorf))

--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
 
     Fixed:
 
+    Fix possible hash field name truncation [834d2b37] (Michael Grunder)
     Fix a possible segfault during failover [5ebb853e] (rlerdorf)
     Fix an overflow bug in ZADD on Windows [35df8ad7] (Michael Grunder)
     Fix errors and a warning [b8de91c9] (Michael Grunder)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2688,7 +2688,7 @@ static inline zval *coerce_hash_field(zval *zv, zval *aux) {
 
     if (UNEXPECTED(Z_TYPE_P(zv) == IS_STRING &&
                    is_numeric_string(Z_STRVAL_P(zv),
-                                     Z_STRLEN_P(zv), &lv, NULL, 1) == IS_LONG))
+                                     Z_STRLEN_P(zv), &lv, NULL, 0) == IS_LONG))
     {
         ZVAL_LONG(aux, lv);
         return aux;

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3395,6 +3395,24 @@ class Redis_Test extends TestSuite {
 	}
     }
 
+    /* Regression test for GitHub issue 2731 */
+    public function testNumericPrefixHashFields() {
+        $hash = [
+            '86deaeb05e3f7760b67e92897a1325e0fdd8618d' => 'one',
+            '-86deaeb05e3f7760b67e92897a1325e0fdd8618d' => 'two',
+            12345 => 'a_real_number',
+            -12345 => 'a_negative_real_number',
+        ];
+
+        $this->assertIsInt($this->redis->del('hash'));
+        $this->assertTrue($this->redis->hmset('hash', $hash));
+
+        $res = $this->redis->hmget('hash', array_keys($hash));
+
+        // The keys from our local variable and res should be equal
+        $this->assertEqualsCanonicalizing(array_keys($hash), array_keys($res));
+    }
+
     public function testHRandField() {
         if (version_compare($this->version, '6.2.0') < 0)
             $this->MarkTestSkipped();


### PR DESCRIPTION
We were incorrectly ignoring errors when calling `is_numeric_string`, meaning we would truncate hash fields that had integer prefixes.

```php
$redis->hmget('hash', ['123notaninteger']);
// Would actually execute:
// HMGET hash 123
```

Fixes #2731