### PR TITLE
Refactor: Use `RedisCmd` for more cluster commands

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -363,17 +363,17 @@ PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot,
     const char *cmd, int cmd_len);
 
 static zend_always_inline short
-cluster_send_cmd_rcmd(redisCluster *c, RedisCmd *cmd)
+cluster_send_rcmd(redisCluster *c, RedisCmd *cmd)
 {
     return cluster_send_command(c, cmd->slot, redis_cmd_str(cmd),
                                 redis_cmd_len(cmd));
 }
 
 static zend_always_inline short
-cluster_send_command_rcmd_ex(redisCluster *c, short slot, RedisCmd *cmd)
+cluster_send_rcmd_ex(redisCluster *c, short slot, RedisCmd *cmd)
 {
     cmd->slot = slot;
-    return cluster_send_cmd_rcmd(c, cmd);
+    return cluster_send_rcmd(c, cmd);
 }
 
 PHP_REDIS_API void cluster_disconnect(redisCluster *c, int force);

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -362,6 +362,20 @@ long long mstime(void);
 PHP_REDIS_API short cluster_send_command(redisCluster *c, short slot,
     const char *cmd, int cmd_len);
 
+static zend_always_inline short
+cluster_send_cmd_rcmd(redisCluster *c, RedisCmd *cmd)
+{
+    return cluster_send_command(c, cmd->slot, redis_cmd_str(cmd),
+                                redis_cmd_len(cmd));
+}
+
+static zend_always_inline short
+cluster_send_command_rcmd_ex(redisCluster *c, short slot, RedisCmd *cmd)
+{
+    cmd->slot = slot;
+    return cluster_send_cmd_rcmd(c, cmd);
+}
+
 PHP_REDIS_API void cluster_disconnect(redisCluster *c, int force);
 
 PHP_REDIS_API int cluster_send_exec(redisCluster *c, short slot);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -111,7 +111,7 @@ cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     ctx = redis_cmd_pop_ctx(cmd);
     slot = cmd->slot;
 
-    if (cluster_send_command(c, slot, redis_cmd_str(cmd), redis_cmd_len(cmd)) < 0 || c->err != NULL) {
+    if (cluster_send_cmd_rcmd(c, cmd) < 0 || c->err != NULL) {
         redis_cmd_ctx_free(ctx);
         redis_cmd_free(cmd);
         RETURN_FALSE;
@@ -147,8 +147,7 @@ cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     ctx = redis_cmd_pop_ctx(cmd);
     slot = cmd->slot;
 
-    if (cluster_send_command(c, slot, redis_cmd_str(cmd), redis_cmd_len(cmd)) < 0 ||
-        c->err != NULL)
+    if (cluster_send_cmd_rcmd(c, cmd) < 0 || c->err != NULL)
     {
         redis_cmd_ctx_free(ctx);
         redis_cmd_free(cmd);
@@ -454,8 +453,7 @@ distcmd_resp_handler(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, short slot,
     mctx->last    = last;
 
     // Attempt to send the command
-    if (cluster_send_command(c,slot,redis_cmd_str(mc->cmd),
-                             redis_cmd_len(mc->cmd)) < 0 || c->err != NULL)
+    if (cluster_send_command_rcmd_ex(c, slot, mc->cmd) < 0 || c->err != NULL)
     {
         efree(mctx);
         return -1;
@@ -2208,8 +2206,7 @@ PHP_METHOD(RedisCluster, watch) {
         }
 
         // If we get a failure from this, we have to abort
-        if (cluster_send_command(c, slot, redis_cmd_str(cmd),
-                                 redis_cmd_len(cmd)) < 0)
+        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0)
         {
             redis_cmd_free(cmd);
             RETURN_FALSE;
@@ -2495,9 +2492,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
     redisCluster *c = GET_CONTEXT();
     char *pat = NULL, *key = NULL;
     size_t key_len = 0, pat_len = 0, pat_free = 0;
-    int key_free = 0;
     RedisCmd *cmd;
-    short slot;
     zval *z_it;
     HashTable *hash;
     long num_ele;
@@ -2527,10 +2522,6 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
     if (completed)
         RETURN_FALSE;
 
-    // Apply any key prefix we have, get the slot
-    key_free = redis_key_prefix(c->flags, &key, &key_len);
-    slot = cluster_hash_key(key, key_len);
-
     if (c->flags->scan & REDIS_SCAN_PREFIX) {
         pat_free = redis_key_prefix(c->flags, &pat, &pat_len);
     }
@@ -2545,13 +2536,19 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
         }
 
         // Create command
-        cmd = redis_fmt_scan_cmd(type, key, key_len, cursor, pat, pat_len, count);
+        cmd = redis_fmt_scan_cmd(c->flags, type, key, key_len, cursor, pat,
+                                 pat_len, count);
+        if (cmd == NULL) {
+            CLUSTER_THROW_EXCEPTION("Couldn't construct SCAN command", 0);
+            if (pat_free) efree(pat);
+            RETURN_FALSE;
+        }
 
         // Send it off
-        if (cluster_send_command(c, slot, redis_cmd_str(cmd), redis_cmd_len(cmd)) == FAILURE)
+        if (cluster_send_cmd_rcmd(c, cmd) == FAILURE)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN command", 0);
-            if (key_free) efree(key);
+            if (pat_free) efree(pat);
             redis_cmd_free(cmd);
             RETURN_FALSE;
         }
@@ -2561,7 +2558,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
                               &cursor) == FAILURE)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't read SCAN response", 0);
-            if (key_free) efree(key);
+            if (pat_free) efree(pat);
             redis_cmd_free(cmd);
             RETURN_FALSE;
         }
@@ -2576,9 +2573,6 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
 
     // Free our pattern
     if (pat_free) efree(pat);
-
-    // Free our key
-    if (key_free) efree(key);
 
     // Update iterator reference
     redisSetScanCursor(z_it, cursor);
@@ -2704,7 +2698,8 @@ PHP_METHOD(RedisCluster, scan) {
         }
 
         /* Construct our command */
-        cmd = redis_fmt_scan_cmd(TYPE_SCAN, NULL, 0, cursor, pat, pat_len, count);
+        cmd = redis_fmt_scan_cmd(NULL, TYPE_SCAN, NULL, 0, cursor, pat,
+                                 pat_len, count);
 
         if ((slot = cluster_cmd_get_slot(c, z_node)) < 0) {
            redis_cmd_free(cmd);
@@ -2712,7 +2707,7 @@ PHP_METHOD(RedisCluster, scan) {
         }
 
         // Send it to the node in question
-        if (cluster_send_command(c, slot, redis_cmd_str(cmd), redis_cmd_len(cmd)) < 0)
+        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN to node", 0);
             redis_cmd_free(cmd);

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -111,7 +111,7 @@ cluster_process_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     ctx = redis_cmd_pop_ctx(cmd);
     slot = cmd->slot;
 
-    if (cluster_send_cmd_rcmd(c, cmd) < 0 || c->err != NULL) {
+    if (cluster_send_rcmd(c, cmd) < 0 || c->err != NULL) {
         redis_cmd_ctx_free(ctx);
         redis_cmd_free(cmd);
         RETURN_FALSE;
@@ -147,7 +147,7 @@ cluster_process_kw_cmd(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     ctx = redis_cmd_pop_ctx(cmd);
     slot = cmd->slot;
 
-    if (cluster_send_cmd_rcmd(c, cmd) < 0 || c->err != NULL)
+    if (cluster_send_rcmd(c, cmd) < 0 || c->err != NULL)
     {
         redis_cmd_ctx_free(ctx);
         redis_cmd_free(cmd);
@@ -453,7 +453,7 @@ distcmd_resp_handler(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, short slot,
     mctx->last    = last;
 
     // Attempt to send the command
-    if (cluster_send_command_rcmd_ex(c, slot, mc->cmd) < 0 || c->err != NULL)
+    if (cluster_send_rcmd_ex(c, slot, mc->cmd) < 0 || c->err != NULL)
     {
         efree(mctx);
         return -1;
@@ -2206,7 +2206,7 @@ PHP_METHOD(RedisCluster, watch) {
         }
 
         // If we get a failure from this, we have to abort
-        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0)
+        if (cluster_send_rcmd_ex(c, slot, cmd) < 0)
         {
             redis_cmd_free(cmd);
             RETURN_FALSE;
@@ -2545,7 +2545,7 @@ static void cluster_kscan_cmd(INTERNAL_FUNCTION_PARAMETERS,
         }
 
         // Send it off
-        if (cluster_send_cmd_rcmd(c, cmd) == FAILURE)
+        if (cluster_send_rcmd(c, cmd) == FAILURE)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN command", 0);
             if (pat_free) efree(pat);
@@ -2707,7 +2707,7 @@ PHP_METHOD(RedisCluster, scan) {
         }
 
         // Send it to the node in question
-        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0)
+        if (cluster_send_rcmd_ex(c, slot, cmd) < 0)
         {
             CLUSTER_THROW_EXCEPTION("Couldn't send SCAN to node", 0);
             redis_cmd_free(cmd);

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -641,17 +641,21 @@ RedisCmd *redis_key_dbl_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 
 /* Generic to construct SCAN and variant commands */
 RedisCmd *
-redis_fmt_scan_cmd(REDIS_SCAN_TYPE type, char *key, int key_len,
-                   uint64_t it, char *pat, int pat_len, long count)
+redis_fmt_scan_cmd(RedisSock *redis_sock, REDIS_SCAN_TYPE type, char *key,
+                   int key_len, uint64_t it, char *pat, int pat_len,
+                   long count)
 {
     static char *kw[] = {"SCAN","SSCAN","HSCAN","ZSCAN"};
     RedisCmd *cmd;
 
-    cmd = redis_cmd_create(NULL, kw[type], strlen(kw[type]));
+    cmd = redis_cmd_create(redis_sock, kw[type], strlen(kw[type]));
 
     // Append our key if it's not a regular SCAN command
     if (type != TYPE_SCAN) {
-        redis_cmd_cat_str(cmd, key, key_len);
+        if (!redis_cmd_cat_key_str(cmd, key, key_len)) {
+            redis_cmd_free(cmd);
+            return NULL;
+        }
     }
 
     // Append cursor

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -138,8 +138,8 @@ RedisCmd *redis_object_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_client_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_command_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_copy_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
-RedisCmd *redis_fmt_scan_cmd(REDIS_SCAN_TYPE type, char *key, int key_len,
-    uint64_t it, char *pat, int pat_len, long count);
+RedisCmd *redis_fmt_scan_cmd(RedisSock *redis_sock, REDIS_SCAN_TYPE type,
+    char *key, int key_len, uint64_t it, char *pat, int pat_len, long count);
 RedisCmd *redis_geoadd_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_geodist_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_migrate_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);

--- a/redis_session.c
+++ b/redis_session.c
@@ -1313,7 +1313,7 @@ PS_CREATE_SID_FUNC(rediscluster)
 
         /* Attempt to kick off our command */
         c->readonly = 0;
-        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
+        if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
             php_error_docref(NULL, E_NOTICE, "Redis connection not available");
             redis_cmd_free(cmd);
             zend_string_release(sid);
@@ -1370,8 +1370,7 @@ PS_VALIDATE_SID_FUNC(rediscluster)
 
     /* We send to master, to ensure consistency */
     c->readonly = 0;
-    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err)
-    {
+    if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         php_error_docref(NULL, E_NOTICE, "Redis connection not available");
         redis_cmd_free(cmd);
         return FAILURE;
@@ -1419,7 +1418,7 @@ PS_UPDATE_TIMESTAMP_FUNC(rediscluster) {
 
     /* Attempt to send EXPIRE command */
     c->readonly = 0;
-    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
+    if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         php_error_docref(NULL, E_NOTICE, "Redis unable to update session expiry");
         redis_cmd_free(cmd);
         return FAILURE;
@@ -1469,7 +1468,7 @@ PS_READ_FUNC(rediscluster) {
     zend_string_release(key);
 
     /* Attempt to kick off our command */
-    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
+    if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }
@@ -1528,7 +1527,7 @@ PS_WRITE_FUNC(rediscluster) {
 
     /* Attempt to send command */
     c->readonly = 0;
-    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
+    if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }
@@ -1564,7 +1563,7 @@ PS_DESTROY_FUNC(rediscluster) {
     zend_string_release(key);
 
     /* Attempt to send command */
-    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
+    if (cluster_send_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }

--- a/redis_session.c
+++ b/redis_session.c
@@ -1313,7 +1313,7 @@ PS_CREATE_SID_FUNC(rediscluster)
 
         /* Attempt to kick off our command */
         c->readonly = 0;
-        if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0 || c->err) {
+        if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
             php_error_docref(NULL, E_NOTICE, "Redis connection not available");
             redis_cmd_free(cmd);
             zend_string_release(sid);
@@ -1370,8 +1370,7 @@ PS_VALIDATE_SID_FUNC(rediscluster)
 
     /* We send to master, to ensure consistency */
     c->readonly = 0;
-    if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0
-        || c->err)
+    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err)
     {
         php_error_docref(NULL, E_NOTICE, "Redis connection not available");
         redis_cmd_free(cmd);
@@ -1420,7 +1419,7 @@ PS_UPDATE_TIMESTAMP_FUNC(rediscluster) {
 
     /* Attempt to send EXPIRE command */
     c->readonly = 0;
-    if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0 || c->err) {
+    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         php_error_docref(NULL, E_NOTICE, "Redis unable to update session expiry");
         redis_cmd_free(cmd);
         return FAILURE;
@@ -1470,7 +1469,7 @@ PS_READ_FUNC(rediscluster) {
     zend_string_release(key);
 
     /* Attempt to kick off our command */
-    if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0 || c->err) {
+    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }
@@ -1529,7 +1528,7 @@ PS_WRITE_FUNC(rediscluster) {
 
     /* Attempt to send command */
     c->readonly = 0;
-    if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0 || c->err) {
+    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }
@@ -1565,7 +1564,7 @@ PS_DESTROY_FUNC(rediscluster) {
     zend_string_release(key);
 
     /* Attempt to send command */
-    if (cluster_send_command(c,slot,redis_cmd_str(cmd),redis_cmd_len(cmd)) < 0 || c->err) {
+    if (cluster_send_command_rcmd_ex(c, slot, cmd) < 0 || c->err) {
         redis_cmd_free(cmd);
         return FAILURE;
     }


### PR DESCRIPTION
Introduce `cluster_send_command_rcmd` and `cluster_send_command_rcmd_ex` that simplifies calling logic that is currently repeatedly extracting the command and length anywy.

Additionally this lets us elide key prefixing and conditional freeing of the duplicate string at the callsites.