### PR TITLE
fix: Use the git sha instead of branch name for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,11 @@ jobs:
           php-version: ${{ matrix.php }}
           ts: ${{ matrix.ts }}
           run-tests: false
+          # The builder embeds the ref in the build-log/artifact filename without
+          # sanitizing it. A branch like "fix/foo" turns the "/" into a path
+          # separator on Windows and the build fails. Pass the commit SHA so the
+          # name is always slash-free.
+          extension-ref: ${{ github.sha }}
 
   pecl:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `/` gets turned into a path separator breaking CI on Windows. This commit attempts to send the commit sha instead which will never have slashes.