### PR TITLE
fix: Reject redirection hosts that cannot fit in our buffer

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1152,6 +1152,9 @@ static int cluster_set_redirection(redisCluster* c, char *msg, int moved)
     if ((port = strrchr(host, ':')) == NULL) return -1;
     *port++ = '\0';
 
+    /* If the host len does not fit in our buffer we must fail */
+    if (port - host - 1 >= sizeof(c->redir_host)) return -1;
+
     char *endptr;
     long slot_val, port_val;
 
@@ -1169,8 +1172,11 @@ static int cluster_set_redirection(redisCluster* c, char *msg, int moved)
 
     // Success, apply it
     c->redir_type = moved ? REDIR_MOVED : REDIR_ASK;
-    strncpy(c->redir_host, host, sizeof(c->redir_host) - 1);
+
     c->redir_host_len = port - host - 1;
+    memcpy(c->redir_host, host, c->redir_host_len);
+    c->redir_host[c->redir_host_len] = '\0';
+
     c->redir_slot = (unsigned short)slot_val;
     c->redir_port = (unsigned short)port_val;
 

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2065,12 +2065,12 @@ PHP_METHOD(RedisCluster, _masters) {
 
 PHP_METHOD(RedisCluster, _redir) {
     redisCluster *c = GET_CONTEXT();
-    char buf[255];
-    size_t len;
+    smart_str s = {0};
 
-    len = snprintf(buf, sizeof(buf), "%s:%d", c->redir_host, c->redir_port);
     if (*c->redir_host && c->redir_host_len) {
-        RETURN_STRINGL(buf, len);
+        smart_str_append_printf(&s, "%s:%d", c->redir_host, c->redir_port);
+        smart_str_0(&s);
+        RETURN_STR(s.s);
     } else {
         RETURN_NULL();
     }


### PR DESCRIPTION
Previously a corrupted or malicious `MOVED` response could embed a host name that was larger than the `c->redir_host` buffer which could leave it non null-terminated.

Worse, `c->redir_host_len` was calculated from the too-large input which could cause subsequent use to memcpy past the end of our buffer.

This fix simply hard rejects any host that we can't store in `c->redir_host` while including a null terminator.

In addition we swich from a statically sized buffer in `RedisCluster::_redir` to using `zend_smart_str`

cc @iliaal 