### PR TITLE
Fix flaky testExists by using deterministic key setup

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -1015,17 +1015,14 @@ class Redis_Test extends TestSuite {
         /* Add multiple keys */
         $mkeys = [];
         for ($i = 0; $i < 10; $i++) {
-            if (rand(1, 2) == 1) {
-                $mkey = "{exists}key:$i";
-                $this->redis->set($mkey, $i);
-                $mkeys[] = $mkey;
-            }
+            $mkey = "{exists}key:$i";
+            $this->redis->set($mkey, $i);
+            $mkeys[] = $mkey;
         }
 
         /* Test passing an array as well as the keys variadic */
         $this->assertEquals(count($mkeys), $this->redis->exists($mkeys));
-        if (count($mkeys))
-            $this->assertEquals(count($mkeys), $this->redis->exists(...$mkeys));
+        $this->assertEquals(count($mkeys), $this->redis->exists(...$mkeys));
     }
 
     public function testTouch() {


### PR DESCRIPTION
The test used rand() to decide which keys to create, making it possible for $mkeys to be empty. This caused EXISTS to receive an empty array, resulting in a sporadic assertion failure: (false) !== 0

Observed in #2825 CI and also in an unrelated branch:
- https://github.com/phpredis/phpredis/actions/runs/24132080914
- https://github.com/phpredis/phpredis/actions/runs/23617186872