### PR TITLE
perf: Drop redundant liveness probe in redis_sock_read_bulk_reply

### DIFF
--- a/library.c
+++ b/library.c
@@ -784,7 +784,12 @@ redis_sock_read_bulk_reply(RedisSock *redis_sock, int bytes)
         return NULL;
     }
 
-    if (-1 == bytes || -1 == redis_check_eof(redis_sock, 1, 0)) {
+    /* The caller reaches this only after successfully reading the bulk
+     * header on this socket, which already proved the stream live, so the
+     * php_stream_eof() liveness probe redis_check_eof() performs is
+     * redundant here. A mid-read disconnect is still caught by the read
+     * loop below. Keep a cheap NULL-stream guard for safety. */
+    if (-1 == bytes || redis_sock->stream == NULL) {
         return NULL;
     }
 


### PR DESCRIPTION
`redis_sock_read_bulk_reply` called `redis_check_eof`, which issues a `php_stream_eof` probe (a `recv(MSG_PEEK)` syscall when the stream buffer is drained), before reading the bulk body. Every caller reaches this function only after reading the bulk-length header on the same socket, which already proved the stream live, so the probe adds a redundant kernel round-trip to the dominant GET/HGET/MGET read path.

Replace it with a cheap NULL-stream guard. A disconnect mid-read is still caught by the existing `php_stream_eof` check inside the read loop.

Built on PHP 8.4; smoke tests plus bulk edge cases (empty, binary with NUL/CRLF, 1MB, null to false) pass.
