### PR TITLE
Enable persistent connections in ZTS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ or host + persistent_id or unix socket + timeout.
 
 Since v4.2.1, it became possible to use connection pooling by setting INI variable `redis.pconnect.pooling_enabled` to 1.
 
-This feature is not available in threaded versions. `pconnect` and `popen` then work like their non
-persistent equivalents.
+In threaded versions (ZTS), persistent connections are kept per-thread: each thread reuses its own
+connections across requests and never shares them with other threads.
 
 ###### *Parameters*
 

--- a/redis.c
+++ b/redis.c
@@ -533,12 +533,6 @@ redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
     redis_object *redis;
     int af_unix;
 
-#ifdef ZTS
-    /* not sure how in threaded mode this works so disabled persistence at
-     * first */
-    persistent = 0;
-#endif
-
     ZEND_PARSE_PARAMETERS_START(1, 7)
         Z_PARAM_STRING(host, host_len)
         Z_PARAM_OPTIONAL


### PR DESCRIPTION
## Problem

Persistent connections (`pconnect`/`popen`) are force-disabled in ZTS builds:

```c
#ifdef ZTS
    /* not sure how in threaded mode this works so disabled persistence at
     * first */
    persistent = 0;
#endif
```

The comment says the behavior was untested, not unsafe. This makes `pconnect` silently behave like `connect` on every threaded SAPI (FrankenPHP, Apache worker/event MPM with ZTS, etc.), so each request pays a fresh TCP/TLS handshake + DNS lookup. Reported downstream at php/frankenphp#2150.

## Why it is safe

The connection pool and the persistent streams are stored in `EG(persistent_list)` (see `redis_sock_get_connection_pool()` and the `persistent_id` passed to `php_stream_xport_create()`). `EG(persistent_list)` is **per-thread** under ZTS. So persistence is per-thread: a thread reuses only its own connections across requests and never shares a socket with another thread. No cross-thread state, no locking required. It is the same mechanism NTS uses per-process, applied per-thread.

RedisCluster / RedisSentinel never had this guard and already honor user-requested persistence through the same `redis_sock_connect()` path.

## How it was tested

Built against ZTS PHP 8.6 and exercised through a real FrankenPHP binary in classic mode with a single worker thread, hitting a real Redis server. Each request calls `pconnect` and returns the Redis-assigned `CLIENT ID`. A reused socket keeps the same id; a new connection per request increments it.

`index.php`:

```php
<?php
$r = new Redis();
$r->pconnect('127.0.0.1', 6379);
echo $r->rawCommand('CLIENT', 'ID');
```

10 sequential requests:

| Build | `CLIENT ID` sequence | Result |
|-------|----------------------|--------|
| `develop` (guard present) | 4742, 4743, 4744 … 4751 | new connection every request |
| this PR | 4739, 4739, 4739 … 4739 | one socket reused across requests |

Reproducer (any ZTS SAPI that keeps threads alive across requests):

```console
# php.ini
extension=redis.so
redis.pconnect.pooling_enabled=0

# Caddyfile (FrankenPHP, single thread for determinism)
{
    auto_https off
    frankenphp { num_threads 1 }
}
:8899 {
    root * /path/to/app
    php_server
}

for i in $(seq 1 10); do curl -s http://127.0.0.1:8899/index.php; echo; done
```

With the guard, the printed id increments each request; with this patch it stays constant, confirming the persistent connection is reused across requests within the thread.

Fixes php/frankenphp#2150
