### PR TITLE
Rework TLS context logic

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -656,8 +656,7 @@ cluster_node_create(redisCluster *c, char *host, size_t host_len,
                                    c->flags->timeout, c->flags->read_timeout,
                                    c->flags->persistent, NULL, 0);
 
-    /* Stream context */
-    node->sock->stream_ctx = c->flags->stream_ctx;
+    redis_sock_set_context(node->sock, c->flags->context);
 
     redis_sock_set_auth(node->sock, c->flags->user, c->flags->pass);
 
@@ -872,6 +871,8 @@ cluster_free(redisCluster *c, int free_ctx)
     if (c->flags->prefix) zend_string_release(c->flags->prefix);
 
     redis_sock_free_auth(c->flags);
+    redis_sock_free_context(c->flags);
+
     efree(c->flags);
 
     /* Call hash table destructors */
@@ -1019,7 +1020,7 @@ void cluster_init_cache(redisCluster *c, redisCachedCluster *cc) {
                                  NULL, 0);
 
         /* Stream context */
-        sock->stream_ctx = c->flags->stream_ctx;
+        redis_sock_set_context(sock, c->flags->context);
 
         /* Add to seed nodes */
         zend_hash_str_update_ptr(c->seeds, key, keylen, sock);
@@ -1074,11 +1075,9 @@ cluster_init_seeds(redisCluster *c, zend_string **seeds, uint32_t nseeds)
                                  c->flags->timeout, c->flags->read_timeout,
                                  c->flags->persistent, NULL, 0);
 
-        /* Stream context */
-        sock->stream_ctx = c->flags->stream_ctx;
-
-        /* Credentials */
+        /* Credentials and context */
         redis_sock_set_auth(sock, c->flags->user, c->flags->pass);
+        redis_sock_set_context(sock, c->flags->context);
 
         // Index this seed by host/port
         key_len = snprintf(key, sizeof(key), "%s:%u", ZSTR_VAL(sock->host),

--- a/common.h
+++ b/common.h
@@ -261,11 +261,11 @@ typedef struct RedisHello {
 /* {{{ struct RedisSock */
 typedef struct {
     php_stream          *stream;
-    php_stream_context  *stream_ctx;
     zend_string         *host;
     int                 port;
     zend_string         *user;
     zend_string         *pass;
+    HashTable           *context;
     double              timeout;
     double              read_timeout;
     long                retry_interval;

--- a/library.c
+++ b/library.c
@@ -223,7 +223,6 @@ redis_sock_set_auth(RedisSock *redis_sock, zend_string *user, zend_string *pass)
     redis_sock->pass = pass ? zend_string_copy(pass) : NULL;
 }
 
-
 PHP_REDIS_API void
 redis_sock_set_auth_zval(RedisSock *redis_sock, zval *zv) {
     zend_string *user, *pass;
@@ -248,6 +247,31 @@ redis_sock_free_auth(RedisSock *redis_sock) {
         zend_string_release(redis_sock->pass);
         redis_sock->pass = NULL;
     }
+}
+
+#if PHP_VERSION_ID < 80000
+static void relay_array_release(HashTable *ht) {
+    if (!ht || (GC_FLAGS(ht) & GC_IMMUTABLE)) {
+        return;
+    }
+
+    if (GC_DELREF(ht) == 0) {
+        zend_array_destroy(ht);
+    }
+}
+#else
+static inline void relay_array_release(HashTable *ht) {
+    zend_array_release(ht);
+}
+#endif
+
+
+void redis_sock_free_context(RedisSock *redis_sock) {
+    if (redis_sock->context == NULL)
+        return;
+
+    relay_array_release(redis_sock->context);
+    redis_sock->context = NULL;
 }
 
 PHP_REDIS_API char *
@@ -3075,7 +3099,7 @@ redis_sock_configure(RedisSock *redis_sock, HashTable *opts)
             }
             redis_sock->retry_interval = zval_get_long(val);
         } else if (zend_string_equals_literal_ci(zkey, "ssl")) {
-            if (redis_sock_set_stream_context(redis_sock, val) != SUCCESS) {
+            if (redis_sock_set_context_zval(redis_sock, val) != SUCCESS) {
                 REDIS_VALUE_EXCEPTION("Invalid SSL context options");
                 return FAILURE;
             }
@@ -3332,6 +3356,26 @@ failure:
     return FAILURE;
 }
 
+static php_stream_context *
+alloc_stream_context(RedisSock *redis_sock) {
+    php_stream_context *ctx;
+    zend_string *zkey;
+    zval *z_ele;
+
+    if (redis_sock->context == NULL)
+        return NULL;
+
+    ctx = php_stream_context_alloc();
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(redis_sock->context, zkey, z_ele) {
+        if (zkey != NULL) {
+            php_stream_context_set_option(ctx, "ssl", ZSTR_VAL(zkey), z_ele);
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    return ctx;
+}
+
 /**
  * redis_sock_connect
  */
@@ -3343,6 +3387,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
     const char *fmtstr = "%s://%s:%d";
     int host_len, usocket = 0, err = 0, tcp_flag = 1;
     ConnectionPool *p = NULL;
+    php_stream_context *ctx;
 
     // Monotonically incrementing persistent id counter
     static unsigned long long counter = 0;
@@ -3353,7 +3398,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
 
     address = ZSTR_VAL(redis_sock->host);
     if ((pos = strstr(address, "://")) == NULL) {
-        strcpy(scheme, redis_sock->stream_ctx ? "ssl" : "tcp");
+        strcpy(scheme, redis_sock->context ? "ssl" : "tcp");
     } else {
         snprintf(scheme, sizeof(scheme), "%.*s", (int)(pos - address), address);
         address = pos + sizeof("://") - 1;
@@ -3413,10 +3458,22 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
         tv_ptr = &tv;
     }
 
+    ctx = alloc_stream_context(redis_sock);
+
     redis_sock->stream = php_stream_xport_create(host, host_len,
         0, STREAM_XPORT_CLIENT | STREAM_XPORT_CONNECT,
         persistent_id ? ZSTR_VAL(persistent_id) : NULL,
-        tv_ptr, redis_sock->stream_ctx, &estr, &err);
+        tv_ptr, ctx, &estr, &err);
+
+    /* On successful connection, the context is moved into the stream so we
+     * can disown it. If the connection failed, clean it up ourselves. */
+    if (ctx && redis_sock->stream) {
+        ZEND_ASSERT(GC_REFCOUNT(ctx->res) == 2);
+        GC_DELREF(ctx->res);
+    } else if (ctx) {
+        ZEND_ASSERT(GC_REFCOUNT(ctx->res) == 1);
+        zend_list_delete(ctx->res);
+    }
 
     if (persistent_id) {
         zend_string_release(persistent_id);
@@ -3546,25 +3603,33 @@ redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len)
     }
 }
 
-PHP_REDIS_API int
-redis_sock_set_stream_context(RedisSock *redis_sock, zval *options)
-{
-    zend_string *zkey;
-    zval *z_ele;
+#if PHP_VERSION_ID < 80000
+#define GC_TRY_ADDREF(ht) do { \
+    if (ht && !(GC_FLAGS(ht) & GC_IMMUTABLE)) { \
+        GC_ADDREF(ht); \
+    } \
+} while(0)
+#endif
 
-    if (!redis_sock || Z_TYPE_P(options) != IS_ARRAY)
-        return FAILURE;
 
-    if (!redis_sock->stream_ctx)
-        redis_sock->stream_ctx = php_stream_context_alloc();
+void redis_sock_set_context(RedisSock *redis_sock, HashTable *ht) {
+    redis_sock_free_context(redis_sock);
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(options), zkey, z_ele) {
-        if (zkey != NULL) {
-            php_stream_context_set_option(redis_sock->stream_ctx, "ssl", ZSTR_VAL(zkey), z_ele);
-        }
-    } ZEND_HASH_FOREACH_END();
+    if (ht == NULL)
+        return;
 
-    return SUCCESS;
+    GC_TRY_ADDREF(ht);
+    redis_sock->context = ht;
+}
+
+int redis_sock_set_context_zval(RedisSock *redis_sock, zval *zv) {
+    HashTable *ht;
+
+    ht = zv && Z_TYPE_P(zv) == IS_ARRAY ? Z_ARRVAL_P(zv) : NULL;
+
+    redis_sock_set_context(redis_sock, ht);
+
+    return ht ? SUCCESS : FAILURE;
 }
 
 PHP_REDIS_API int
@@ -3903,6 +3968,8 @@ PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock)
     redis_sock_free_auth(redis_sock);
     redis_free_reply_callbacks(redis_sock);
     redis_sock_release_hello(&redis_sock->hello);
+    redis_sock_free_context(redis_sock);
+
     efree(redis_sock);
 }
 

--- a/library.h
+++ b/library.h
@@ -158,7 +158,11 @@ PHP_REDIS_API int redis_check_eof(RedisSock *redis_sock, zend_bool no_retry, zen
 PHP_REDIS_API RedisSock *redis_sock_get(zval *id, int nothrow);
 PHP_REDIS_API void redis_free_socket(RedisSock *redis_sock);
 PHP_REDIS_API void redis_sock_set_err(RedisSock *redis_sock, const char *msg, int msg_len);
-PHP_REDIS_API int redis_sock_set_stream_context(RedisSock *redis_sock, zval *options);
+
+void redis_sock_set_context(RedisSock *redis_sock, HashTable *ht);
+void redis_sock_free_context(RedisSock *redis_sock);
+int redis_sock_set_context_zval(RedisSock *redis_sock, zval *zv);
+
 PHP_REDIS_API int redis_sock_set_backoff(RedisSock *redis_sock, zval *options);
 
 PHP_REDIS_API int

--- a/redis.c
+++ b/redis.c
@@ -603,13 +603,13 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
         redis_free_socket(redis->sock);
     }
 
-    redis->sock = redis_sock_create(host, host_len, port, timeout, read_timeout, persistent,
-        persistent_id, retry_interval);
+    redis->sock = redis_sock_create(host, host_len, port, timeout, read_timeout,
+                                    persistent, persistent_id, retry_interval);
 
     if (context) {
         /* Stream context (e.g. TLS) */
         if ((ele = REDIS_HASH_STR_FIND_STATIC(Z_ARRVAL_P(context), "stream"))) {
-            redis_sock_set_stream_context(redis->sock, ele);
+            redis_sock_set_context_zval(redis->sock, ele);
         }
 
         /* AUTH */

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -246,9 +246,8 @@ static void redis_cluster_init(redisCluster *c, HashTable *ht_seeds, double time
         c->flags->user = zend_string_copy(user);
     if (pass && ZSTR_LEN(pass))
         c->flags->pass = zend_string_copy(pass);
-    if (context) {
-        redis_sock_set_stream_context(c->flags, context);
-    }
+    if (context)
+        redis_sock_set_context_zval(c->flags, context);
 
     c->flags->timeout = timeout;
     c->flags->read_timeout = read_timeout;

--- a/redis_session.c
+++ b/redis_session.c
@@ -568,9 +568,7 @@ PS_OPEN_FUNC(redis)
             redis_sock->compression = session_compression_type();
             redis_sock->compression_level = INI_INT("redis.session.compression_level");
 
-            if (Z_TYPE(context) == IS_ARRAY) {
-                redis_sock_set_stream_context(redis_sock, &context);
-            }
+            redis_sock_set_context_zval(redis_sock, &context);
 
             redis_pool_add(pool, redis_sock, weight);
             redis_sock->prefix = prefix;
@@ -1061,7 +1059,7 @@ PS_OPEN_FUNC(rediscluster) {
     redis_sock_set_auth(c->flags, user, pass);
 
     if ((context = REDIS_HASH_STR_FIND_TYPE_STATIC(ht_conf, "stream", IS_ARRAY)) != NULL) {
-        redis_sock_set_stream_context(c->flags, context);
+        redis_sock_set_context_zval(c->flags, context);
     }
 
     /* First attempt to load from cache */

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -45,6 +45,7 @@ class Redis_Cluster_Test extends Redis_Test {
     public function testSwapDB() { $this->markTestSkipped(); }
     public function testConnectException() { $this->markTestSkipped(); }
     public function testTlsConnect() { $this->markTestSkipped(); }
+    public function testTlsReconnect() { $this->markTestSkipped(); }
     public function testReset() { $this->markTestSkipped(); }
     public function testInvalidAuthArgs() { $this->markTestSkipped(); }
     public function testScanErrors() { $this->markTestSkipped(); }
@@ -124,8 +125,8 @@ class Redis_Cluster_Test extends Redis_Test {
     }
 
     /* Load our seeds on construction */
-    public function __construct($host, $port, $auth) {
-        parent::__construct($host, $port, $auth);
+    public function __construct($host, $port, $auth, $tls_port = 6378) {
+        parent::__construct($host, $port, $auth, $tls_port);
 
         self::$seeds = $this->loadSeeds($host, $port);
     }

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -8624,15 +8624,45 @@ class Redis_Test extends TestSuite {
         }
     }
 
+    /* Regression test for GitHub PR #2802). Make sure we don't leak the
+     * context array when explicitly reconnecting in a loop */
+    public function testTlsReconnect() {
+        $tls_port = $this->getTlsPort();
+        if (($fp = @fsockopen($this->getHost(), $tls_port)) == NULL)
+            $this->markTestSkipped();
+
+        fclose($fp);
+
+        $redis = new Redis;
+
+        $context = ['stream' => [
+            'verify_peer_name' => false,
+            'verify_peer' => false,
+        ]];
+
+        $base = memory_get_usage(true);
+
+        for ($i = 0; $i < 20; $i++) {
+            $redis->connect('tls://' . $this->getHost(), $tls_port, 0, null, 0,
+                            0, $context);
+        }
+
+        $final = memory_get_usage(true);
+
+        $this->assertLTE(10000, $final - $base);
+    }
+
     public function testTlsConnect() {
-        if (($fp = @fsockopen($this->getHost(), 6378)) == NULL)
+        $tls_port = $this->getTlsPort();
+
+        if (($fp = @fsockopen($this->getHost(), $tls_port)) == NULL)
             $this->markTestSkipped();
 
         fclose($fp);
 
         foreach (['localhost' => true, '127.0.0.1' => false] as $host => $verify) {
             $redis = new Redis();
-            $this->assertTrue($redis->connect('tls://' . $host, 6378, 0, null, 0, 0, [
+            $this->assertTrue($redis->connect('tls://' . $host, $tls_port, 0, null, 0, 0, [
                 'stream' => ['verify_peer_name' => $verify, 'verify_peer' => false]
             ]));
         }

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -53,7 +53,7 @@ error_reporting(E_ALL);
 ini_set( 'display_errors','1');
 
 /* Grab options */
-$opt = getopt('', ['host:', 'port:', 'class:', 'test:', 'nocolors', 'user:', 'auth:']);
+$opt = getopt('', ['host:', 'port:', 'tls-port:', 'class:', 'test:', 'nocolors', 'user:', 'auth:']);
 
 /* The test class(es) we want to run */
 $classes = getClassArray($opt['class'] ?? 'redis');
@@ -66,6 +66,7 @@ $filter = $opt['test'] ?? NULL;
 /* Grab override host/port if it was passed */
 $host = $opt['host'] ?? '127.0.0.1';
 $port = $opt['port'] ?? 6379;
+$tls_port = $opt['tls-port'] ?? 6378;
 
 /* Get optional username and auth (password) */
 $user = $opt['user'] ?? NULL;
@@ -116,7 +117,7 @@ foreach ($classes as $class) {
         }
     } else {
         echo TestSuite::make_bold($class) . "\n";
-        if (TestSuite::run("$class", $filter, $host, $port, $auth))
+        if (TestSuite::run("$class", $filter, $host, $port, $auth, $tls_port))
             exit(1);
     }
 }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -9,6 +9,7 @@ class TestSuite
     /* Host and port the unit tests will use */
     private string $host;
     private ?int $port = 6379;
+    private ?int $tls_port = 6378;
 
     /* Redis authentication we'll use */
     private $auth;
@@ -35,14 +36,16 @@ class TestSuite
     public static array $errors = [];
     public static array $warnings = [];
 
-    public function __construct(string $host, ?int $port, $auth) {
+    public function __construct(string $host, ?int $port, $auth, ?int $tls_port = 6378) {
         $this->host = $host;
         $this->port = $port;
         $this->auth = $auth;
+        $this->tls_port = $tls_port;
     }
 
     public function getHost() { return $this->host; }
     public function getPort() { return $this->port; }
+    public function getTlsPort() { return $this->tls_port; }
     public function getAuth() { return $this->auth; }
 
     public static function errorMessage(string $fmt, ...$args) {
@@ -574,7 +577,7 @@ class TestSuite
 
     public static function run($class_name, ?string $limit = NULL,
                                ?string $host = NULL, ?int $port = NULL,
-                               $auth = NULL)
+                               $auth = NULL, ?int $tls_port = 6378)
     {
         if ($limit)
             $limit = strtolower($limit);
@@ -599,7 +602,7 @@ class TestSuite
             echo self::make_bold($padded_name);
 
             $count = count($class_name::$errors);
-            $rt = new $class_name($host, $port, $auth);
+            $rt = new $class_name($host, $port, $auth, $tls_port);
 
             try {
                 $rt->setUp();


### PR DESCRIPTION
Instead of currying around a `php_stream_context` object, just retain the context array provided by the user itself like we do with other connection information like host and port. This lets users reconnect in a loop without leaking memory.

```php
$redis = new \Redis;
while (true) {
    // Previously each reconnect call would leak the
    // `php_stream_context` structure.
    $redis->connect('tls://127.0.0.1', 9999, 1, null, 0, 0, [
        'stream' => ['verify_peer' => false, 'verify_peer_name' => false],
    ]);

    $redis->ping();

    $redis->close();
}
```

See #2802