### PR TITLE
perf: Avoid zero-fill in redis_key_prefix

### DIFF
--- a/library.c
+++ b/library.c
@@ -4483,9 +4483,10 @@ redis_key_prefix(RedisSock *redis_sock, char **key, size_t *key_len) {
     }
 
     ret_len = ZSTR_LEN(redis_sock->prefix) + *key_len;
-    ret = ecalloc(1 + ret_len, 1);
+    ret = emalloc(1 + ret_len);
     memcpy(ret, ZSTR_VAL(redis_sock->prefix), ZSTR_LEN(redis_sock->prefix));
     memcpy(ret + ZSTR_LEN(redis_sock->prefix), *key, *key_len);
+    ret[ret_len] = '\0';
 
     *key = ret;
     *key_len = ret_len;


### PR DESCRIPTION
`redis_key_prefix` allocated the prefixed-key buffer with `ecalloc`, then overwrote the whole allocation with two `memcpy` calls. The zero-fill is wasted on every keyed argument when a prefix is set.

Switch to `emalloc` and write the single trailing NUL explicitly.

Built on PHP 8.4; `testPrefix` passes and a smoke test confirms the prefix is still applied on the wire.
