### PR TITLE
Make sure `_digest` throws an exception in PHP < 8.1

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -8704,6 +8704,13 @@ class Redis_Test extends TestSuite {
             );
 
             $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        } else {
+            $this->assertThrowsMatch($this->redis,
+                function($r) {
+                    $r->_digest('foo');
+                },
+                '/^.*8\.1.*$/'
+            );
         }
     }
 


### PR DESCRIPTION
Ensure we are throwing an eception if the user calls `_digest` in PHP 8.0 or older.