### PR TITLE
Fix build on PHP 8.6-dev

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2010,12 +2010,12 @@ PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
         if ((z_tmp = zend_hash_index_find(Z_ARRVAL(z_tab), 0)) == NULL ||
             strcasecmp(Z_STRVAL_P(z_tmp), sctx->kw) != 0
         ) {
-            zval_dtor(&z_tab);
+            zval_ptr_dtor_nogc(&z_tab);
             efree(sctx);
             RETURN_FALSE;
         }
 
-        zval_dtor(&z_tab);
+        zval_ptr_dtor_nogc(&z_tab);
         pull = 1;
     }
 
@@ -2046,7 +2046,7 @@ PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
         {
             is_pmsg = *Z_STRVAL_P(z_type) == 'p';
         } else {
-            zval_dtor(&z_tab);
+            zval_ptr_dtor_nogc(&z_tab);
             continue;
         }
 
@@ -2085,14 +2085,14 @@ PHP_REDIS_API void cluster_sub_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
         // If we have a return value, free it
         zval_ptr_dtor(&z_ret);
 
-        zval_dtor(&z_tab);
+        zval_ptr_dtor_nogc(&z_tab);
     }
 
     // We're no longer subscribing, due to an error
     c->subscribed_slot = -1;
 
     // Cleanup
-    zval_dtor(&z_tab);
+    zval_ptr_dtor_nogc(&z_tab);
     efree(sctx);
 
     // Failure
@@ -2116,8 +2116,8 @@ PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
         if (!cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, pull, mbulk_resp_loop_raw, &z_tab) ||
             (z_chan = zend_hash_index_find(Z_ARRVAL(z_tab), 1)) == NULL
         ) {
-            zval_dtor(&z_tab);
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(&z_tab);
+            zval_ptr_dtor_nogc(return_value);
             RETURN_FALSE;
         }
 
@@ -2125,8 +2125,8 @@ PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
         if ((z_flag = zend_hash_index_find(Z_ARRVAL(z_tab), 2)) == NULL ||
             Z_STRLEN_P(z_flag) != 2
         ) {
-            zval_dtor(&z_tab);
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(&z_tab);
+            zval_ptr_dtor_nogc(return_value);
             RETURN_FALSE;
         }
 
@@ -2136,7 +2136,7 @@ PHP_REDIS_API void cluster_unsub_resp(INTERNAL_FUNCTION_PARAMETERS,
         // Add result
         add_assoc_bool(return_value, Z_STRVAL_P(z_chan), flag[1] == '1');
 
-        zval_dtor(&z_tab);
+        zval_ptr_dtor_nogc(&z_tab);
         pull = 1;
     }
 }
@@ -2331,7 +2331,7 @@ cluster_gen_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 
         /* Call our specified callback */
         if (cb(c->cmd_sock, &z_result, c->reply_len, ctx) == FAILURE) {
-            zval_dtor(&z_result);
+            zval_ptr_dtor_nogc(&z_result);
             CLUSTER_RETURN_FALSE(c);
         }
     }
@@ -2461,7 +2461,7 @@ cluster_xrange_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
     c->cmd_sock->compression = c->flags->compression;
 
     if (redis_read_stream_messages(c->cmd_sock, c->reply_len, &z_messages) < 0) {
-        zval_dtor(&z_messages);
+        zval_ptr_dtor_nogc(&z_messages);
         CLUSTER_RETURN_FALSE(c);
     }
 
@@ -2485,7 +2485,7 @@ cluster_xread_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
     } else {
         array_init(&z_streams);
         if (redis_read_stream_messages_multi(c->cmd_sock, c->reply_len, &z_streams) < 0) {
-            zval_dtor(&z_streams);
+            zval_ptr_dtor_nogc(&z_streams);
             CLUSTER_RETURN_FALSE(c);
         }
     }
@@ -2507,7 +2507,7 @@ cluster_xclaim_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
     ZEND_ASSERT(ctx == NULL || ctx == PHPREDIS_CTX_PTR);
 
     if (redis_read_xclaim_reply(c->cmd_sock, c->reply_len, ctx == PHPREDIS_CTX_PTR, &z_msg) < 0) {
-        zval_dtor(&z_msg);
+        zval_ptr_dtor_nogc(&z_msg);
         CLUSTER_RETURN_FALSE(c);
     }
 
@@ -2542,7 +2542,7 @@ cluster_vemb_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
     return;
 
 fail:
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
     CLUSTER_RETURN_FALSE(c);
 }
 
@@ -2556,7 +2556,7 @@ cluster_vinfo_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx) {
 
     array_init_size(&z_ret, c->reply_len / 2);
     if (redis_read_vinfo_response(c->cmd_sock, &z_ret, c->reply_len) != SUCCESS) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         CLUSTER_RETURN_FALSE(c);
     }
 
@@ -2623,7 +2623,7 @@ cluster_xinfo_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx)
 
     array_init(&z_ret);
     if (redis_read_xinfo_response(c->cmd_sock, &z_ret, c->reply_len) != SUCCESS) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         CLUSTER_RETURN_FALSE(c);
     }
 
@@ -2658,7 +2658,7 @@ cluster_acl_custom_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, void *ctx
 
     array_init(&z_ret);
     if (cb(c->cmd_sock, &z_ret, c->reply_len) != SUCCESS) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         CLUSTER_RETURN_FALSE(c);
     }
 
@@ -2701,7 +2701,7 @@ PHP_REDIS_API zval *cluster_zval_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
 
     // Call our callback
     if (cb(c->cmd_sock, z_ret, c->reply_len, NULL) == FAILURE) {
-        zval_dtor(z_ret);
+        zval_ptr_dtor_nogc(z_ret);
         return NULL;
     }
 
@@ -2727,7 +2727,7 @@ PHP_REDIS_API void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
             c->cmd_sock = SLOT_SOCK(c, fi->slot);
 
             if (cluster_check_response(c, &c->reply_type) < 0) {
-                zval_dtor(multi_resp);
+                zval_ptr_dtor_nogc(multi_resp);
                 RETURN_FALSE;
             }
 
@@ -2742,7 +2742,7 @@ PHP_REDIS_API void cluster_multi_mbulk_resp(INTERNAL_FUNCTION_PARAMETERS,
     }
 
     // Set our return array
-    zval_dtor(return_value);
+    zval_ptr_dtor_nogc(return_value);
     RETVAL_ZVAL(multi_resp, 0, 1);
 }
 
@@ -2858,7 +2858,7 @@ PHP_REDIS_API void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
     if (c->reply_type != TYPE_LINE) {
         php_error_docref(0, E_ERROR,
             "Invalid reply type returned for MSET command");
-        zval_dtor(mctx->z_multi);
+        zval_ptr_dtor_nogc(mctx->z_multi);
         efree(mctx->z_multi);
         efree(mctx);
         RETURN_FALSE;
@@ -3061,7 +3061,7 @@ static int mbulk_resp_loop_zipdbl(RedisSock *redis_sock, zval *z_result,
                 zend_string *tmp, *zstr = zval_get_tmp_string(z, &tmp);
                 add_assoc_double_ex(z_result, ZSTR_VAL(zstr), ZSTR_LEN(zstr), atof(line));
                 zend_tmp_string_release(tmp);
-                zval_dtor(z);
+                zval_ptr_dtor_nogc(z);
 
                 /* Free our key and line */
                 efree(key);

--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2867,9 +2867,9 @@ PHP_REDIS_API void cluster_mset_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster 
     // Set our return if it's the last call
     if (mctx->last) {
         if (CLUSTER_IS_ATOMIC(c)) {
-            ZVAL_BOOL(return_value, zval_is_true(mctx->z_multi));
+            ZVAL_BOOL(return_value, zend_is_true(mctx->z_multi));
         } else {
-            add_next_index_bool(&c->multi_resp, zval_is_true(mctx->z_multi));
+            add_next_index_bool(&c->multi_resp, zend_is_true(mctx->z_multi));
         }
         efree(mctx->z_multi);
     }

--- a/library.c
+++ b/library.c
@@ -3055,7 +3055,7 @@ redis_sock_configure(RedisSock *redis_sock, HashTable *opts)
                 redis_sock->persistent_id = zval_get_string(val);
                 redis_sock->persistent = 1;
             } else {
-                redis_sock->persistent = zval_is_true(val);
+                redis_sock->persistent = zend_is_true(val);
             }
         } else if (zend_string_equals_literal_ci(zkey, "maxRetries")) {
             if (Z_TYPE_P(val) != IS_LONG || Z_LVAL_P(val) < 0) {

--- a/library.c
+++ b/library.c
@@ -542,7 +542,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
         zend_hash_str_update_mem(subs, Z_STRVAL_P(z_tmp), Z_STRLEN_P(z_tmp),
                                     &sctx->cb, sizeof(sctx->cb));
 
-        zval_dtor(&z_resp);
+        zval_ptr_dtor_nogc(&z_resp);
     }
 
     if (strcasecmp(sctx->kw, "ssubscribe") == 0) {
@@ -596,7 +596,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
         ) {
             is_pmsg = *Z_STRVAL_P(z_type)=='p';
         } else {
-            zval_dtor(&z_resp);
+            zval_ptr_dtor_nogc(&z_resp);
             continue;
         }
 
@@ -645,7 +645,7 @@ PHP_REDIS_API int redis_subscribe_response(INTERNAL_FUNCTION_PARAMETERS,
 
         // If we have a return value free it
         zval_ptr_dtor(&z_ret);
-        zval_dtor(&z_resp);
+        zval_ptr_dtor_nogc(&z_resp);
     }
 
     RETVAL_TRUE;
@@ -657,7 +657,7 @@ error:
     zend_hash_destroy(subs);
     efree(subs);
 failure:
-    zval_dtor(&z_resp);
+    zval_ptr_dtor_nogc(&z_resp);
     RETVAL_FALSE;
     return FAILURE;
 }
@@ -689,8 +689,8 @@ PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
             (z_chan = zend_hash_index_find(Z_ARRVAL(z_resp), 1)) == NULL
         ) {
             efree(sctx);
-            zval_dtor(&z_resp);
-            zval_dtor(&z_ret);
+            zval_ptr_dtor_nogc(&z_resp);
+            zval_ptr_dtor_nogc(&z_ret);
             RETVAL_FALSE;
             return FAILURE;
         }
@@ -704,7 +704,7 @@ PHP_REDIS_API int redis_unsubscribe_response(INTERNAL_FUNCTION_PARAMETERS,
             add_assoc_bool_ex(&z_ret, Z_STRVAL_P(z_chan), Z_STRLEN_P(z_chan), 1);
         }
 
-        zval_dtor(&z_resp);
+        zval_ptr_dtor_nogc(&z_resp);
     }
 
     efree(sctx);
@@ -1584,7 +1584,7 @@ redis_read_lpos_response(zval *zdst, RedisSock *redis_sock, char reply_type,
 
         for (i = 0;  i < elements; ++i) {
             if (redis_sock_gets(redis_sock, inbuf, sizeof(inbuf), &len) < 0) {
-                zval_dtor(zdst);
+                zval_ptr_dtor_nogc(zdst);
                 return FAILURE;
             }
             add_next_index_long(zdst, atol(inbuf + 1));
@@ -1747,7 +1747,7 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
     }
 
     /* replace */
-    zval_dtor(z_tab);
+    zval_ptr_dtor_nogc(z_tab);
     ZVAL_ZVAL(z_tab, &z_ret, 0, 0);
 }
 
@@ -1763,7 +1763,7 @@ array_zip_values_recursive(zval *z_tab)
          zend_hash_move_forward(Z_ARRVAL_P(z_tab))
     ) {
         if ((zv = zend_hash_get_current_data(Z_ARRVAL_P(z_tab))) == NULL) {
-            zval_dtor(&z_ret);
+            zval_ptr_dtor_nogc(&z_ret);
             return FAILURE;
         }
         if (Z_TYPE_P(zv) == IS_STRING) {
@@ -1771,12 +1771,12 @@ array_zip_values_recursive(zval *z_tab)
             zend_hash_move_forward(Z_ARRVAL_P(z_tab));
             if ((zv = zend_hash_get_current_data(Z_ARRVAL_P(z_tab))) == NULL) {
                 zend_string_release(zkey);
-                zval_dtor(&z_ret);
+                zval_ptr_dtor_nogc(&z_ret);
                 return FAILURE;
             }
             if (Z_TYPE_P(zv) == IS_ARRAY && array_zip_values_recursive(zv) != SUCCESS) {
                 zend_string_release(zkey);
-                zval_dtor(&z_ret);
+                zval_ptr_dtor_nogc(&z_ret);
                 return FAILURE;
             }
             ZVAL_ZVAL(&z_sub, zv, 1, 0);
@@ -1784,14 +1784,14 @@ array_zip_values_recursive(zval *z_tab)
             zend_string_release(zkey);
         } else {
             if (Z_TYPE_P(zv) == IS_ARRAY && array_zip_values_recursive(zv) != SUCCESS) {
-                zval_dtor(&z_ret);
+                zval_ptr_dtor_nogc(&z_ret);
                 return FAILURE;
             }
             ZVAL_ZVAL(&z_sub, zv, 1, 0);
             add_next_index_zval(&z_ret, &z_sub);
         }
     }
-    zval_dtor(z_tab);
+    zval_ptr_dtor_nogc(z_tab);
     ZVAL_ZVAL(z_tab, &z_ret, 0, 0);
     return SUCCESS;
 }
@@ -1873,7 +1873,7 @@ redis_read_mpop_response(RedisSock *redis_sock, zval *zdst, int elements,
         int i;
         for (i = 0; i < elements; i++) {
             if (read_mbulk_header(redis_sock, &subele) < 0 || subele != 2) {
-                zval_dtor(&zele);
+                zval_ptr_dtor_nogc(&zele);
                 goto fail;
             }
             redis_mbulk_reply_loop(redis_sock, &zele, subele, UNSERIALIZE_KEYS);
@@ -1889,7 +1889,7 @@ redis_read_mpop_response(RedisSock *redis_sock, zval *zdst, int elements,
     return SUCCESS;
 
 fail:
-    zval_dtor(zdst);
+    zval_ptr_dtor_nogc(zdst);
     ZVAL_FALSE(zdst);
 
     return FAILURE;
@@ -1970,7 +1970,7 @@ redis_read_geosearch_response(zval *zdst, RedisSock *redis_sock,
         } ZEND_HASH_FOREACH_END();
 
         // Cleanup
-        zval_dtor(&z_multi_result);
+        zval_ptr_dtor_nogc(&z_multi_result);
     }
 
     return SUCCESS;
@@ -2050,7 +2050,7 @@ redis_hello_response(INTERNAL_FUNCTION_PARAMETERS,
     if (redis_read_multibulk_recursive(redis_sock, numElems, 0, &z_ret) != SUCCESS ||
         array_zip_values_recursive(&z_ret) != SUCCESS)
     {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         goto fail;
     }
 
@@ -2071,7 +2071,7 @@ redis_hello_response(INTERNAL_FUNCTION_PARAMETERS,
     zv = zend_hash_str_find(Z_ARRVAL(z_ret), ZEND_STRL("version"));
     redis_sock->hello.version = zv ? zval_get_string(zv) : ZSTR_EMPTY_ALLOC();
 
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
 
     if (ctx == PHPREDIS_CTX_PTR) {
         ZVAL_STR_COPY(&z_ret, redis_sock->hello.server);
@@ -2235,7 +2235,7 @@ redis_xrange_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     if (read_mbulk_header(redis_sock, &messages) < 0 ||
         redis_read_stream_messages(redis_sock, messages, &z_messages) < 0)
     {
-        zval_dtor(&z_messages);
+        zval_ptr_dtor_nogc(&z_messages);
         REDIS_RESPONSE_ERROR(redis_sock, z_tab);
         return -1;
     }
@@ -2275,7 +2275,7 @@ redis_read_stream_messages_multi(RedisSock *redis_sock, int count, zval *z_strea
     return 0;
 failure:
     efree(id);
-    zval_dtor(&z_messages);
+    zval_ptr_dtor_nogc(&z_messages);
     return -1;
 }
 
@@ -2301,7 +2301,7 @@ redis_xread_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return 0;
 
 cleanup:
-    zval_dtor(&z_rv);
+    zval_ptr_dtor_nogc(&z_rv);
 failure:
     REDIS_RESPONSE_ERROR(redis_sock, z_tab);
     return -1;
@@ -2408,8 +2408,8 @@ redis_read_xclaim_reply(RedisSock *redis_sock, int count, int is_xautoclaim, zva
     return 0;
 
 failure:
-    zval_dtor(&z_msgs);
-    zval_dtor(rv);
+    zval_ptr_dtor_nogc(&z_msgs);
+    zval_ptr_dtor_nogc(rv);
     if (id) efree(id);
 
     return -1;
@@ -2481,7 +2481,7 @@ redis_read_xinfo_response(RedisSock *redis_sock, zval *z_ret, int elements)
         case TYPE_MULTIBULK:
             array_init(&zv);
             if (redis_read_xinfo_response(redis_sock, &zv, li) != SUCCESS) {
-                zval_dtor(&zv);
+                zval_ptr_dtor_nogc(&zv);
                 goto failure;
             }
             if (key) {
@@ -2563,7 +2563,7 @@ redis_vinfo_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     array_init_size(&z_ret, count / 2);
 
     if (redis_read_vinfo_response(redis_sock, &z_ret, count) != SUCCESS) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         REDIS_RESPONSE_ERROR(redis_sock, z_tab);
         return FAILURE;
     }
@@ -2631,7 +2631,7 @@ redis_vemb_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     array_init_size(&z_ret, count);
 
     if (redis_read_vemb_response(redis_sock, &z_ret, count) != SUCCESS) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         REDIS_RESPONSE_ERROR(redis_sock, z_tab);
         return FAILURE;
     }
@@ -2693,7 +2693,7 @@ redis_vlinks_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     return SUCCESS;
 
 fail:
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
     REDIS_RESPONSE_ERROR(redis_sock, z_tab);
     return FAILURE;
 }
@@ -2768,7 +2768,7 @@ redis_xinfo_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             REDIS_RETURN_ZVAL(redis_sock, z_tab, z_ret);
             return SUCCESS;
         }
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
     }
 
     REDIS_RESPONSE_ERROR(redis_sock, z_tab);
@@ -2862,7 +2862,7 @@ int redis_acl_custom_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, 
 
         res = cb(redis_sock, &zret, len);
         if (res == FAILURE) {
-            zval_dtor(&zret);
+            zval_ptr_dtor_nogc(&zret);
             ZVAL_FALSE(&zret);
         }
     } else {

--- a/redis.c
+++ b/redis.c
@@ -2235,7 +2235,7 @@ PHP_METHOD(Redis, exec)
         redis_sock->mode &= ~MULTI;
         redis_sock->watching = 0;
         if (ret < 0) {
-            zval_dtor(&z_ret);
+            zval_ptr_dtor_nogc(&z_ret);
             ZVAL_FALSE(&z_ret);
         }
     }
@@ -2252,7 +2252,7 @@ PHP_METHOD(Redis, exec)
                 array_init(&z_ret);
                 if (redis_sock_read_multibulk_multi_reply_loop(
                     INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock, &z_ret) != SUCCESS) {
-                    zval_dtor(&z_ret);
+                    zval_ptr_dtor_nogc(&z_ret);
                     ZVAL_FALSE(&z_ret);
                 }
             }
@@ -3089,7 +3089,7 @@ generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, REDIS_SCAN_TYPE type) {
         /* Free our previous reply if we're back in the loop.  We know we are
          * if our return_value is an array */
         if (Z_TYPE_P(return_value) == IS_ARRAY) {
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(return_value);
             ZVAL_NULL(return_value);
         }
 

--- a/redis.c
+++ b/redis.c
@@ -1274,7 +1274,7 @@ PHP_METHOD(Redis, sPop)
     } else if (ZEND_NUM_ARGS() == 2) {
         REDIS_PROCESS_KW_CMD("SPOP", redis_key_long_cmd, redis_sock_read_multibulk_reply);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 
 }
@@ -1861,7 +1861,7 @@ PHP_METHOD(Redis, zPopMax)
     } else if (ZEND_NUM_ARGS() == 2) {
         REDIS_PROCESS_KW_CMD("ZPOPMAX", redis_key_long_cmd, redis_mbulk_reply_zipped_keys_dbl);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 }
 /* }}} */
@@ -1874,7 +1874,7 @@ PHP_METHOD(Redis, zPopMin)
     } else if (ZEND_NUM_ARGS() == 2) {
         REDIS_PROCESS_KW_CMD("ZPOPMIN", redis_key_long_cmd, redis_mbulk_reply_zipped_keys_dbl);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 }
 /* }}} */

--- a/redis_array.c
+++ b/redis_array.c
@@ -66,17 +66,17 @@ redis_array_free(RedisArray *ra)
 
     /* Redis objects */
     for(i = 0; i< ra->count; i++) {
-        zval_dtor(&ra->redis[i]);
+        zval_ptr_dtor_nogc(&ra->redis[i]);
         zend_string_release(ra->hosts[i]);
     }
     efree(ra->redis);
     efree(ra->hosts);
 
     /* delete hash function */
-    zval_dtor(&ra->z_fun);
+    zval_ptr_dtor_nogc(&ra->z_fun);
 
     /* Distributor */
-    zval_dtor(&ra->z_dist);
+    zval_ptr_dtor_nogc(&ra->z_dist);
 
     /* Hashing algorithm */
     if (ra->algorithm) zend_string_release(ra->algorithm);
@@ -215,8 +215,8 @@ PHP_METHOD(RedisArray, __construct)
     if (algorithm) zend_string_release(algorithm);
     if (user) zend_string_release(user);
     if (pass) zend_string_release(pass);
-    zval_dtor(&z_dist);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_dist);
+    zval_ptr_dtor_nogc(&z_fun);
 
 finish:
 
@@ -278,10 +278,10 @@ ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd,
     /* multi/exec */
     if(ra->z_multi_exec) {
         call_user_function(&redis_ce->function_table, ra->z_multi_exec, &z_fun, return_value, argc, z_callargs);
-        zval_dtor(return_value);
-        zval_dtor(&z_fun);
+        zval_ptr_dtor_nogc(return_value);
+        zval_ptr_dtor_nogc(&z_fun);
         for (i = 0; i < argc; ++i) {
-            zval_dtor(&z_callargs[i]);
+            zval_ptr_dtor_nogc(&z_callargs[i]);
         }
         efree(z_callargs);
         RETURN_ZVAL(getThis(), 1, 0);
@@ -296,7 +296,7 @@ ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd,
         ra_index_multi(redis_inst, MULTI);
         /* call using discarded temp value and extract exec results after. */
         call_user_function(&redis_ce->function_table, redis_inst, &z_fun, return_value, argc, z_callargs);
-        zval_dtor(return_value);
+        zval_ptr_dtor_nogc(return_value);
 
         /* add keys to index. */
         ra_index_key(key, key_len, redis_inst);
@@ -310,7 +310,7 @@ ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd,
             /* check if we have an error. */
             if (ra->prev && RA_CALL_FAILED(return_value, cmd)) { /* there was an error reading, try with prev ring. */
                 /* Free previous return value */
-                zval_dtor(return_value);
+                zval_ptr_dtor_nogc(return_value);
 
                 /* ERROR, FALLBACK TO PREVIOUS RING and forward a reference to the first redis instance we were looking at. */
                 ra_forward_call(INTERNAL_FUNCTION_PARAM_PASSTHRU, ra->prev, cmd, cmd_len, z_args, z_new_target ? z_new_target : redis_inst);
@@ -324,9 +324,9 @@ ra_forward_call(INTERNAL_FUNCTION_PARAMETERS, RedisArray *ra, const char *cmd,
     }
 
     /* cleanup */
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
     for (i = 0; i < argc; ++i) {
-        zval_dtor(&z_callargs[i]);
+        zval_ptr_dtor_nogc(&z_callargs[i]);
     }
     efree(z_callargs);
 }
@@ -544,7 +544,7 @@ multihost_distribute(INTERNAL_FUNCTION_PARAMETERS, const char *method_name)
 
     multihost_distribute_call(ra, return_value, &z_fun, 0, NULL);
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 static void
@@ -569,7 +569,7 @@ multihost_distribute_flush(INTERNAL_FUNCTION_PARAMETERS, const char *method_name
 
     multihost_distribute_call(ra, return_value, &z_fun, 1, z_args);
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 PHP_METHOD(RedisArray, info)
@@ -630,8 +630,8 @@ PHP_METHOD(RedisArray, keys)
 
     multihost_distribute_call(ra, return_value, &z_fun, 1, z_args);
 
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 PHP_METHOD(RedisArray, getOption)
@@ -657,7 +657,7 @@ PHP_METHOD(RedisArray, getOption)
 
     multihost_distribute_call(ra, return_value, &z_fun, 1, z_args);
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 PHP_METHOD(RedisArray, setOption)
@@ -686,8 +686,8 @@ PHP_METHOD(RedisArray, setOption)
 
     multihost_distribute_call(ra, return_value, &z_fun, 2, z_args);
 
-    zval_dtor(&z_args[1]);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_args[1]);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 PHP_METHOD(RedisArray, select)
@@ -713,7 +713,7 @@ PHP_METHOD(RedisArray, select)
 
     multihost_distribute_call(ra, return_value, &z_fun, 1, z_args);
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 }
 
 #define HANDLE_MULTI_EXEC(ra, cmd, cmdlen) do { \
@@ -733,7 +733,7 @@ PHP_METHOD(RedisArray, select)
         } \
         /* call */\
         ra_forward_call(INTERNAL_FUNCTION_PARAM_PASSTHRU, ra, cmd, cmdlen, &z_arg_array, NULL); \
-        zval_dtor(&z_arg_array); \
+        zval_ptr_dtor_nogc(&z_arg_array); \
         return; \
     } \
 } while(0)
@@ -826,13 +826,13 @@ PHP_METHOD(RedisArray, mget)
         call_user_function(&redis_ce->function_table, &ra->redis[n], &z_fun, &z_ret, 1, &z_arg);
 
         /* cleanup args array */
-        zval_dtor(&z_arg);
+        zval_ptr_dtor_nogc(&z_arg);
 
         /* Error out if we didn't get a proper response */
         if (Z_TYPE(z_ret) != IS_ARRAY) {
             /* cleanup */
-            zval_dtor(&z_ret);
-            zval_dtor(&z_tmp_array);
+            zval_ptr_dtor_nogc(&z_ret);
+            zval_ptr_dtor_nogc(&z_tmp_array);
             RETVAL_FALSE;
             goto cleanup;
         }
@@ -843,10 +843,10 @@ PHP_METHOD(RedisArray, mget)
             ZVAL_ZVAL(&z_arg, z_cur, 1, 0);
             add_index_zval(&z_tmp_array, i, &z_arg);
         }
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
     }
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 
     array_init(return_value);
     /* copy temp array in the right order to return_value */
@@ -858,7 +858,7 @@ PHP_METHOD(RedisArray, mget)
     }
 
     /* cleanup */
-    zval_dtor(&z_tmp_array);
+    zval_ptr_dtor_nogc(&z_tmp_array);
 cleanup:
     efree(argv);
     efree(pos);
@@ -955,7 +955,7 @@ PHP_METHOD(RedisArray, mset)
         }
 
         if(!found) {
-            zval_dtor(&z_argarray);
+            zval_ptr_dtor_nogc(&z_argarray);
             continue; /* don't run empty MSETs */
         }
 
@@ -968,11 +968,11 @@ PHP_METHOD(RedisArray, mset)
             call_user_function(&redis_ce->function_table, &ra->redis[n], &z_fun, &z_ret, 1, &z_argarray);
         }
 
-        zval_dtor(&z_argarray);
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_argarray);
+        zval_ptr_dtor_nogc(&z_ret);
     }
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 
     /* Free any keys that we needed to allocate memory for, because they weren't strings */
     for(i = 0; i < argc; i++) {
@@ -1028,7 +1028,7 @@ ra_generic_del(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
     /* init data structures */
     h_keys = Z_ARRVAL(z_keys);
     if ((argc = zend_hash_num_elements(h_keys)) == 0) {
-        if (free_zkeys) zval_dtor(&z_keys);
+        if (free_zkeys) zval_ptr_dtor_nogc(&z_keys);
         efree(z_args);
         RETURN_FALSE;
     }
@@ -1076,7 +1076,7 @@ ra_generic_del(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
         }
 
         if(!found) {    /* don't run empty DEL or UNLINK commands */
-            zval_dtor(&z_argarray);
+            zval_ptr_dtor_nogc(&z_argarray);
             continue;
         }
 
@@ -1090,11 +1090,11 @@ ra_generic_del(INTERNAL_FUNCTION_PARAMETERS, char *kw, int kw_len)
         }
         total += Z_LVAL(z_ret);    /* increment total */
 
-        zval_dtor(&z_argarray);
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_argarray);
+        zval_ptr_dtor_nogc(&z_ret);
     }
 
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 
     RETVAL_LONG(total);
 
@@ -1104,7 +1104,7 @@ cleanup:
     efree(argc_each);
 
     if(free_zkeys) {
-        zval_dtor(&z_keys);
+        zval_ptr_dtor_nogc(&z_keys);
     }
     efree(z_args);
 }
@@ -1148,7 +1148,7 @@ ra_generic_scan_cmd(INTERNAL_FUNCTION_PARAMETERS, const char *kw, int kw_len)
 
     ZVAL_STRINGL(&z_fun, kw, kw_len);
     call_user_function(&redis_ce->function_table, redis_inst, &z_fun, return_value, ZEND_NUM_ARGS(), z_args);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 
     ZVAL_ZVAL(z_cursor, &z_args[1], 0, 1);
 }
@@ -1194,7 +1194,7 @@ PHP_METHOD(RedisArray, scan)
 
     ZVAL_STRING(&z_fun, "SCAN");
     call_user_function(&redis_ce->function_table, redis_inst, &z_fun, return_value, ZEND_NUM_ARGS() - 1, z_args);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_fun);
 
     ZVAL_ZVAL(z_iter, &z_args[0], 0, 1);
 }

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -202,7 +202,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zval(Z_ARRVAL(z_tmp), name, name_len, &z_fun, 1, 0);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find distributor */
@@ -210,7 +210,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zval(Z_ARRVAL(z_tmp), name, name_len, &z_dist, 1, 0);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find hash algorithm */
@@ -218,7 +218,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_string(Z_ARRVAL(z_tmp), name, name_len, &algorithm);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find index option */
@@ -226,7 +226,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_index);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find autorehash option */
@@ -234,7 +234,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_autorehash);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find retry interval option */
@@ -242,7 +242,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_long(Z_ARRVAL(z_tmp), name, name_len, &l_retry_interval);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find pconnect option */
@@ -250,7 +250,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_pconnect);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find lazy connect option */
@@ -258,7 +258,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_lazy_connect);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find connect timeout option */
@@ -266,7 +266,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &d_connect_timeout);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find read timeout option */
@@ -274,7 +274,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &read_timeout);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find consistent option */
@@ -285,7 +285,7 @@ RedisArray *ra_load_array(const char *name) {
             consistent = Z_TYPE_P(z_data) == IS_STRING &&
                          redis_strncmp(Z_STRVAL_P(z_data), ZEND_STRL("1")) == 0;
         }
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* find auth option */
@@ -293,7 +293,7 @@ RedisArray *ra_load_array(const char *name) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_auth(Z_ARRVAL(z_tmp), name, name_len, &user, &pass);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* create RedisArray object */
@@ -309,10 +309,10 @@ RedisArray *ra_load_array(const char *name) {
     if (user) zend_string_release(user);
     if (pass) zend_string_release(pass);
 
-    zval_dtor(&z_params_hosts);
-    zval_dtor(&z_params_prev);
-    zval_dtor(&z_dist);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_params_hosts);
+    zval_ptr_dtor_nogc(&z_params_prev);
+    zval_ptr_dtor_nogc(&z_dist);
+    zval_ptr_dtor_nogc(&z_fun);
 
     return ra;
 }
@@ -385,7 +385,7 @@ ra_make_array(HashTable *hosts, zval *z_fun, zval *z_dist, HashTable *hosts_prev
 
     if (ra_load_hosts(ra, hosts, user, pass, retry_interval, b_lazy_connect) == NULL || !ra->count) {
         for (i = 0; i < ra->count; ++i) {
-            zval_dtor(&ra->redis[i]);
+            zval_ptr_dtor_nogc(&ra->redis[i]);
             zend_string_release(ra->hosts[i]);
         }
         efree(ra->redis);
@@ -435,8 +435,8 @@ ra_call_extractor(RedisArray *ra, const char *key, int key_len)
         out = zval_get_string(&z_ret);
     }
 
-    zval_dtor(&z_argv);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_argv);
+    zval_ptr_dtor_nogc(&z_ret);
     return out;
 }
 
@@ -474,8 +474,8 @@ ra_call_distributor(RedisArray *ra, const char *key, int key_len)
 
     ret = (Z_TYPE(z_ret) == IS_LONG) ? Z_LVAL(z_ret) : -1;
 
-    zval_dtor(&z_argv);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_argv);
+    zval_ptr_dtor_nogc(&z_ret);
     return ret;
 }
 
@@ -573,8 +573,8 @@ ra_index_multi(zval *z_redis, long multi_value) {
     ZVAL_STRINGL(&z_fun_multi, "MULTI", 5);
     ZVAL_LONG(&z_args[0], multi_value);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_multi, &z_ret, 1, z_args);
-    zval_dtor(&z_fun_multi);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_multi);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 static void
@@ -604,9 +604,9 @@ ra_index_change_keys(const char *cmd, zval *z_keys, zval *z_redis) {
     /* run cmd */
     call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, argc, z_args);
 
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_fun);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_fun);
+    zval_ptr_dtor_nogc(&z_ret);
     efree(z_args);      /* free container */
 }
 
@@ -643,7 +643,7 @@ ra_index_keys(zval *z_pairs, zval *z_redis) {
     ra_index_change_keys("SADD", &z_keys, z_redis);
 
     /* cleanup */
-    zval_dtor(&z_keys);
+    zval_ptr_dtor_nogc(&z_keys);
 }
 
 void
@@ -659,10 +659,10 @@ ra_index_key(const char *key, int key_len, zval *z_redis) {
 
     /* run SADD */
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_sadd, &z_ret, 2, z_args);
-    zval_dtor(&z_fun_sadd);
-    zval_dtor(&z_args[1]);
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_sadd);
+    zval_ptr_dtor_nogc(&z_args[1]);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 void
@@ -673,7 +673,7 @@ ra_index_exec(zval *z_redis, zval *return_value, int keep_all) {
     /* run EXEC */
     ZVAL_STRINGL(&z_fun_exec, "EXEC", 4);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_exec, &z_ret, 0, NULL);
-    zval_dtor(&z_fun_exec);
+    zval_ptr_dtor_nogc(&z_fun_exec);
 
     /* extract first element of exec array and put into return_value. */
     if(Z_TYPE(z_ret) == IS_ARRAY) {
@@ -686,7 +686,7 @@ ra_index_exec(zval *z_redis, zval *return_value, int keep_all) {
                 }
         }
     }
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* zval *zptr = &z_ret; */
     /* php_var_dump(&zptr, 0); */
@@ -701,8 +701,8 @@ ra_index_discard(zval *z_redis, zval *return_value) {
     ZVAL_STRINGL(&z_fun_discard, "DISCARD", 7);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_discard, &z_ret, 0, NULL);
 
-    zval_dtor(&z_fun_discard);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_discard);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 void
@@ -714,8 +714,8 @@ ra_index_unwatch(zval *z_redis, zval *return_value) {
     ZVAL_STRINGL(&z_fun_unwatch, "UNWATCH", 7);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_unwatch, &z_ret, 0, NULL);
 
-    zval_dtor(&z_fun_unwatch);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_unwatch);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 zend_bool
@@ -753,15 +753,15 @@ ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long 
     ZVAL_NULL(&z_ret);
     ZVAL_STRINGL(&z_fun, "TYPE", 4);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg);
-    zval_dtor(&z_fun);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* run TYPE */
     ZVAL_NULL(&z_ret);
     ZVAL_STRINGL(&z_fun, "TTL", 3);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_arg);
-    zval_dtor(&z_fun);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* Get the result from the pipeline. */
     ra_index_exec(z_from, &z_ret, 1);
@@ -775,8 +775,8 @@ ra_get_key_type(zval *z_redis, const char *key, int key_len, zval *z_from, long 
             res[i++] = Z_LVAL_P(z_data);
         } ZEND_HASH_FOREACH_END();
     }
-    zval_dtor(&z_arg);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_arg);
+    zval_ptr_dtor_nogc(&z_ret);
     return success;
 }
 
@@ -794,10 +794,10 @@ ra_remove_from_index(zval *z_redis, const char *key, int key_len) {
     call_user_function(&redis_ce->function_table, z_redis, &z_fun_srem, &z_ret, 2, z_args);
 
     /* cleanup */
-    zval_dtor(&z_fun_srem);
-    zval_dtor(&z_args[1]);
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_srem);
+    zval_ptr_dtor_nogc(&z_args[1]);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 
@@ -814,9 +814,9 @@ ra_del_key(const char *key, int key_len, zval *z_from) {
     ZVAL_STRINGL(&z_fun_del, "DEL", 3);
     ZVAL_STRINGL(&z_args[0], key, key_len);
     call_user_function(&redis_ce->function_table, z_from, &z_fun_del, &z_ret, 1, z_args);
-    zval_dtor(&z_fun_del);
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_del);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* remove key from index */
     ra_remove_from_index(z_from, key, key_len);
@@ -839,9 +839,9 @@ ra_expire_key(const char *key, int key_len, zval *z_to, long ttl) {
         ZVAL_STRINGL(&z_args[0], key, key_len);
         ZVAL_LONG(&z_args[1], ttl);
         call_user_function(&redis_ce->function_table, z_to, &z_fun_expire, &z_ret, 2, z_args);
-        zval_dtor(&z_fun_expire);
-        zval_dtor(&z_args[0]);
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_fun_expire);
+        zval_ptr_dtor_nogc(&z_args[0]);
+        zval_ptr_dtor_nogc(&z_ret);
     }
 
     return 1;
@@ -863,15 +863,15 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
     ZVAL_STRINGL(&z_args[2], "-1", 2);
     ZVAL_BOOL(&z_args[3], 1);
     call_user_function(&redis_ce->function_table, z_from, &z_fun_zrange, &z_ret, 4, z_args);
-    zval_dtor(&z_fun_zrange);
-    zval_dtor(&z_args[2]);
-    zval_dtor(&z_args[1]);
-    zval_dtor(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_fun_zrange);
+    zval_ptr_dtor_nogc(&z_args[2]);
+    zval_ptr_dtor_nogc(&z_args[1]);
+    zval_ptr_dtor_nogc(&z_args[0]);
 
 
     if(Z_TYPE(z_ret) != IS_ARRAY) { /* key not found or replaced */
         /* TODO: report? */
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         return 0;
     }
 
@@ -906,13 +906,13 @@ ra_move_zset(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
     ra_expire_key(key, key_len, z_to, ttl);
 
     /* cleanup */
-    zval_dtor(&z_fun_zadd);
-    zval_dtor(&z_ret_dest);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_zadd);
+    zval_ptr_dtor_nogc(&z_ret_dest);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* Free the array itself */
     for (i = 0; i < 1 + 2 * count; i++) {
-        zval_dtor(&z_zadd_args[i]);
+        zval_ptr_dtor_nogc(&z_zadd_args[i]);
     }
     efree(z_zadd_args);
 
@@ -928,12 +928,12 @@ ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl)
     ZVAL_STRINGL(&z_fun_get, "GET", 3);
     ZVAL_STRINGL(&z_args[0], key, key_len);
     call_user_function(&redis_ce->function_table, z_from, &z_fun_get, &z_ret, 1, z_args);
-    zval_dtor(&z_fun_get);
+    zval_ptr_dtor_nogc(&z_fun_get);
 
     if(Z_TYPE(z_ret) != IS_STRING) { /* key not found or replaced */
         /* TODO: report? */
-        zval_dtor(&z_args[0]);
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_args[0]);
+        zval_ptr_dtor_nogc(&z_ret);
         return 0;
     }
 
@@ -942,21 +942,21 @@ ra_move_string(const char *key, int key_len, zval *z_from, zval *z_to, long ttl)
         ZVAL_STRINGL(&z_fun_set, "SETEX", 5);
         ZVAL_LONG(&z_args[1], ttl);
         ZVAL_STRINGL(&z_args[2], Z_STRVAL(z_ret), Z_STRLEN(z_ret)); /* copy z_ret to arg 1 */
-        zval_dtor(&z_ret); /* free memory from our previous call */
+        zval_ptr_dtor_nogc(&z_ret); /* free memory from our previous call */
         call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 3, z_args);
         /* cleanup */
-        zval_dtor(&z_args[2]);
+        zval_ptr_dtor_nogc(&z_args[2]);
     } else {
         ZVAL_STRINGL(&z_fun_set, "SET", 3);
         ZVAL_STRINGL(&z_args[1], Z_STRVAL(z_ret), Z_STRLEN(z_ret)); /* copy z_ret to arg 1 */
-        zval_dtor(&z_ret); /* free memory from our previous return value */
+        zval_ptr_dtor_nogc(&z_ret); /* free memory from our previous return value */
         call_user_function(&redis_ce->function_table, z_to, &z_fun_set, &z_ret, 2, z_args);
         /* cleanup */
-        zval_dtor(&z_args[1]);
+        zval_ptr_dtor_nogc(&z_args[1]);
     }
-    zval_dtor(&z_fun_set);
-    zval_dtor(&z_args[0]);
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_fun_set);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_ret);
 
     return 1;
 }
@@ -969,27 +969,27 @@ ra_move_hash(const char *key, int key_len, zval *z_from, zval *z_to, long ttl) {
     ZVAL_STRINGL(&z_args[0], key, key_len);
     ZVAL_STRINGL(&z_fun_hgetall, "HGETALL", 7);
     call_user_function(&redis_ce->function_table, z_from, &z_fun_hgetall, &z_args[1], 1, z_args);
-    zval_dtor(&z_fun_hgetall);
+    zval_ptr_dtor_nogc(&z_fun_hgetall);
 
     if (Z_TYPE(z_args[1]) != IS_ARRAY) { /* key not found or replaced */
         /* TODO: report? */
-        zval_dtor(&z_args[1]);
-        zval_dtor(&z_args[0]);
+        zval_ptr_dtor_nogc(&z_args[1]);
+        zval_ptr_dtor_nogc(&z_args[0]);
         return 0;
     }
 
     /* run HMSET on target */
     ZVAL_STRINGL(&z_fun_hmset, "HMSET", 5);
     call_user_function(&redis_ce->function_table, z_to, &z_fun_hmset, &z_ret_dest, 2, z_args);
-    zval_dtor(&z_fun_hmset);
-    zval_dtor(&z_ret_dest);
+    zval_ptr_dtor_nogc(&z_fun_hmset);
+    zval_ptr_dtor_nogc(&z_ret_dest);
 
     /* Expire if needed */
     ra_expire_key(key, key_len, z_to, ttl);
 
     /* cleanup */
-    zval_dtor(&z_args[1]);
-    zval_dtor(&z_args[0]);
+    zval_ptr_dtor_nogc(&z_args[1]);
+    zval_ptr_dtor_nogc(&z_args[0]);
 
     return 1;
 }
@@ -1018,15 +1018,15 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
     call_user_function(&redis_ce->function_table, z_from, &z_fun_retrieve, &z_ret, list_count, z_retrieve_args);
 
     /* cleanup */
-    zval_dtor(&z_fun_retrieve);
+    zval_ptr_dtor_nogc(&z_fun_retrieve);
     for(i = 0; i < list_count; ++i) {
-        zval_dtor(&z_retrieve_args[i]);
+        zval_ptr_dtor_nogc(&z_retrieve_args[i]);
     }
     efree(z_retrieve_args);
 
     if(Z_TYPE(z_ret) != IS_ARRAY) { /* key not found or replaced */
         /* TODO: report? */
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         return 0;
     }
 
@@ -1045,19 +1045,19 @@ ra_move_collection(const char *key, int key_len, zval *z_from, zval *z_to,
     } ZEND_HASH_FOREACH_END();
 
     /* Clean up our input return value */
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
 
     call_user_function(&redis_ce->function_table, z_to, &z_fun_sadd, &z_ret, count, z_sadd_args);
 
     /* cleanup */
-    zval_dtor(&z_fun_sadd);
+    zval_ptr_dtor_nogc(&z_fun_sadd);
     for (i = 0; i < count; i++) {
-        zval_dtor(&z_sadd_args[i]);
+        zval_ptr_dtor_nogc(&z_sadd_args[i]);
     }
     efree(z_sadd_args);
 
     /* Clean up our output return value */
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
 
     /* Expire if needed */
     ra_expire_key(key, key_len, z_to, ttl);
@@ -1150,8 +1150,8 @@ zval_rehash_callback(zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cache,
     zend_call_function(z_cb, z_cb_cache);
 
     /* cleanup */
-    zval_dtor(&z_args[0]);
-    zval_dtor(z_ret);
+    zval_ptr_dtor_nogc(&z_args[0]);
+    zval_ptr_dtor_nogc(z_ret);
 }
 
 static void
@@ -1172,8 +1172,8 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
     }
     ZVAL_NULL(&z_ret);
     call_user_function(&redis_ce->function_table, z_redis, &z_fun, &z_ret, 1, &z_argv);
-    zval_dtor(&z_argv);
-    zval_dtor(&z_fun);
+    zval_ptr_dtor_nogc(&z_argv);
+    zval_ptr_dtor_nogc(&z_fun);
 
     if (Z_TYPE(z_ret) == IS_ARRAY) {
         h_keys = Z_ARRVAL(z_ret);
@@ -1181,7 +1181,7 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
     }
 
     if (!count) {
-        zval_dtor(&z_ret);
+        zval_ptr_dtor_nogc(&z_ret);
         return;
     }
 
@@ -1203,7 +1203,7 @@ ra_rehash_server(RedisArray *ra, zval *z_redis, zend_string *hostname, zend_bool
     } ZEND_HASH_FOREACH_END();
 
     /* cleanup */
-    zval_dtor(&z_ret);
+    zval_ptr_dtor_nogc(&z_ret);
 }
 
 void

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -293,7 +293,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_seeds), name, name_len)) != NULL) {
         ht_seeds = Z_ARRVAL_P(z_value);
     } else {
-        zval_dtor(&z_seeds);
+        zval_ptr_dtor_nogc(&z_seeds);
         CLUSTER_THROW_EXCEPTION("Couldn't find seeds for cluster", 0);
         return;
     }
@@ -303,7 +303,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &timeout);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* Read timeout */
@@ -311,7 +311,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &read_timeout);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* Persistent connections */
@@ -319,21 +319,21 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_bool(Z_ARRVAL(z_tmp), name, name_len, &persistent);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     if ((iptr = INI_STR("redis.clusters.auth"))) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_auth(Z_ARRVAL(z_tmp), name, name_len, &user, &pass);
-        zval_dtor(&z_tmp);
+        zval_ptr_dtor_nogc(&z_tmp);
     }
 
     /* Attempt to create/connect to the cluster */
     redis_cluster_init(c, ht_seeds, timeout, read_timeout, persistent, user, pass, NULL);
 
     /* Clean up */
-    zval_dtor(&z_seeds);
+    zval_ptr_dtor_nogc(&z_seeds);
     if (user) zend_string_release(user);
     if (pass) zend_string_release(pass);
 }
@@ -828,7 +828,7 @@ PHP_METHOD(RedisCluster, mget) {
     if (cluster_mkey_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, "MGET",
                         sizeof("MGET")-1, z_ret, cluster_mbulk_mget_resp) < 0)
     {
-        zval_dtor(z_ret);
+        zval_ptr_dtor_nogc(z_ret);
         efree(z_ret);
         RETURN_FALSE;
     }
@@ -859,7 +859,7 @@ PHP_METHOD(RedisCluster, msetnx) {
     if (cluster_mset_cmd(INTERNAL_FUNCTION_PARAM_PASSTHRU, "MSETNX",
                          sizeof("MSETNX")-1, z_ret, cluster_msetnx_resp) ==-1)
     {
-        zval_dtor(z_ret);
+        zval_ptr_dtor_nogc(z_ret);
         efree(z_ret);
         RETURN_FALSE;
     }
@@ -937,7 +937,7 @@ PHP_METHOD(RedisCluster, keys) {
         {
             php_error_docref(0, E_ERROR, "Can't send KEYS to %s:%d",
                 ZSTR_VAL(node->sock->host), node->sock->port);
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(return_value);
             efree(cmd);
             RETURN_FALSE;
         }
@@ -2525,7 +2525,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
     do {
         /* Free our return value if we're back in the loop */
         if (Z_TYPE_P(return_value) == IS_ARRAY) {
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(return_value);
             ZVAL_NULL(return_value);
         }
 
@@ -2697,7 +2697,7 @@ PHP_METHOD(RedisCluster, scan) {
     do {
         /* Free our return value if we're back in the loop */
         if (Z_TYPE_P(return_value) == IS_ARRAY) {
-            zval_dtor(return_value);
+            zval_ptr_dtor_nogc(return_value);
             ZVAL_NULL(return_value);
         }
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2595,7 +2595,7 @@ PHP_METHOD(RedisCluster, acl) {
 
     /* ACL in cluster needs a slot argument, and then at least the op */
     if (argc < 2) {
-        WRONG_PARAM_COUNT;
+        zend_wrong_param_count();
         RETURN_FALSE;
     }
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1005,7 +1005,7 @@ PHP_METHOD(RedisCluster, spop) {
     } else if (ZEND_NUM_ARGS() == 2) {
         CLUSTER_PROCESS_KW_CMD("SPOP", redis_key_long_cmd, cluster_mbulk_resp, 0);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 }
 /* }}} */
@@ -1765,7 +1765,7 @@ PHP_METHOD(RedisCluster, zpopmax) {
     } else if (ZEND_NUM_ARGS() == 2) {
         CLUSTER_PROCESS_KW_CMD("ZPOPMAX", redis_key_long_cmd, cluster_mbulk_zipdbl_resp, 0);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 }
 /* }}} */
@@ -1777,7 +1777,7 @@ PHP_METHOD(RedisCluster, zpopmin) {
     } else if (ZEND_NUM_ARGS() == 2) {
         CLUSTER_PROCESS_KW_CMD("ZPOPMIN", redis_key_long_cmd, cluster_mbulk_zipdbl_resp, 0);
     } else {
-        ZEND_WRONG_PARAM_COUNT();
+        zend_wrong_param_count();
     }
 }
 /* }}} */

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -531,7 +531,7 @@ redis_failover_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 } else if (zend_string_equals_literal_ci(zkey, "port")) {
                     port = zval_get_long(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "force")) {
-                    force = zval_is_true(z_ele);
+                    force = zend_is_true(z_ele);
                 }
             }
         } ZEND_HASH_FOREACH_END();
@@ -677,7 +677,7 @@ void redis_get_zcmd_options(redisZcmdOptions *dst, zval *src, int flags) {
 
         if (key) {
             if ((flags & REDIS_ZCMD_HAS_WITHSCORES) && zend_string_equals_literal_ci(key, "WITHSCORES"))
-                dst->withscores = zval_is_true(zv);
+                dst->withscores = zend_is_true(zv);
             else if ((flags & REDIS_ZCMD_HAS_LIMIT) && zend_string_equals_literal_ci(key, "LIMIT") &&
                      Z_TYPE_P(zv) == IS_ARRAY)
             {
@@ -1165,7 +1165,7 @@ redis_zrandmember_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 if (zend_string_equals_literal_ci(zkey, "count")) {
                     count = zval_get_long(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "withscores")) {
-                    withscores = zval_is_true(z_ele);
+                    withscores = zend_is_true(z_ele);
                 }
             }
         } ZEND_HASH_FOREACH_END();
@@ -2421,7 +2421,7 @@ static void fill_set_options_ht(redisSetOptions *dst, HashTable *ht) {
             } else if (zstr_to_eq_type(&dst->eq.type, key)) {
                 dst->eq.zval = zv;
             } else if (zend_string_equals_literal_ci(key, "GET")) {
-                dst->get = zval_is_true(zv);
+                dst->get = zend_is_true(zv);
             }
         } else if (Z_TYPE_P(zv) == IS_STRING) {
             key = Z_STR_P(zv);
@@ -2693,13 +2693,13 @@ redis_getex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     expire = zval_get_long(z_ele);
                     persist = 0;
                 } else if (ZSTR_STRICMP_STATIC(zkey, "PERSIST")) {
-                    persist = zval_is_true(z_ele);
+                    persist = zend_is_true(z_ele);
                     exp_type = NULL;
                 }
             } else if (Z_TYPE_P(z_ele) == IS_STRING &&
                        zend_string_equals_literal_ci(Z_STR_P(z_ele), "PERSIST"))
             {
-                persist = zval_is_true(z_ele);
+                persist = zend_is_true(z_ele);
                 exp_type = NULL;
             }
         } ZEND_HASH_FOREACH_END();
@@ -3126,14 +3126,14 @@ static void redis_get_lcs_options(redisLcsOptions *dst, HashTable *ht) {
         if (key) {
             if (zend_string_equals_literal_ci(key, "LEN")) {
                 dst->idx = 0;
-                dst->len = zval_is_true(zv);
+                dst->len = zend_is_true(zv);
             } else if (zend_string_equals_literal_ci(key, "IDX")) {
                 dst->len = 0;
-                dst->idx = zval_is_true(zv);
+                dst->idx = zend_is_true(zv);
             } else if (zend_string_equals_literal_ci(key, "MINMATCHLEN")) {
                 dst->minmatchlen = zval_get_long(zv);
             } else if (zend_string_equals_literal_ci(key, "WITHMATCHLEN")) {
-                dst->withmatchlen = zval_is_true(zv);
+                dst->withmatchlen = zend_is_true(zv);
             } else {
                 php_error_docref(NULL, E_WARNING, "Unknown LCS option '%s'", ZSTR_VAL(key));
             }
@@ -3922,7 +3922,7 @@ redis_hrandfield_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                 if (zend_string_equals_literal_ci(zkey, "count")) {
                     count = zval_get_long(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "withvalues")) {
-                    withvalues = zval_is_true(z_ele);
+                    withvalues = zend_is_true(z_ele);
                 }
             } else if (Z_TYPE_P(z_ele) == IS_STRING) {
                 if (zend_string_equals_literal_ci(Z_STR_P(z_ele), "WITHVALUES")) {
@@ -4158,7 +4158,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
     // ALPHA
     if (((z_ele = zend_hash_str_find(ht_opts, "alpha", sizeof("alpha") - 1)) != NULL ||
          (z_ele = zend_hash_str_find(ht_opts, "ALPHA", sizeof("ALPHA") - 1)) != NULL) &&
-         zval_is_true(z_ele)
+         zend_is_true(z_ele)
     ) {
         add_next_index_stringl(&z_argv, "ALPHA", sizeof("ALPHA") - 1);
     }
@@ -4499,7 +4499,7 @@ static int get_georadius_count_options(zval *optval, geoOptions *opts) {
 
         z_tmp = zend_hash_index_find(Z_ARRVAL_P(optval), 1);
         if (z_tmp) {
-            opts->any = zval_is_true(z_tmp);
+            opts->any = zend_is_true(z_tmp);
         }
     } else {
         if (Z_LVAL_P(optval) <= 0)
@@ -5665,13 +5665,13 @@ redis_build_client_tracking_command(smart_string *cmdstr, int argc, zval *z_args
                     }
                     prefix = z_ele;
                 } else if (zend_string_equals_literal_ci(zkey, "bcast")) {
-                    bcast = zval_is_true(z_ele);
+                    bcast = zend_is_true(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "optin")) {
-                    optin = zval_is_true(z_ele);
+                    optin = zend_is_true(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "optout")) {
-                    optout = zval_is_true(z_ele);
+                    optout = zend_is_true(z_ele);
                 } else if (zend_string_equals_literal_ci(zkey, "noloop")) {
-                    noloop = zval_is_true(z_ele);
+                    noloop = zend_is_true(z_ele);
                 }
             }
         } ZEND_HASH_FOREACH_END();
@@ -5685,7 +5685,7 @@ redis_build_client_tracking_command(smart_string *cmdstr, int argc, zval *z_args
         ZVAL_STRICMP_STATIC(&z_args[0], "off")
     )) {
         redis_cmd_append_sstr(cmdstr, Z_STRVAL(z_args[0]), Z_STRLEN(z_args[0]));
-    } else if (zval_is_true(&z_args[0])) {
+    } else if (zend_is_true(&z_args[0])) {
         REDIS_CMD_APPEND_SSTR_STATIC(cmdstr, "ON");
     } else {
         REDIS_CMD_APPEND_SSTR_STATIC(cmdstr, "OFF");
@@ -5760,7 +5760,7 @@ redis_client_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             ZVAL_STRICMP_STATIC(&z_args[0], "no")
         )) {
             redis_cmd_append_sstr(&cmdstr, Z_STRVAL(z_args[0]), Z_STRLEN(z_args[0]));
-        } else if (zval_is_true(&z_args[0])) {
+        } else if (zend_is_true(&z_args[0])) {
             REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "YES");
         } else {
             REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "NO");
@@ -5790,7 +5790,7 @@ redis_client_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             ZVAL_STRICMP_STATIC(&z_args[0], "off")
         )) {
             redis_cmd_append_sstr(&cmdstr, Z_STRVAL(z_args[0]), Z_STRLEN(z_args[0]));
-        } else if (zval_is_true(&z_args[0])) {
+        } else if (zend_is_true(&z_args[0])) {
             REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "ON");
         } else {
             REDIS_CMD_APPEND_SSTR_STATIC(&cmdstr, "OFF");
@@ -5964,7 +5964,7 @@ redis_copy_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             if (zend_string_equals_literal_ci(zkey, "db")) {
                 db = zval_get_long(zv);
             } else if (zend_string_equals_literal_ci(zkey, "replace")) {
-                replace = zval_is_true(zv);
+                replace = zend_is_true(zv);
             }
         } ZEND_HASH_FOREACH_END();
     }
@@ -7023,9 +7023,9 @@ static void parse_vadd_options(redisVAddOptions *dst, HashTable *ht) {
                 if (validate_vadd_integer(key, zv, 1))
                     dst->ef = Z_LVAL_P(zv);
             } else if (zend_string_equals_literal_ci(key, "CAS")) {
-                dst->cas = zval_is_true(zv);
+                dst->cas = zend_is_true(zv);
             } else if (zend_string_equals_literal_ci(key, "VALUES")) {
-                dst->values = zval_is_true(zv);
+                dst->values = zend_is_true(zv);
             } else if (zend_string_equals_literal_ci(key, "SETATTR")) {
                 dst->attributes = zval_to_vattr(zv);
             }
@@ -7220,7 +7220,7 @@ static void parse_vsim_options(redisVSimOptions *dst, HashTable *ht) {
                 if (validate_vadd_integer(key, zv, 1))
                     dst->count = Z_LVAL_P(zv);
             } else if (zend_string_equals_literal_ci(key, "WITHSCORES")) {
-                dst->withscores = zval_is_true(zv);
+                dst->withscores = zend_is_true(zv);
             }
         } else if (Z_TYPE_P(zv) == IS_STRING) {
             if (zend_string_equals_literal_ci(Z_STR_P(zv), "FP32")) {
@@ -7587,7 +7587,7 @@ void redis_setoption_handler(INTERNAL_FUNCTION_PARAMETERS,
             }
             break;
         case REDIS_OPT_PACK_IGNORE_NUMBERS:
-            redis_sock->pack_ignore_numbers = zval_is_true(val);
+            redis_sock->pack_ignore_numbers = zend_is_true(val);
             RETURN_TRUE;
         case REDIS_OPT_COMPRESSION_LEVEL:
             val_long = zval_get_long(val);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4069,7 +4069,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         if (slot) {
             php_error_docref(NULL, E_WARNING,
                 "SORT BY option is not allowed in Redis Cluster");
-            zval_dtor(&z_argv);
+            zval_ptr_dtor_nogc(&z_argv);
             return FAILURE;
         }
 
@@ -4099,7 +4099,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         if (cross_slot) {
             php_error_docref(0, E_WARNING,
                 "Error, SORT key and STORE key have different slots!");
-            zval_dtor(&z_argv);
+            zval_ptr_dtor_nogc(&z_argv);
             return FAILURE;
         }
 
@@ -4120,7 +4120,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         if (slot) {
             php_error_docref(NULL, E_WARNING,
                 "GET option for SORT disabled in Redis Cluster");
-            zval_dtor(&z_argv);
+            zval_ptr_dtor_nogc(&z_argv);
             return FAILURE;
         }
 
@@ -4149,7 +4149,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             if (added == 0) {
                 php_error_docref(NULL, E_WARNING,
                     "Array of GET values requested, but none are valid");
-                zval_dtor(&z_argv);
+                zval_ptr_dtor_nogc(&z_argv);
                 return FAILURE;
             }
         }
@@ -4179,7 +4179,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
             ) {
                 php_error_docref(NULL, E_WARNING,
                     "LIMIT options on SORT command must be longs or strings");
-                zval_dtor(&z_argv);
+                zval_ptr_dtor_nogc(&z_argv);
                 return FAILURE;
             }
 
@@ -4221,7 +4221,7 @@ int redis_sort_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
     /* Clean up our arguments array.  Note we don't have to free any prefixed
      * key as that we didn't duplicate the pointer if we prefixed */
-    zval_dtor(&z_argv);
+    zval_ptr_dtor_nogc(&z_argv);
 
     // Push our length and command
     *cmd_len = cmdstr.len;

--- a/redis_session.c
+++ b/redis_session.c
@@ -523,7 +523,7 @@ PS_OPEN_FUNC(redis)
                     ZVAL_ZVAL(&context, zv, 1, 0);
                 }
 
-                zval_dtor(&params);
+                zval_ptr_dtor_nogc(&params);
             }
 
             if ((url->path == NULL && url->host == NULL) || weight <= 0 || timeout <= 0) {
@@ -992,7 +992,7 @@ PS_OPEN_FUNC(rediscluster) {
     /* We need seeds */
     zv = REDIS_HASH_STR_FIND_TYPE_STATIC(Z_ARRVAL(z_conf), "seed", IS_ARRAY);
     if (zv == NULL) {
-        zval_dtor(&z_conf);
+        zval_ptr_dtor_nogc(&z_conf);
         return FAILURE;
     }
 
@@ -1009,7 +1009,7 @@ PS_OPEN_FUNC(rediscluster) {
     if (timeout < 0 || read_timeout < 0) {
         php_error_docref(NULL, E_WARNING,
             "Can't set negative timeout values in session configuration");
-        zval_dtor(&z_conf);
+        zval_ptr_dtor_nogc(&z_conf);
         return FAILURE;
     }
 
@@ -1037,7 +1037,7 @@ PS_OPEN_FUNC(rediscluster) {
         if (user) zend_string_release(user); \
         if (pass) zend_string_release(pass); \
         free_seed_array(seeds, nseeds); \
-        zval_dtor(&z_conf); \
+        zval_ptr_dtor_nogc(&z_conf); \
 
     /* Extract at least one valid seed or abort */
     seeds = cluster_validate_args(timeout, read_timeout, ht_seeds, &nseeds, NULL);


### PR DESCRIPTION
PHP 8.6 development branch removes some legacy macros/aliases.
This PR fixes the build, and will still work on older PHP versions as well.
The only change that may need more attention is the one for zval_dtor(), although the code is now equivalent I find it surprising how much zval_dtor() was used instead of zval_ptr_dtor(): the former is equivalent to zval_ptr_dtor_nogc() and won't add the zval for the cycle collector while the latter does. It might be fine, just pointing out...