### PR TITLE
Support negative Zstd compression levels

### DIFF
--- a/library.c
+++ b/library.c
@@ -4047,7 +4047,7 @@ redis_compress(RedisSock *redis_sock, char **dst, size_t *dstlen, char *buf, siz
                 size_t size;
                 int level;
 
-                if (redis_sock->compression_level < 1) {
+                if (redis_sock->compression_level == 0) {
 #ifdef ZSTD_CLEVEL_DEFAULT
                     level = ZSTD_CLEVEL_DEFAULT;
 #else


### PR DESCRIPTION
### Summary

`OPT_COMPRESSION_LEVEL` treated **any** value below `1` as "use the default", so negative Zstd levels (e.g. `-5`) were silently discarded and replaced with the default level 3. Zstd supports negative ("fast") compression levels, so they should be honored.

This changes the guard in the `REDIS_COMPRESSION_ZSTD` branch of `redis_compress()` from `compression_level < 1` to `compression_level == 0`:

- `0` — the `ecalloc` default and Zstd's own "use default" sentinel — still maps to `ZSTD_CLEVEL_DEFAULT` (or `3`).
- Negative values now pass through to `ZSTD_compress()`.

No lower-bound clamp is added: `ZSTD_compress()` already clamps extreme negatives to `ZSTD_minCLevel()` internally, and `ZSTD_minCLevel()` only exists since libzstd 1.3.6 while phpredis supports ≥ 1.3.0 (`config.m4`), so calling it would break the build on older libzstd. The existing upper-bound clamp to `ZSTD_maxCLevel()` is unchanged.

### Before

```php
$redis->setOption(Redis::OPT_COMPRESSION_LEVEL, -5); // ignored, used level 3
```

### After

```php
$redis->setOption(Redis::OPT_COMPRESSION_LEVEL, -5); // uses Zstd level -5
```