### PR TITLE
Minor `DELEX` refactor

### DIFF
--- a/redis_commands.c
+++ b/redis_commands.c
@@ -2822,14 +2822,6 @@ int redis_decr_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
         TYPE_DECR, redis_sock, cmd, cmd_len, slot, ctx);
 }
 
-typedef enum delExType {
-    REDIS_DELEX_NONE,
-    REDIS_DELEX_IFEQ,
-    REDIS_DELEX_IFNE,
-    REDIS_DELEX_IFDEQ,
-    REDIS_DELEX_IFDNE
-} delExType;
-
 typedef enum xdelExMode {
     REDIS_XDELEX_NONE,
     REDIS_XDELEX_KEEPREF,
@@ -2837,33 +2829,14 @@ typedef enum xdelExMode {
     REDIS_XDELEX_ACKED,
 } xdelExMode;
 
-static zend_bool stringToDelExType(delExType *dst, zend_string *src) {
-    *dst = REDIS_DELEX_NONE;
-
-    if (zend_string_equals_literal_ci(src, "IFEQ")) {
-        *dst = REDIS_DELEX_IFEQ;
-    } else if (zend_string_equals_literal_ci(src, "IFNE")) {
-        *dst = REDIS_DELEX_IFNE;
-    } else if (zend_string_equals_literal_ci(src, "IFDEQ")) {
-        *dst = REDIS_DELEX_IFDEQ;
-    } else if (zend_string_equals_literal_ci(src, "IFDNE")) {
-        *dst = REDIS_DELEX_IFDNE;
-    } else {
-        return 0;
-    }
-
-    return 1;
-}
-
 int redis_delex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
                     char **cmd, int *cmd_len, short *slot, void **ctx)
 {
-    delExType type = REDIS_DELEX_NONE;
+    redisEqType type = REDIS_IF_NONE;
     smart_string cmdstr = {0};
-    zend_string *key, *ztype;;
+    zend_string *key, *ztype;
     HashTable *ht = NULL;
     zval *zv = NULL;
-    zend_bool pack;
 
     ZEND_PARSE_PARAMETERS_START(1, 2)
         Z_PARAM_STR(key)
@@ -2878,21 +2851,17 @@ int redis_delex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
             ZVAL_DEREF(zv);
 
-            if (stringToDelExType(&type, ztype))
+            if (zstr_to_eq_type(&type, ztype))
                 break;
 
             php_error_docref(NULL, E_WARNING, "Unknown option '%s'", ZSTR_VAL(ztype));
         } ZEND_HASH_FOREACH_END();
     }
 
-    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, type != REDIS_DELEX_NONE ? 3 : 1, "DELEX");
-    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+    REDIS_CMD_INIT_SSTR_STATIC(&cmdstr, type != REDIS_IF_NONE ? 3 : 1, "DELEX");
 
-    if (type != REDIS_DELEX_NONE) {
-        redis_cmd_append_sstr_zstr(&cmdstr, ztype);
-        pack = type == REDIS_DELEX_IFEQ || type == REDIS_DELEX_IFNE;
-        redis_cmd_append_sstr_zval(&cmdstr, zv, pack ? redis_sock : NULL);
-    }
+    redis_cmd_append_sstr_key_zstr(&cmdstr, key, redis_sock, slot);
+    redis_cmd_append_eq_clause(&cmdstr, redis_sock, type, zv);
 
     *cmd = cmdstr.c;
     *cmd_len = cmdstr.len;


### PR DESCRIPTION
We had a `delExType` enum which was later made redundant by `redisEqType` as they have the same semantics.

This commit just removes `delExType` and uses the new enum.