### PR TITLE
perf: Skip mstime() in cluster_send_command when no timeout is set

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1627,7 +1627,7 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot, const char
     c->cmd_sock = SLOT_SOCK(c, slot);
 
     /* Get the current time in milliseconds to handle any timeout */
-    msstart = mstime();
+    msstart = c->waitms ? mstime() : 0;
 
     /* Our main cluster request/reply loop.  This loop runs until we're able to
      * get a valid reply from a node, hit our "request" timeout, or encounter a


### PR DESCRIPTION
`cluster_send_command` captured `msstart` via `mstime()` (a `gettimeofday` call) on entry to every command. The elapsed-time check below already calls `mstime()` only when `c->waitms` is non-zero, so when no request timeout is configured the initial capture is dead work.

Gate the initial capture on `c->waitms` too.

Compile-verified against PHP 8.4 (no cluster available for a runtime test). Behavior is unchanged for the timeout path.
