### PR TITLE
library: redis_sock_getc returns int not char to detect EOF

### DIFF
--- a/library.h
+++ b/library.h
@@ -312,8 +312,8 @@ static inline char *redis_sock_get_line(RedisSock *redis_sock, char *buf, size_t
     return res;
 }
 
-static inline char redis_sock_getc(RedisSock *redis_sock) {
-    char res;
+static inline int redis_sock_getc(RedisSock *redis_sock) {
+    int res;
 
     res = php_stream_getc(redis_sock->stream);
     if (res != EOF)


### PR DESCRIPTION
`php_stream_getc` returns `int` but `redis_sock_getc` stored the result in a `char` and returned that, truncating the EOF sentinel. On unsigned-char platforms (ARM Linux, AIX, PPC) `EOF == -1` becomes `0xFF` after promotion and `res != EOF` is always true; on signed-char platforms a server byte of `0xFF` is indistinguishable from real EOF. Subscribe loops can busy-loop or stall. Return `int`, matching the standard `getc`-style convention.