### PR TITLE
Add missing `const` qualifier to fix GCC warning

### DIFF
--- a/redis_array_impl.c
+++ b/redis_array_impl.c
@@ -443,7 +443,7 @@ ra_call_extractor(RedisArray *ra, const char *key, int key_len)
 static zend_string *
 ra_extract_key(RedisArray *ra, const char *key, int key_len)
 {
-    char *start, *end;
+    const char *start, *end;
 
     if (Z_TYPE(ra->z_fun) != IS_NULL) {
         return ra_call_extractor(ra, key, key_len);


### PR DESCRIPTION
This was the warning:

```
/data/git/github.com/phpredis/redis_array_impl.c: In function 'ra_extract_key':
/data/git/github.com/phpredis/redis_array_impl.c:450:23: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  450 |     } else if ((start = strchr(key, '{')) == NULL || (end = strchr(start + 1, '}')) == NULL) {
      |                       ^
```