### PR TITLE
Add a monotonically incrementing persistent id counter

### DIFF
--- a/library.c
+++ b/library.c
@@ -3334,6 +3334,9 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
     int host_len, usocket = 0, err = 0, tcp_flag = 1;
     ConnectionPool *p = NULL;
 
+    // Monotonically incrementing persistent id counter
+    static unsigned long long counter = 0;
+
     if (redis_sock->stream != NULL) {
         redis_sock_disconnect(redis_sock, 0, 1);
     }
@@ -3383,7 +3386,8 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
             }
 
             gettimeofday(&tv, NULL);
-            persistent_id = strpprintf(0, "phpredis_%ld%ld", tv.tv_sec, (long)tv.tv_usec);
+            persistent_id = strpprintf(0, "phpredis_%ld%ld:%llu", tv.tv_sec,
+                                       (long)tv.tv_usec, ++counter);
         } else {
             if (redis_sock->persistent_id) {
                 persistent_id = strpprintf(0, "phpredis:%s:%s", host, ZSTR_VAL(redis_sock->persistent_id));


### PR DESCRIPTION
When a persistent ID is not provided, we were generating a "unique" one by constructing a string with the current seconds and microseconds.

If two connections are createed in rapid succession, they can both generate the same `persistent_id` and therefore both use the same underlying `php_stream`.

```php
$r1 = new Redis;
$r2 = new Redis;

// If the two of these execute on the same second and usec, they will both use
// the same persistent_id and therefore the same underlying socket.
$r1->pconnect('localhost', 6379);
$r2->pconnect('localhost', 6379);

// Close and free the first connection
$r1->close();

// Segfault. Closing an already closed stream
$r2->close();
```

This commit simply adds a function scoped static monotonically incremented counter which is used to make the persistent id's truly unique.

Fixes #2762