### PR TITLE
session: derive lock secret from php_random_bytes_silent

### DIFF
--- a/redis_session.c
+++ b/redis_session.c
@@ -20,6 +20,13 @@
 
 #include "common.h"
 
+#if PHP_VERSION_ID < 80400
+#include <ext/standard/php_random.h>
+#else
+#include <ext/random/php_random.h>
+#endif
+#include <ext/hash/php_hash.h>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -331,12 +338,21 @@ static void generate_lock_key(redis_session_lock_status *status) {
 }
 
 static void generate_lock_secret(redis_session_lock_status *status) {
+    unsigned char buf[16];
     char hostname[HOST_NAME_MAX] = {0};
 
-    gethostname(hostname, HOST_NAME_MAX);
     if (status->lock_secret)
         zend_string_release(status->lock_secret);
 
+    if (php_random_bytes_silent(buf, sizeof(buf)) == SUCCESS) {
+        zend_string *s = zend_string_alloc(sizeof(buf) * 2, 0);
+        php_hash_bin2hex(ZSTR_VAL(s), buf, sizeof(buf));
+        ZSTR_VAL(s)[sizeof(buf) * 2] = '\0';
+        status->lock_secret = s;
+        return;
+    }
+
+    gethostname(hostname, HOST_NAME_MAX);
     status->lock_secret = strpprintf(0, "%s|%ld", hostname, (long)getpid());
 }
 


### PR DESCRIPTION
`generate_lock_secret` derived the session lock secret from `hostname|pid`, roughly 22 bits of guessable entropy and also readable from Redis under `<key>_LOCK`. Replace with 16 bytes from `php_random_bytes_silent` hex-encoded. The hostname|pid path stays as a fallback for the rare case where `php_random_bytes_silent` fails, so the caller always sees a non-NULL secret. Defense in depth: an attacker with write access to the Redis instance can already bypass the lock by `DEL`-ing the key directly, so this is not a primary defense; worth fixing for the case where only the lock key itself is exposed.