### PR TITLE
move from backward to foward compat macro for bin2hex

### DIFF
--- a/library.c
+++ b/library.c
@@ -916,7 +916,7 @@ static zend_string *redis_hash_auth(zend_string *user, zend_string *pass) {
     efree(ctx);
 
     hex = zend_string_safe_alloc(ops->digest_size, 2, 0, 0);
-    php_hash_bin2hex(ZSTR_VAL(hex), digest, ops->digest_size);
+    zend_bin2hex(ZSTR_VAL(hex), digest, ops->digest_size);
     ZSTR_VAL(hex)[2 * ops->digest_size] = 0;
 
     efree(digest);

--- a/php_compat.h
+++ b/php_compat.h
@@ -17,11 +17,11 @@
 #define ZEND_UNREACHABLE() do { ZEND_ASSERT(0); ZEND_ASSUME(0); } while (0)
 #endif
 
-#if PHP_VERSION_ID >= 80600
+#if PHP_VERSION_ID < 80600
 /* php_hash_bin2hex() was dropped from ext/hash in PHP 8.6; the equivalent
  * routine now lives in the Zend engine as zend_bin2hex(), which has an
  * identical signature (char *out, const unsigned char *in, size_t in_len). */
-#define php_hash_bin2hex(out, in, in_len) zend_bin2hex((out), (in), (in_len))
+#define zend_bin2hex(out, in, in_len) php_hash_bin2hex((out), (in), (in_len))
 #endif
 
 #if PHP_VERSION_ID < 80600

--- a/redis.c
+++ b/redis.c
@@ -315,7 +315,7 @@ static void redis_random_hex_bytes(char *dst, size_t dstsize) {
 
     /* First try to have PHP generate the bytes */
     if (php_random_bytes_silent(ZSTR_VAL(s), bytes) == SUCCESS) {
-        php_hash_bin2hex(dst, (unsigned char *)ZSTR_VAL(s), bytes);
+        zend_bin2hex(dst, (unsigned char *)ZSTR_VAL(s), bytes);
         zend_string_release(s);
         return;
     }

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -7278,7 +7278,7 @@ static zend_string *redis_xxh3_digest(RedisSock *redis_sock, zval *zv) {
     ops->hash_final(digest, ctx);
 
     hex = zend_string_safe_alloc(ops->digest_size, 2, 0, 0);
-    php_hash_bin2hex(ZSTR_VAL(hex), digest, ops->digest_size);
+    zend_bin2hex(ZSTR_VAL(hex), digest, ops->digest_size);
     ZSTR_VAL(hex)[ZSTR_LEN(hex)] = '\0';
 
     efree(ctx);

--- a/redis_session.c
+++ b/redis_session.c
@@ -336,7 +336,7 @@ static void generate_lock_secret(redis_session_lock_status *status) {
 
     if (php_random_bytes_silent(buf, sizeof(buf)) == SUCCESS) {
         zend_string *s = zend_string_alloc(sizeof(buf) * 2, 0);
-        php_hash_bin2hex(ZSTR_VAL(s), buf, sizeof(buf));
+        zend_bin2hex(ZSTR_VAL(s), buf, sizeof(buf));
         ZSTR_VAL(s)[sizeof(buf) * 2] = '\0';
         status->lock_secret = s;
         return;


### PR DESCRIPTION
Seems better to use newer code

Using only `PHP_VERSION_ID < xxx` for compatibility macro will make it easier to clean up when raising the minimum supported version  (no other sources affected)

Consistent with other compatibility macros.