### PR TITLE
Implement `DIGEST` and `_digest` helper (for php >= 8.1)

### DIFF
--- a/redis.c
+++ b/redis.c
@@ -2620,6 +2620,24 @@ PHP_METHOD(Redis, _pack) {
     redis_pack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock);
 }
 
+#if PHP_VERSION_ID >= 80100
+PHP_METHOD(Redis, _digest) {
+    RedisSock *redis_sock;
+    zval *zv;
+
+    redis_sock = redis_sock_get_instance(getThis(), 0);
+    if (redis_sock == NULL) {
+        RETURN_FALSE;
+    }
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ZVAL(zv)
+    ZEND_PARSE_PARAMETERS_END();
+
+    RETURN_STR(redis_digest_handler(redis_sock, zv));
+}
+#endif
+
 PHP_METHOD(Redis, _unpack) {
     RedisSock *redis_sock;
 
@@ -3178,6 +3196,10 @@ PHP_METHOD(Redis, geosearch) {
 
 PHP_METHOD(Redis, geosearchstore) {
     REDIS_PROCESS_CMD(geosearchstore, redis_long_response);
+}
+
+PHP_METHOD(Redis, digest) {
+    REDIS_PROCESS_KW_CMD("DIGEST", redis_key_cmd, redis_ping_response);
 }
 
 /*

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -590,6 +590,17 @@ class Redis {
      */
     public function _pack(mixed $value): string;
 
+#if PHP_VERSION_ID >= 80100
+
+    /**
+     * Compute the XXH3 digest of a packed value.
+     *
+     * @param mixed $value The value to compute the digest for.
+     * @return string The computed digest.
+     */
+    public function _digest(mixed $value): string;
+#endif
+
     /**
      * Unpack the provided value with the configured compressor and serializer
      * as set with Redis::setOption().
@@ -5037,6 +5048,16 @@ class Redis {
      * $redis->zUnionStore('dst', ['zs1', 'zs2', 'zs3']);
      */
     public function zunionstore(string $dst, array $keys, ?array $weights = null, ?string $aggregate = null): Redis|int|false;
+
+    /**
+     * Ask the server for the XXH3 digest of a given key's value
+     *
+     * @param strinig $key The key to retrieve the digest for.
+     * @return Redis|string|false The XXH3 digest as a string or false on failure.
+     */
+    public function digest(string $key): Redis|string|false;
 }
+
+
 
 class RedisException extends RuntimeException {}

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4c712b9de716d8008f7d3b38aa8b7125b08a042b */
+ * Stub hash: b3bd2917baa5afac66331f28a0d2cdd6a7981083 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -27,6 +27,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis__unserialize, 0, 1, 
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis__pack arginfo_class_Redis__serialize
+
+#if PHP_VERSION_ID >= 80100
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Redis__digest, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_Redis__unpack arginfo_class_Redis__unserialize
 
@@ -1299,6 +1305,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_zunionstore arginfo_class_Redis_zinterstore
 
+#define arginfo_class_Redis_digest arginfo_class_Redis_dump
+
 ZEND_METHOD(Redis, __construct);
 ZEND_METHOD(Redis, __destruct);
 ZEND_METHOD(Redis, _compress);
@@ -1307,6 +1315,9 @@ ZEND_METHOD(Redis, _prefix);
 ZEND_METHOD(Redis, _serialize);
 ZEND_METHOD(Redis, _unserialize);
 ZEND_METHOD(Redis, _pack);
+#if PHP_VERSION_ID >= 80100
+ZEND_METHOD(Redis, _digest);
+#endif
 ZEND_METHOD(Redis, _unpack);
 ZEND_METHOD(Redis, acl);
 ZEND_METHOD(Redis, append);
@@ -1583,6 +1594,7 @@ ZEND_METHOD(Redis, zinterstore);
 ZEND_METHOD(Redis, zscan);
 ZEND_METHOD(Redis, zunion);
 ZEND_METHOD(Redis, zunionstore);
+ZEND_METHOD(Redis, digest);
 
 static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, __construct, arginfo_class_Redis___construct, ZEND_ACC_PUBLIC)
@@ -1593,6 +1605,9 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, _serialize, arginfo_class_Redis__serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, _unserialize, arginfo_class_Redis__unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, _pack, arginfo_class_Redis__pack, ZEND_ACC_PUBLIC)
+#if PHP_VERSION_ID >= 80100
+	ZEND_ME(Redis, _digest, arginfo_class_Redis__digest, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Redis, _unpack, arginfo_class_Redis__unpack, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, acl, arginfo_class_Redis_acl, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, append, arginfo_class_Redis_append, ZEND_ACC_PUBLIC)
@@ -1884,6 +1899,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, zscan, arginfo_class_Redis_zscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zunion, arginfo_class_Redis_zunion, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zunionstore, arginfo_class_Redis_zunionstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, digest, arginfo_class_Redis_digest, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2024,6 +2024,19 @@ PHP_METHOD(RedisCluster, _pack) {
     redis_pack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags);
 }
 
+#if PHP_VERSION_ID >= 80100
+PHP_METHOD(RedisCluster, _digest) {
+    redisCluster *c = GET_CONTEXT();
+    zval *zv;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ZVAL(zv)
+    ZEND_PARSE_PARAMETERS_END();
+
+    RETURN_STR(redis_digest_handler(c->flags, zv));
+}
+#endif
+
 PHP_METHOD(RedisCluster, _unpack) {
     redisCluster *c = GET_CONTEXT();
     redis_unpack_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU, c->flags);
@@ -3436,6 +3449,10 @@ PHP_METHOD(RedisCluster, command) {
 
 PHP_METHOD(RedisCluster, copy) {
     CLUSTER_PROCESS_CMD(copy, cluster_1_resp, 0);
+}
+
+PHP_METHOD(RedisCluster, digest) {
+    CLUSTER_PROCESS_KW_CMD("DIGEST", redis_key_cmd, cluster_bulk_raw_resp, 1);
 }
 
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -74,6 +74,13 @@ class RedisCluster {
      */
     public function _pack(mixed $value): string;
 
+#if PHP_VERSION_ID >= 80100
+    /**
+     * @see Redis::_digest()
+     */
+    public function _digest(string $value): string;
+#endif
+
     /**
      * @see Redis::_unpack()
      */
@@ -1380,6 +1387,11 @@ class RedisCluster {
      * @see https://redis.io/commands/zdiff
      */
     public function zdiff(array $keys, ?array $options = null): RedisCluster|array|false;
+
+    /**
+     * @see https://redis.io/commands/digest
+     */
+    public function digest(string $key): RedisCluster|string|false;
 }
 
 class RedisClusterException extends RuntimeException {}

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cd1fe38b8b2078964d1b7f50252f6f931d20fd35 */
+ * Stub hash: 390bc7324c3678a103fdff12ee552fd9e74975f8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -28,6 +28,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster__pack, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#if PHP_VERSION_ID >= 80100
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_RedisCluster__digest, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_RedisCluster__unpack arginfo_class_RedisCluster__unserialize
 
@@ -1187,12 +1193,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_zdiff, 0,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_RedisCluster_digest arginfo_class_RedisCluster_dump
+
 ZEND_METHOD(RedisCluster, __construct);
 ZEND_METHOD(RedisCluster, _compress);
 ZEND_METHOD(RedisCluster, _uncompress);
 ZEND_METHOD(RedisCluster, _serialize);
 ZEND_METHOD(RedisCluster, _unserialize);
 ZEND_METHOD(RedisCluster, _pack);
+#if PHP_VERSION_ID >= 80100
+ZEND_METHOD(RedisCluster, _digest);
+#endif
 ZEND_METHOD(RedisCluster, _unpack);
 ZEND_METHOD(RedisCluster, _prefix);
 ZEND_METHOD(RedisCluster, _masters);
@@ -1443,6 +1454,7 @@ ZEND_METHOD(RedisCluster, zinter);
 ZEND_METHOD(RedisCluster, zdiffstore);
 ZEND_METHOD(RedisCluster, zunion);
 ZEND_METHOD(RedisCluster, zdiff);
+ZEND_METHOD(RedisCluster, digest);
 
 static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, __construct, arginfo_class_RedisCluster___construct, ZEND_ACC_PUBLIC)
@@ -1451,6 +1463,9 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, _serialize, arginfo_class_RedisCluster__serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _unserialize, arginfo_class_RedisCluster__unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _pack, arginfo_class_RedisCluster__pack, ZEND_ACC_PUBLIC)
+#if PHP_VERSION_ID >= 80100
+	ZEND_ME(RedisCluster, _digest, arginfo_class_RedisCluster__digest, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(RedisCluster, _unpack, arginfo_class_RedisCluster__unpack, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _prefix, arginfo_class_RedisCluster__prefix, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _masters, arginfo_class_RedisCluster__masters, ZEND_ACC_PUBLIC)
@@ -1701,6 +1716,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zdiffstore, arginfo_class_RedisCluster_zdiffstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zunion, arginfo_class_RedisCluster_zunion, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zdiff, arginfo_class_RedisCluster_zdiff, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, digest, arginfo_class_RedisCluster_digest, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cd1fe38b8b2078964d1b7f50252f6f931d20fd35 */
+ * Stub hash: 390bc7324c3678a103fdff12ee552fd9e74975f8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -22,6 +22,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RedisCluster__unserialize arginfo_class_RedisCluster__compress
 
 #define arginfo_class_RedisCluster__pack arginfo_class_RedisCluster__compress
+
+#if PHP_VERSION_ID >= 80100
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster__digest, 0, 0, 1)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_RedisCluster__unpack arginfo_class_RedisCluster__compress
 
@@ -1016,12 +1022,17 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_zdiff, 0, 0, 1)
 	ZEND_ARG_INFO(0, options)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_RedisCluster_digest arginfo_class_RedisCluster__prefix
+
 ZEND_METHOD(RedisCluster, __construct);
 ZEND_METHOD(RedisCluster, _compress);
 ZEND_METHOD(RedisCluster, _uncompress);
 ZEND_METHOD(RedisCluster, _serialize);
 ZEND_METHOD(RedisCluster, _unserialize);
 ZEND_METHOD(RedisCluster, _pack);
+#if PHP_VERSION_ID >= 80100
+ZEND_METHOD(RedisCluster, _digest);
+#endif
 ZEND_METHOD(RedisCluster, _unpack);
 ZEND_METHOD(RedisCluster, _prefix);
 ZEND_METHOD(RedisCluster, _masters);
@@ -1272,6 +1283,7 @@ ZEND_METHOD(RedisCluster, zinter);
 ZEND_METHOD(RedisCluster, zdiffstore);
 ZEND_METHOD(RedisCluster, zunion);
 ZEND_METHOD(RedisCluster, zdiff);
+ZEND_METHOD(RedisCluster, digest);
 
 static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, __construct, arginfo_class_RedisCluster___construct, ZEND_ACC_PUBLIC)
@@ -1280,6 +1292,9 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, _serialize, arginfo_class_RedisCluster__serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _unserialize, arginfo_class_RedisCluster__unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _pack, arginfo_class_RedisCluster__pack, ZEND_ACC_PUBLIC)
+#if PHP_VERSION_ID >= 80100
+	ZEND_ME(RedisCluster, _digest, arginfo_class_RedisCluster__digest, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(RedisCluster, _unpack, arginfo_class_RedisCluster__unpack, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _prefix, arginfo_class_RedisCluster__prefix, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, _masters, arginfo_class_RedisCluster__masters, ZEND_ACC_PUBLIC)
@@ -1530,6 +1545,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, zdiffstore, arginfo_class_RedisCluster_zdiffstore, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zunion, arginfo_class_RedisCluster_zunion, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, zdiff, arginfo_class_RedisCluster_zdiff, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, digest, arginfo_class_RedisCluster_digest, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -16,6 +16,7 @@
   +----------------------------------------------------------------------+
 */
 
+#include "hash/php_hash.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -7488,6 +7489,45 @@ void redis_pack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
     RETVAL_STRINGL(val, len);
     if (valfree) efree(val);
 }
+
+#if PHP_VERSION_ID >= 80100
+zend_string *redis_digest_handler(RedisSock *redis_sock, zval *zv) {
+    zend_string *algo, *hex;
+    const php_hash_ops *ops;
+    unsigned char *digest;
+    int valfree;
+    size_t len;
+    char *val;
+    void *ctx;
+
+    algo = zend_string_init(ZEND_STRL("XXH3"), 0);
+    ops  = php_hash_fetch_ops(algo);
+    if (ops == NULL) {
+        zend_string_release(algo);
+        return NULL;
+    }
+
+    valfree = redis_pack(redis_sock, zv, &val, &len);
+
+    ctx = emalloc(ops->context_size);
+    ops->hash_init(ctx, NULL);
+    ops->hash_update(ctx, (const unsigned char *)val, len);
+
+    digest = emalloc(ops->digest_size);
+    ops->hash_final(digest, ctx);
+
+    hex = zend_string_safe_alloc(ops->digest_size, 2, 0, 0);
+    php_hash_bin2hex(ZSTR_VAL(hex), digest, ops->digest_size);
+    ZSTR_VAL(hex)[ZSTR_LEN(hex)] = '\0';
+
+    efree(ctx);
+    efree(digest);
+    if (valfree) efree(val);
+    zend_string_release(algo);
+
+    return hex;
+}
+#endif
 
 void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
     zend_string *str;

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -456,6 +456,10 @@ void redis_uncompress_handler(INTERNAL_FUNCTION_PARAMETERS,
 void redis_pack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 void redis_unpack_handler(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 
+#if PHP_VERSION_ID >= 80100
+zend_string *redis_digest_handler(RedisSock *redis_sock, zval *zv);
+#endif
+
 #endif
 
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4c712b9de716d8008f7d3b38aa8b7125b08a042b */
+ * Stub hash: b3bd2917baa5afac66331f28a0d2cdd6a7981083 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -23,6 +23,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Redis__unserialize arginfo_class_Redis__compress
 
 #define arginfo_class_Redis__pack arginfo_class_Redis__compress
+
+#if PHP_VERSION_ID >= 80100
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis__digest, 0, 0, 1)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+#endif
 
 #define arginfo_class_Redis__unpack arginfo_class_Redis__compress
 
@@ -1131,6 +1137,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_zunionstore arginfo_class_Redis_zinterstore
 
+#define arginfo_class_Redis_digest arginfo_class_Redis__prefix
+
 ZEND_METHOD(Redis, __construct);
 ZEND_METHOD(Redis, __destruct);
 ZEND_METHOD(Redis, _compress);
@@ -1139,6 +1147,9 @@ ZEND_METHOD(Redis, _prefix);
 ZEND_METHOD(Redis, _serialize);
 ZEND_METHOD(Redis, _unserialize);
 ZEND_METHOD(Redis, _pack);
+#if PHP_VERSION_ID >= 80100
+ZEND_METHOD(Redis, _digest);
+#endif
 ZEND_METHOD(Redis, _unpack);
 ZEND_METHOD(Redis, acl);
 ZEND_METHOD(Redis, append);
@@ -1415,6 +1426,7 @@ ZEND_METHOD(Redis, zinterstore);
 ZEND_METHOD(Redis, zscan);
 ZEND_METHOD(Redis, zunion);
 ZEND_METHOD(Redis, zunionstore);
+ZEND_METHOD(Redis, digest);
 
 static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, __construct, arginfo_class_Redis___construct, ZEND_ACC_PUBLIC)
@@ -1425,6 +1437,9 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, _serialize, arginfo_class_Redis__serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, _unserialize, arginfo_class_Redis__unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, _pack, arginfo_class_Redis__pack, ZEND_ACC_PUBLIC)
+#if PHP_VERSION_ID >= 80100
+	ZEND_ME(Redis, _digest, arginfo_class_Redis__digest, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Redis, _unpack, arginfo_class_Redis__unpack, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, acl, arginfo_class_Redis_acl, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, append, arginfo_class_Redis_append, ZEND_ACC_PUBLIC)
@@ -1716,6 +1731,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, zscan, arginfo_class_Redis_zscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zunion, arginfo_class_Redis_zunion, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, zunionstore, arginfo_class_Redis_zunionstore, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, digest, arginfo_class_Redis_digest, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -8679,5 +8679,32 @@ class Redis_Test extends TestSuite {
         $this->assertEquals($data, $runner->getData());
         $this->assertEquals(600, $this->redis->ttl($runner->getSessionKey()));
     }
+
+    public function testDigest() {
+        if ( ! $this->haveCommand('DIGEST'))
+            $this->markTestSkipped();
+
+        $key = 'foo';
+        $val = 'bar';
+
+        $this->redis->set($key, $val);
+        $digest = $this->redis->digest($key);
+        $this->assertTrue(is_string($digest) && strlen($digest) == 16);
+
+        /* In PHP >= 8.1 we can verify the value */
+        if (PHP_VERSION_ID >= 80100) {
+            $this->assertEquals($this->redis->_digest($val), $digest);
+
+            $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+
+            $this->assertTrue($this->redis->set($key, $val));
+            $this->assertEquals(
+                $this->redis->_digest($val),
+                $this->redis->digest($key)
+            );
+
+            $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        }
+    }
 }
 ?>


### PR DESCRIPTION
Redis implemented new CAS semantics which work both with values and the XXH3 digest of those values.

This commit implements the Redis command itself and a helper which computes the XXH3 digest locally. Note that we can only be sure to have the `XXH3` hashing algorithm in PHP >= 8.1 so the `_digest` helper is limited to PHP 8.1 or newer.