### PR TITLE
Fix zipping non-string keys

### DIFF
--- a/library.c
+++ b/library.c
@@ -1706,8 +1706,9 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
                                         int decode)
 {
 
-    zval z_ret, z_sub;
     HashTable *keytable = Z_ARRVAL_P(z_tab);
+    zend_string *hkey, *tmp;
+    zval z_ret, z_sub;
 
     array_init_size(&z_ret, zend_hash_num_elements(keytable) / 2);
 
@@ -1722,13 +1723,14 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
         }
 
         /* get current value, a key */
-        zend_string *hkey = Z_STR_P(z_key_p);
+        hkey = zval_get_tmp_string(z_key_p, &tmp);
 
         /* move forward */
         zend_hash_move_forward(keytable);
 
         /* fetch again */
         if ((z_value_p = zend_hash_get_current_data(keytable)) == NULL) {
+            zend_tmp_string_release(tmp);
             continue;   /* this should never happen, according to the PHP people. */
         }
 
@@ -1743,7 +1745,10 @@ static void array_zip_values_and_scores(RedisSock *redis_sock, zval *z_tab,
         } else {
             ZVAL_ZVAL(&z_sub, z_value_p, 1, 0);
         }
+
         zend_symtable_update(Z_ARRVAL_P(&z_ret), hkey, &z_sub);
+
+        zend_tmp_string_release(tmp);
     }
 
     /* replace */

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -3074,6 +3074,23 @@ class Redis_Test extends TestSuite {
         $this->assertEquals(0, $this->redis->zRevRank('z', 'five'));
     }
 
+    /* Regression for GitHub issue #2791 */
+    public function testZSetSerialization() {
+        $this->redis->del('zs_f', 'zs_a');
+        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+
+        $this->redis->zAdd('zs_f', 3.14, 3.14);
+        $this->redis->zAdd('zs_a', 1, ['foo', 'bar']);
+
+        $res_float = $this->redis->zRange('zs_f', 0, -1, true);
+        $this->assertEquals(['3.14' => 3.14], $res_float);
+
+        $res_array = @$this->redis->zRange('zs_a', 0, -1, true);
+        $this->assertEquals(['Array' => 1.0], $res_array);
+
+        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+    }
+
     public function testZRangeScoreArg() {
         $this->redis->del('{z}');
 


### PR DESCRIPTION
In `array_zip_values_and_scores` we were blindly calling `Z_STR_P` on the `zval` assuming it must be a string.

This isn't the case however if the user did something like this:

```php
$redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
$redis->zAdd('zs', 3.14, ['pi', 'is', 'cool']);

// segfault when we try to get `Z_STR_P` from `['pi', 'is', 'cool']`
$redis->zRange('zs', 0, -1, true);
```

Potential fix for #2791

Windows tests are failing because of a bug in the GitHub action. They'll fail until a PR is merged.