### PR TITLE
If nodes of the cluster are not reachable clear the slots cache

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1589,6 +1589,7 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char
          * node until we find one that is available. */
         if (cluster_sock_write(c, cmd, cmd_len, 0) == -1) {
             /* We have to abort, as no nodes are reachable */
+            cluster_cache_clear(c);
             CLUSTER_THROW_EXCEPTION("Can't communicate with any node in the cluster", 0);
             return -1;
         }


### PR DESCRIPTION
During AWS ElastiCache(redis/valkey) upgrade their system builds completely different cluster(All new masters - Possibly swaps with slaves, we're not sure).
If slots cache is turned on - "Can't communicate with any node in the cluster" error happens with all requests unless PHP_FPM is fully restarted.
This change forces phpredis to issue a cache clear operation in such a case.