### PR TITLE
refactor: Remove legacy `sentinel` `RedisSock` bool

### DIFF
--- a/common.h
+++ b/common.h
@@ -315,7 +315,6 @@ typedef struct {
     zend_bool           reply_literal;
     zend_bool           null_mbulk_as_null;
     zend_bool           tcp_keepalive;
-    zend_bool           sentinel;
     size_t              txBytes;
     size_t              rxBytes;
     uint8_t             flags;

--- a/library.c
+++ b/library.c
@@ -3159,7 +3159,7 @@ redis_check_echo_response(RedisSock *redis_sock, char *hdr, const char *id,
 
     /* Sentinel doesn't have ECHO but it will contain the ID in the error
      * message so just check that */
-    if (redis_sock->sentinel) {
+    if (redis_sock->type == REDIS_SOCK_SENTINEL) {
         return redis_strncmp(hdr, ZEND_STRL("-ERR unknown command")) == 0 &&
                strstr(hdr, id) != NULL;
     }

--- a/redis_sentinel.c
+++ b/redis_sentinel.c
@@ -55,7 +55,6 @@ PHP_METHOD(RedisSentinel, __construct)
     if (opts != NULL && redis_sock_configure(sentinel->sock, opts) != SUCCESS) {
         RETURN_THROWS();
     }
-    sentinel->sock->sentinel = 1;
 }
 
 PHP_METHOD(RedisSentinel, ckquorum)


### PR DESCRIPTION
We now have an attached enum `RedisSockType` that we can use instead.