### PR TITLE
Fix two theoretical OOB reads

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -1273,7 +1273,7 @@ static int cluster_check_response(redisCluster *c, REDIS_REPLY_TYPE *reply_type)
         int moved;
 
         // Attempt to read the error
-        if (!redis_sock_get_line(c->cmd_sock, inbuf, sizeof(inbuf), &nbytes)) {
+        if (redis_sock_gets(c->cmd_sock, inbuf, sizeof(inbuf), &nbytes) < 0) {
             return -1;
         }
 
@@ -1283,7 +1283,7 @@ static int cluster_check_response(redisCluster *c, REDIS_REPLY_TYPE *reply_type)
             return !cluster_set_redirection(c, inbuf, moved) ? 1 : -1;
         }
         // Capture the error string Redis returned
-        cluster_set_err(c, inbuf, strlen(inbuf)-2);
+        cluster_set_err(c, inbuf, nbytes);
         return 0;
     }
 

--- a/library.c
+++ b/library.c
@@ -4497,7 +4497,9 @@ redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t *line_siz
         return -1;
     }
 
-    if(redis_sock_get_line(redis_sock, buf, buf_size, line_size) == NULL) {
+    if(redis_sock_get_line(redis_sock, buf, buf_size, line_size) == NULL ||
+       *line_size < 2 || memcmp(buf + *line_size - 2, ZEND_STRL("\r\n")) != 0)
+    {
         if (redis_sock->port < 0) {
             snprintf(buf, buf_size, "read error on connection to %s", ZSTR_VAL(redis_sock->host));
         } else {
@@ -4512,8 +4514,8 @@ redis_sock_gets(RedisSock *redis_sock, char *buf, int buf_size, size_t *line_siz
     }
 
     /* We don't need \r\n */
-    *line_size-=2;
-    buf[*line_size]='\0';
+    *line_size -= 2;
+    buf[*line_size] = '\0';
 
     /* Success! */
     return 0;


### PR DESCRIPTION
Make sure we have >= 2 bytes with a `\r\n` suffix for directed line reply reads.