### PR TITLE
Inform the user if we couldn't extract any session servers.

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -558,6 +558,9 @@ PS_OPEN_FUNC(redis)
     if (pool->head) {
         PS_SET_MOD_DATA(pool);
         return SUCCESS;
+    } else {
+        php_error_docref(NULL, E_WARNING,
+            "Unable to extract any servers from session.save_path");
     }
 
 fail:


### PR DESCRIPTION
Add a specific warning when we can't parse any servers from `php.session_save_path`.

PHP will then display the save path, but this will let users know there was a problem parsing the path.

Fixes #1390