### PR TITLE
Fix PHP 8.6 builds

### DIFF
--- a/cluster_library.h
+++ b/cluster_library.h
@@ -114,7 +114,7 @@ static zend_always_inline zend_bool cluster_is_ask(const char *p, size_t len) {
     mc.kw_len = keyword_len; \
 
 static zend_always_inline zend_bool cluster_caching_enabled(void) {
-    return INI_INT("redis.clusters.cache_slots") == 1;
+    return zend_ini_long_literal("redis.clusters.cache_slots") == 1;
 }
 
 /* Cluster redirection enum */

--- a/common.h
+++ b/common.h
@@ -15,7 +15,7 @@
 #include <zend_smart_str.h>
 #include <zend_smart_string.h>
 
-#define PHPREDIS_GET_OBJECT(class_entry, o) (class_entry *)((char *)o - XtOffsetOf(class_entry, std))
+#define PHPREDIS_GET_OBJECT(class_entry, o) (class_entry *)((char *)o - offsetof(class_entry, std))
 #define PHPREDIS_ZVAL_GET_OBJECT(class_entry, z) PHPREDIS_GET_OBJECT(class_entry, Z_OBJ_P(z))
 
 /* We'll fallthrough if we want to */

--- a/library.c
+++ b/library.c
@@ -131,7 +131,7 @@ redis_sock_get_connection_pool(RedisSock *redis_sock)
     zend_string *persistent_id;
 
     /* Generate our unique pool id depending on configuration */
-    persistent_id = redis_pool_spprintf(redis_sock, INI_STR("redis.pconnect.pool_pattern"));
+    persistent_id = redis_pool_spprintf(redis_sock, zend_ini_string_literal("redis.pconnect.pool_pattern"));
 
     /* Return early if we can find the pool */
     if ((le = zend_hash_find_ptr(&EG(persistent_list), persistent_id))) {
@@ -938,7 +938,7 @@ static void append_auth_hash(smart_str *dst, zend_string *user, zend_string *pas
 
 /* A printf like function to generate our connection pool hash value. */
 PHP_REDIS_API zend_string *
-redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...) {
+redis_pool_spprintf(RedisSock *redis_sock, const char *fmt, ...) {
     smart_str str = {0};
 
     smart_str_alloc(&str, 128, 0);
@@ -3047,7 +3047,7 @@ static php_socket_t redis_stream_fd_for_select(php_stream *stream) {
 }
 
 static int redis_detect_dirty_config(void) {
-    int val = INI_INT("redis.pconnect.pool_detect_dirty");
+    int val = zend_ini_long_literal("redis.pconnect.pool_detect_dirty");
 
     if (val >= 0 && val <= 2)
         return val;
@@ -3058,7 +3058,7 @@ static int redis_detect_dirty_config(void) {
 }
 
 static int redis_pool_poll_timeout(void) {
-    int val = INI_INT("redis.pconnect.pool_poll_timeout");
+    int val = zend_ini_long_literal("redis.pconnect.pool_poll_timeout");
     if (val >= 0)
         return val;
 
@@ -3152,7 +3152,7 @@ redis_sock_check_liveness(RedisSock *redis_sock)
         goto failure;
 
     redis_sock->status = REDIS_SOCK_STATUS_CONNECTED;
-    if (!INI_INT("redis.pconnect.echo_check_liveness")) {
+    if (!zend_ini_long_literal("redis.pconnect.echo_check_liveness")) {
         return SUCCESS;
     }
 
@@ -3283,7 +3283,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
     }
 
     if (redis_sock->persistent) {
-        if (INI_INT("redis.pconnect.pooling_enabled")) {
+        if (zend_ini_long_literal("redis.pconnect.pooling_enabled")) {
             p = redis_sock_get_connection_pool(redis_sock);
             if (zend_llist_count(&p->list) > 0) {
                 redis_sock->stream = *(php_stream **)zend_llist_get_last(&p->list);
@@ -3296,7 +3296,7 @@ PHP_REDIS_API int redis_sock_connect(RedisSock *redis_sock)
                 p->nb_active--;
             }
 
-            int limit = INI_INT("redis.pconnect.connection_limit");
+            int limit = zend_ini_long_literal("redis.pconnect.connection_limit");
             if (limit > 0 && p->nb_active >= limit) {
                 redis_sock_set_err(redis_sock, ZEND_STRL("Connection limit reached"));
                 return FAILURE;
@@ -3423,7 +3423,7 @@ redis_sock_disconnect(RedisSock *redis_sock, int force, int is_reset_mode)
     } else if (redis_sock->stream) {
         if (redis_sock->persistent) {
             ConnectionPool *p = NULL;
-            if (INI_INT("redis.pconnect.pooling_enabled")) {
+            if (zend_ini_long_literal("redis.pconnect.pooling_enabled")) {
                 p = redis_sock_get_connection_pool(redis_sock);
             }
             if (force || !redis_sock_is_atomic(redis_sock)) {
@@ -4365,7 +4365,8 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, size_t *val_len)
             return 1;
 #endif
             break;
-        EMPTY_SWITCH_DEFAULT_CASE()
+        default:
+            ZEND_UNREACHABLE();
     }
 
     return 0;
@@ -4432,7 +4433,8 @@ redis_unserialize(RedisSock* redis_sock, const char *val, int val_len,
             ret = !php_json_decode(z_ret, (char *)val, val_len, 1, PHP_JSON_PARSER_DEFAULT_DEPTH);
 #endif
             break;
-        EMPTY_SWITCH_DEFAULT_CASE()
+        default:
+            ZEND_UNREACHABLE();
     }
 
     return ret;

--- a/library.h
+++ b/library.h
@@ -24,7 +24,7 @@ void redis_free_reply_callbacks(RedisSock *redis_sock);
 PHP_REDIS_API int redis_extract_auth_info(zval *ztest, zend_string **user, zend_string **pass);
 PHP_REDIS_API void redis_with_metadata(zval *zdst, zval *zsrc, zend_long length);
 
-PHP_REDIS_API zend_string *redis_pool_spprintf(RedisSock *redis_sock, char *fmt, ...);
+PHP_REDIS_API zend_string *redis_pool_spprintf(RedisSock *redis_sock, const char *fmt, ...);
 
 PHP_REDIS_API char *redis_sock_read(RedisSock *redis_sock, int *buf_len);
 PHP_REDIS_API int redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t* line_len);

--- a/php_compat.h
+++ b/php_compat.h
@@ -1,6 +1,8 @@
 #ifndef PHP_REDIS_COMPAT_H
 #define PHP_REDIS_COMPAT_H
 
+#include <stddef.h>
+
 #include "php.h"
 #include <ext/hash/php_hash.h>
 
@@ -9,6 +11,25 @@
 #include <ext/standard/php_rand.h>
 #else
 #include <ext/random/php_random.h>
+#endif
+
+#ifndef ZEND_UNREACHABLE
+#define ZEND_UNREACHABLE() do { ZEND_ASSERT(0); ZEND_ASSUME(0); } while (0)
+#endif
+
+#if PHP_VERSION_ID < 80600
+
+#define zend_ini_bool_literal(name) \
+    zend_ini_parse_bool(zend_ini_str((name), sizeof("" name) - 1, 0))
+#define zend_ini_long_literal(name) \
+    zend_ini_long((name), sizeof("" name) - 1, 0)
+#define zend_ini_double_literal(name) \
+    zend_ini_double((name), sizeof("" name) - 1, 0)
+#define zend_ini_str_literal(name) \
+    zend_ini_str((name), sizeof("" name) - 1, 0)
+#define zend_ini_string_literal(name) \
+    zend_ini_string((name), sizeof("" name) - 1, 0)
+
 #endif
 
 #if PHP_VERSION_ID < 80000

--- a/redis.c
+++ b/redis.c
@@ -334,7 +334,7 @@ static void redis_random_hex_bytes(char *dst, size_t dstsize) {
 static void redis_init_object_handlers(void) {
     memcpy(&redis_object_handlers, zend_get_std_object_handlers(),
            sizeof(redis_object_handlers));
-    redis_object_handlers.offset = XtOffsetOf(redis_object, std);
+    redis_object_handlers.offset = offsetof(redis_object, std);
     redis_object_handlers.free_obj = free_redis_object;
     redis_object_handlers.clone_obj = NULL;
 }

--- a/redis_array.c
+++ b/redis_array.c
@@ -105,7 +105,7 @@ redis_array_init_object_handlers(void)
 {
     memcpy(&redis_array_object_handlers, zend_get_std_object_handlers(),
            sizeof(redis_array_object_handlers));
-    redis_array_object_handlers.offset = XtOffsetOf(redis_array_object, std);
+    redis_array_object_handlers.offset = offsetof(redis_array_object, std);
     redis_array_object_handlers.free_obj = free_redis_array_object;
     redis_array_object_handlers.clone_obj = NULL;
 }

--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -135,7 +135,7 @@ ra_find_name(const char *name) {
     const char *ini_names, *p, *next;
     /* php_printf("Loading redis array with name=[%s]\n", name); */
 
-    ini_names = INI_STR("redis.arrays.names");
+    ini_names = zend_ini_string_literal("redis.arrays.names");
     for(p = ini_names; p;) {
         next = strchr(p, ',');
         if(next) {
@@ -168,7 +168,7 @@ RedisArray *ra_load_array(const char *name) {
     double d_connect_timeout = 0, read_timeout = 0.0;
     HashTable *hHosts = NULL, *hPrev = NULL;
     size_t name_len = strlen(name);
-    char *iptr;
+    const char *iptr;
 
     /* find entry */
     if(!ra_find_name(name))
@@ -179,7 +179,7 @@ RedisArray *ra_load_array(const char *name) {
 
     /* find hosts */
     array_init(&z_params_hosts);
-    if ((iptr = INI_STR("redis.arrays.hosts")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.hosts")) != NULL) {
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_hosts);
         if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_hosts), name, name_len)) != NULL) {
             hHosts = Z_ARRVAL_P(z_data);
@@ -188,7 +188,7 @@ RedisArray *ra_load_array(const char *name) {
 
     /* find previous hosts */
     array_init(&z_params_prev);
-    if ((iptr = INI_STR("redis.arrays.previous")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.previous")) != NULL) {
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_params_prev);
         if ((z_data = zend_hash_str_find(Z_ARRVAL(z_params_prev), name, name_len)) != NULL) {
             if (Z_TYPE_P(z_data) == IS_ARRAY) {
@@ -198,7 +198,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find function */
-    if ((iptr = INI_STR("redis.arrays.functions")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.functions")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zval(Z_ARRVAL(z_tmp), name, name_len, &z_fun, 1, 0);
@@ -206,7 +206,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find distributor */
-    if ((iptr = INI_STR("redis.arrays.distributor")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.distributor")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zval(Z_ARRVAL(z_tmp), name, name_len, &z_dist, 1, 0);
@@ -214,7 +214,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find hash algorithm */
-    if ((iptr = INI_STR("redis.arrays.algorithm")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.algorithm")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_string(Z_ARRVAL(z_tmp), name, name_len, &algorithm);
@@ -222,7 +222,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find index option */
-    if ((iptr = INI_STR("redis.arrays.index")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.index")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_index);
@@ -230,7 +230,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find autorehash option */
-    if ((iptr = INI_STR("redis.arrays.autorehash")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.autorehash")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_autorehash);
@@ -238,7 +238,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find retry interval option */
-    if ((iptr = INI_STR("redis.arrays.retryinterval")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.retryinterval")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_long(Z_ARRVAL(z_tmp), name, name_len, &l_retry_interval);
@@ -246,7 +246,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find pconnect option */
-    if ((iptr = INI_STR("redis.arrays.pconnect")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.pconnect")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_pconnect);
@@ -254,7 +254,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find lazy connect option */
-    if ((iptr = INI_STR("redis.arrays.lazyconnect")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.lazyconnect")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_zend_bool(Z_ARRVAL(z_tmp), name, name_len, &b_lazy_connect);
@@ -262,7 +262,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find connect timeout option */
-    if ((iptr = INI_STR("redis.arrays.connecttimeout")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.connecttimeout")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &d_connect_timeout);
@@ -270,7 +270,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find read timeout option */
-    if ((iptr = INI_STR("redis.arrays.readtimeout")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.readtimeout")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &read_timeout);
@@ -278,7 +278,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find consistent option */
-    if ((iptr = INI_STR("redis.arrays.consistent")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.consistent")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         if ((z_data = zend_hash_str_find(Z_ARRVAL(z_tmp), name, name_len)) != NULL) {
@@ -289,7 +289,7 @@ RedisArray *ra_load_array(const char *name) {
     }
 
     /* find auth option */
-    if ((iptr = INI_STR("redis.arrays.auth")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.arrays.auth")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_auth(Z_ARRVAL(z_tmp), name, name_len, &user, &pass);
@@ -1225,4 +1225,3 @@ ra_rehash(RedisArray *ra, zend_fcall_info *z_cb, zend_fcall_info_cache *z_cb_cac
         ra_rehash_server(ra, &ra->prev->redis[i], ra->prev->hosts[i], ra->index, z_cb, z_cb_cache);
     }
 }
-

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -173,7 +173,7 @@ redis_cluster_init_object_handlers(void)
 {
     memcpy(&RedisCluster_handlers, zend_get_std_object_handlers(),
            sizeof(RedisCluster_handlers));
-    RedisCluster_handlers.offset = XtOffsetOf(redisCluster, std);
+    RedisCluster_handlers.offset = offsetof(redisCluster, std);
     RedisCluster_handlers.free_obj = free_cluster_context;
     RedisCluster_handlers.clone_obj = NULL;
 }
@@ -300,12 +300,12 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     zend_string *user = NULL, *pass = NULL;
     double timeout = 0, read_timeout = 0;
     int persistent = 0;
-    char *iptr;
+    const char *iptr;
     HashTable *ht_seeds = NULL;
 
     /* Seeds */
     array_init(&z_seeds);
-    if ((iptr = INI_STR("redis.clusters.seeds")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.clusters.seeds")) != NULL) {
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_seeds);
     }
     if ((z_value = zend_hash_str_find(Z_ARRVAL(z_seeds), name, name_len)) != NULL) {
@@ -317,7 +317,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     }
 
     /* Connection timeout */
-    if ((iptr = INI_STR("redis.clusters.timeout")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.clusters.timeout")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &timeout);
@@ -325,7 +325,7 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     }
 
     /* Read timeout */
-    if ((iptr = INI_STR("redis.clusters.read_timeout")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.clusters.read_timeout")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_double(Z_ARRVAL(z_tmp), name, name_len, &read_timeout);
@@ -333,14 +333,14 @@ void redis_cluster_load(redisCluster *c, char *name, int name_len) {
     }
 
     /* Persistent connections */
-    if ((iptr = INI_STR("redis.clusters.persistent")) != NULL) {
+    if ((iptr = zend_ini_string_literal("redis.clusters.persistent")) != NULL) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_bool(Z_ARRVAL(z_tmp), name, name_len, &persistent);
         zval_ptr_dtor_nogc(&z_tmp);
     }
 
-    if ((iptr = INI_STR("redis.clusters.auth"))) {
+    if ((iptr = zend_ini_string_literal("redis.clusters.auth"))) {
         array_init(&z_tmp);
         sapi_module.treat_data(PARSE_STRING, estrdup(iptr), &z_tmp);
         redis_conf_auth(Z_ARRVAL(z_tmp), name, name_len, &user, &pass);

--- a/redis_session.c
+++ b/redis_session.c
@@ -155,7 +155,7 @@ redis_pool_free(redis_pool *pool) {
 
 /* Retrieve session.gc_maxlifetime from php.ini protecting against an integer overflow */
 static int session_gc_maxlifetime(void) {
-    zend_long value = INI_INT("session.gc_maxlifetime");
+    zend_long value = zend_ini_long_literal("session.gc_maxlifetime");
     if (value > INT_MAX) {
         php_error_docref(NULL, E_NOTICE, "session.gc_maxlifetime overflows INT_MAX, truncating.");
         return INT_MAX;
@@ -169,7 +169,7 @@ static int session_gc_maxlifetime(void) {
 
 /* Retrieve redis.session.compression from php.ini */
 static int session_compression_type(void) {
-    const char *compression = INI_STR("redis.session.compression");
+    const char *compression = zend_ini_string_literal("redis.session.compression");
 
     if(compression == NULL || *compression == '\0' ||
        redis_strncasecmp(compression, ZEND_STRL("none")) == 0)
@@ -352,25 +352,25 @@ lock_acquire(RedisSock *redis_sock, redis_session_lock_status *lock_status) {
     int result;
 
     /* Short circuit if we are already locked or not using session locks */
-    if (lock_status->is_locked || !INI_INT("redis.session.locking_enabled"))
+    if (lock_status->is_locked || !zend_ini_long_literal("redis.session.locking_enabled"))
         return SUCCESS;
 
     /* How long to wait between attempts to acquire lock */
-    wait_time = INI_INT("redis.session.lock_wait_time");
+    wait_time = zend_ini_long_literal("redis.session.lock_wait_time");
     if (wait_time == 0) {
         wait_time = 20000;
     }
 
     /* Maximum number of times to retry (-1 means infinite) */
-    retries = INI_INT("redis.session.lock_retries");
+    retries = zend_ini_long_literal("redis.session.lock_retries");
     if (retries == 0) {
         retries = 100;
     }
 
     /* How long should the lock live (in seconds) */
-    expiry = INI_INT("redis.session.lock_expire");
+    expiry = zend_ini_long_literal("redis.session.lock_expire");
     if (expiry == 0) {
-        expiry = INI_INT("max_execution_time");
+        expiry = zend_ini_long_literal("max_execution_time");
     }
 
     generate_lock_key(lock_status);
@@ -422,13 +422,13 @@ static int
 write_allowed(RedisSock *redis_sock, redis_session_lock_status *lock_status) {
     RedisCmd *cmd;
 
-    if (!INI_INT("redis.session.locking_enabled")) {
+    if (!zend_ini_long_literal("redis.session.locking_enabled")) {
         return 1;
     }
     /* If locked and redis.session.lock_expire is not set => TTL=max_execution_time
        Therefore it is guaranteed that the current process is still holding the lock */
 
-    if (lock_status->is_locked && INI_INT("redis.session.lock_expire") != 0) {
+    if (lock_status->is_locked && zend_ini_long_literal("redis.session.lock_expire") != 0) {
         char *reply = NULL;
         int replylen;
 
@@ -569,9 +569,9 @@ lock_release_lua(RedisSock *redis_sock, redis_session_lock_status *status) {
 }
 
 static lockDelCmd lock_release_cmd(void) {
-    char *cmd;
+    const char *cmd;
 
-    cmd = INI_STR("redis.session.lock_release_cmd");
+    cmd = zend_ini_string_literal("redis.session.lock_release_cmd");
 
     if (cmd == NULL) {
         return LOCK_DEL_EVAL;
@@ -738,7 +738,7 @@ PS_OPEN_FUNC(redis)
             }
 
             redis_sock->compression = session_compression_type();
-            redis_sock->compression_level = INI_INT("redis.session.compression_level");
+            redis_sock->compression_level = zend_ini_long_literal("redis.session.compression_level");
 
             redis_sock_set_context_zval(redis_sock, &context);
 
@@ -905,7 +905,7 @@ PS_UPDATE_TIMESTAMP_FUNC(redis)
         return FAILURE;
 
     /* No need to update the session timestamp if we've already done so */
-    if (INI_INT("redis.session.early_refresh")) {
+    if (zend_ini_long_literal("redis.session.early_refresh")) {
         return SUCCESS;
     }
 
@@ -967,7 +967,7 @@ PS_READ_FUNC(redis)
     pool->lock_status.session_key = redis_session_key(redis_sock, key);
 
     /* Update the session ttl if early refresh is enabled */
-    if (INI_INT("redis.session.early_refresh")) {
+    if (zend_ini_long_literal("redis.session.early_refresh")) {
         cmd = redis_cmd_create_literal(redis_sock, "GETEX");
         redis_cmd_cat_zstr(cmd, pool->lock_status.session_key);
         redis_cmd_cat_literal(cmd, "EX");
@@ -978,7 +978,7 @@ PS_READ_FUNC(redis)
     }
 
     if (lock_acquire(redis_sock, &pool->lock_status) != SUCCESS) {
-        if (INI_INT("redis.session.lock_failure_readonly")) {
+        if (zend_ini_long_literal("redis.session.lock_failure_readonly")) {
             // opt-in legacy behavior: readonly session
             php_error_docref(NULL, E_WARNING, "Failed to acquire session lock, session will be read only");
         } else {
@@ -1239,7 +1239,7 @@ PS_OPEN_FUNC(rediscluster) {
     }
 
     c->flags->compression = session_compression_type();
-    c->flags->compression_level = INI_INT("redis.session.compression_level");
+    c->flags->compression_level = zend_ini_long_literal("redis.session.compression_level");
 
     redis_sock_set_auth(c->flags, user, pass);
 
@@ -1291,7 +1291,7 @@ PS_CREATE_SID_FUNC(rediscluster)
         return php_session_create_id(NULL);
     }
 
-    if (INI_INT("session.use_strict_mode") == 0) {
+    if (zend_ini_long_literal("session.use_strict_mode") == 0) {
         return php_session_create_id((void **) &c);
     }
 
@@ -1401,7 +1401,7 @@ PS_UPDATE_TIMESTAMP_FUNC(rediscluster) {
     short slot;
 
     /* No need to update the session timestamp if we've already done so */
-    if (INI_INT("redis.session.early_refresh")) {
+    if (zend_ini_long_literal("redis.session.early_refresh")) {
         return SUCCESS;
     }
 
@@ -1451,7 +1451,7 @@ PS_READ_FUNC(rediscluster) {
     key = cluster_session_key(c, key, &slot);
 
     /* Update the session ttl if early refresh is enabled */
-    if (INI_INT("redis.session.early_refresh")) {
+    if (zend_ini_long_literal("redis.session.early_refresh")) {
         cmd = redis_cmd_fmt(NULL, "GETEX", "Ssd", key, "EX", 2,
                             session_gc_maxlifetime());
         c->readonly = 0;

--- a/sentinel_library.c
+++ b/sentinel_library.c
@@ -19,7 +19,7 @@ redis_sentinel_init_object_handlers(void)
 {
     memcpy(&redis_sentinel_object_handlers, zend_get_std_object_handlers(),
            sizeof(redis_sentinel_object_handlers));
-    redis_sentinel_object_handlers.offset = XtOffsetOf(redis_sentinel_object, std);
+    redis_sentinel_object_handlers.offset = offsetof(redis_sentinel_object, std);
     redis_sentinel_object_handlers.free_obj = free_redis_sentinel_object;
 }
 


### PR DESCRIPTION
* USe the new PHP 8.6 `zned_ini_<type>` helpers and define them in older versions of PHP
* Switch from `XtOffsetof` to `offsetof`
* User `ZEND_UNREACHABLE` instead of `ZEND_EMPTY_SWITCH_CASE`