### PR TITLE
Cloning our objects should not segfault

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -217,6 +217,7 @@ create_redis_object(zend_class_entry *ce)
     memcpy(&redis_object_handlers, zend_get_std_object_handlers(), sizeof(redis_object_handlers));
     redis_object_handlers.offset = XtOffsetOf(redis_object, std);
     redis_object_handlers.free_obj = free_redis_object;
+    redis_object_handlers.clone_obj = NULL;
     redis->std.handlers = &redis_object_handlers;
 
     return &redis->std;

--- a/redis_array.c
+++ b/redis_array.c
@@ -121,6 +121,7 @@ create_redis_array_object(zend_class_entry *ce)
     memcpy(&redis_array_object_handlers, zend_get_std_object_handlers(), sizeof(redis_array_object_handlers));
     redis_array_object_handlers.offset = XtOffsetOf(redis_array_object, std);
     redis_array_object_handlers.free_obj = free_redis_array_object;
+    redis_array_object_handlers.clone_obj = NULL;
     obj->std.handlers = &redis_array_object_handlers;
 
     return &obj->std;

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -209,6 +209,7 @@ zend_object * create_cluster_context(zend_class_entry *class_type) {
     memcpy(&RedisCluster_handlers, zend_get_std_object_handlers(), sizeof(RedisCluster_handlers));
     RedisCluster_handlers.offset = XtOffsetOf(redisCluster, std);
     RedisCluster_handlers.free_obj = free_cluster_context;
+    RedisCluster_handlers.clone_obj = NULL;
 
     cluster->std.handlers = &RedisCluster_handlers;
 


### PR DESCRIPTION
In a future release we can actually implement cloning logic along with lazy reconnection but for now, just throw a fatal error.

Fixes #1760