### PR TITLE
Tests/easier triage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,11 +96,12 @@ php tests/TestRedis.php --class RedisSentinel [--port <sentinel-port>]
 With any of the above test invocations you can limit tests with the `--test
 <name>` option. Each value is a substring match. Multiple filters can be passed
 as a comma-separated list, as repeated `--test` options, or by mixing both forms.
-For example
+Prefix a filter with `!` to exclude matching tests. Exclusions take precedence;
+when there are no positive filters, all tests not excluded will run. For example
 
 ```sh
-# Will run any test with "get", "set", or "echo" in the name
-php tests/TestRedis.php --class Redis --test get,set --test echo
+# Run tests matching "get", "set", or "echo", except those matching "range"
+php tests/TestRedis.php --class Redis --test 'get,set,!range' --test echo
 ```
 
 ### Regression tests

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,12 +93,14 @@ php tests/TestRedis.php --class RedisSentinel [--port <sentinel-port>]
 
 ### Running specific tests
 
-With any of the above test invocations you can limit to a specific test with the
-`--test <name>` option. This is a substring match so for example
+With any of the above test invocations you can limit tests with the `--test
+<name>` option. Each value is a substring match. Multiple filters can be passed
+as a comma-separated list, as repeated `--test` options, or by mixing both forms.
+For example
 
 ```sh
-# Will run any test with "get" in the name
-php tests/TestRedis.php --class Redis --test get
+# Will run any test with "get", "set", or "echo" in the name
+php tests/TestRedis.php --class Redis --test get,set --test echo
 ```
 
 ### Regression tests

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ tests/make-cluster.sh stop
 php tests/TestRedis.php --class RedisSentinel
 ~~~
 
-Note that it is possible to run only tests which match a substring of the test itself by passing the additional argument '--test <str>' when invoking. Multiple test filters can be provided either as a comma-separated list, with repeated `--test` arguments, or by combining both forms.
+Note that it is possible to filter tests by a substring of the test itself by passing the additional argument '--test <str>' when invoking. Multiple test filters can be provided either as a comma-separated list, with repeated `--test` arguments, or by combining both forms. Prefix a filter with `!` to exclude matching tests. Exclusions take precedence over inclusions, and when only exclusions are provided all other tests run.
 
 ~~~
 # Just run the 'echo' test
@@ -162,6 +162,12 @@ php tests/TestRedis.php --class Redis --test echo
 
 # Run tests matching 'get', 'set', or 'echo'
 php tests/TestRedis.php --class Redis --test get,set --test echo
+
+# Run tests matching 'get' or 'set', except those matching 'range'
+php tests/TestRedis.php --class Redis --test 'get,set,!range'
+
+# Run every test except those matching 'commandstats'
+php tests/TestRedis.php --class Redis --test '!commandstats'
 ~~~
 
 ## API Documentation

--- a/README.md
+++ b/README.md
@@ -154,11 +154,14 @@ tests/make-cluster.sh stop
 php tests/TestRedis.php --class RedisSentinel
 ~~~
 
-Note that it is possible to run only tests which match a substring of the test itself by passing the additional argument '--test <str>' when invoking.
+Note that it is possible to run only tests which match a substring of the test itself by passing the additional argument '--test <str>' when invoking. Multiple test filters can be provided either as a comma-separated list, with repeated `--test` arguments, or by combining both forms.
 
 ~~~
 # Just run the 'echo' test
 php tests/TestRedis.php --class Redis --test echo
+
+# Run tests matching 'get', 'set', or 'echo'
+php tests/TestRedis.php --class Redis --test get,set --test echo
 ~~~
 
 ## API Documentation

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -48,6 +48,73 @@ function raHosts($host, $ports) {
     }, $ports);
 }
 
+function getOriginalCommand(array $args): array {
+    $fallback = array_merge([PHP_BINARY], $args);
+
+    /* On Linux, /proc preserves the executable and any PHP options exactly as
+     * they were invoked. */
+    if ( ! is_readable('/proc/self/cmdline'))
+        return $fallback;
+
+    $raw = @file_get_contents('/proc/self/cmdline');
+    if ($raw === false)
+        return $fallback;
+
+    $command = explode("\0", rtrim($raw, "\0"));
+
+    /* The PHP-visible argument vector should be the tail of the process
+     * command line, beginning with the test script. */
+    if (count($command) < count($args) ||
+        array_slice($command, -count($args)) !== $args)
+    {
+        return $fallback;
+    }
+
+    return $command;
+}
+
+function escapeCommandArgument(string $arg): string {
+    if (preg_match('/^[a-zA-Z0-9_@%+=:,\.\/-]+$/D', $arg))
+        return $arg;
+
+    return escapeshellarg($arg);
+}
+
+function getFailedTestCommand(array $args, array $failed_tests): string {
+    $command = getOriginalCommand($args);
+    $script_index = count($command) - count($args);
+    $result = array_slice($command, 0, $script_index + 1);
+
+    /* Keep the original invocation but replace its test filters with the
+     * complete set of failed tests. */
+    for ($i = $script_index + 1; $i < count($command); $i++) {
+        if ($command[$i] === '--test') {
+            $i++;
+            continue;
+        }
+
+        if (strncmp($command[$i], '--test=', strlen('--test=')) === 0)
+            continue;
+
+        $result[] = $command[$i];
+    }
+
+    $result[] = '--test';
+    $result[] = implode(',', $failed_tests);
+
+    return implode(' ', array_map('escapeCommandArgument', $result));
+}
+
+function printFailedTestCommand(array $args) {
+    $failed_tests = TestSuite::getFailedTests();
+
+    if ( ! $failed_tests)
+        return;
+
+    echo "\nTo rerun only the failed tests:\n";
+    echo getFailedTestCommand($args, $failed_tests) . "\n";
+}
+
 /* Make sure errors go to stdout and are shown */
 error_reporting(E_ALL);
 ini_set( 'display_errors','1');
@@ -111,14 +178,17 @@ foreach ($classes as $class) {
             foreach ($test_classes as $test_class) {
                 /* Run until we encounter a failure */
                 if (run_ra_tests($test_class, $filter, $host, $full_ring, $sub_ring, $auth) != 0) {
+                    printFailedTestCommand($argv);
                     exit(1);
                 }
             }
         }
     } else {
         echo TestSuite::make_bold($class) . "\n";
-        if (TestSuite::run("$class", $filter, $host, $port, $auth, $tls_port))
+        if (TestSuite::run("$class", $filter, $host, $port, $auth, $tls_port)) {
+            printFailedTestCommand($argv);
             exit(1);
+        }
     }
 }
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -518,15 +518,50 @@ class TestSuite
         throw new TestSkippedException($msg);
     }
 
-    private static function getMaxTestLen(array $methods, ?string $limit): int {
+    private static function normalizeTestLimit($limit): ?array {
+        if ( ! $limit)
+            return NULL;
+
+        if ( ! is_array($limit))
+            $limit = [$limit];
+
+        $result = [];
+
+        foreach ($limit as $tests) {
+            foreach (explode(',', $tests) as $test) {
+                $test = strtolower(trim($test));
+
+                if ($test !== '')
+                    $result[$test] = true;
+            }
+        }
+
+        return $result ? array_keys($result) : NULL;
+    }
+
+    private static function testMatches(string $name, ?array $limits): bool {
+        if ($limits === NULL)
+            return true;
+
+        $name = strtolower($name);
+
+        foreach ($limits as $limit) {
+            if (strstr($name, $limit) !== false)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static function getMaxTestLen(array $methods, ?array $limits): int {
         $result = 0;
 
         foreach ($methods as $obj_method) {
-            $name = strtolower($obj_method->name);
+            $name = $obj_method->name;
 
             if (substr($name, 0, 4) != 'test')
                 continue;
-            if ($limit && !strstr($name, $limit))
+            if ( ! self::testMatches($name, $limits))
                 continue;
 
             if (strlen($name) > $result) {
@@ -577,26 +612,25 @@ class TestSuite
                           defined('STDOUT') && posix_isatty(STDOUT);
     }
 
-    public static function run($class_name, ?string $limit = NULL,
+    public static function run($class_name, $limit = NULL,
                                ?string $host = NULL, ?int $port = NULL,
                                $auth = NULL, ?int $tls_port = 6378)
     {
-        if ($limit)
-            $limit = strtolower($limit);
+        $limits = self::normalizeTestLimit($limit);
 
         $rc = new ReflectionClass($class_name);
         $methods = $rc->GetMethods(ReflectionMethod::IS_PUBLIC);
 
-        $max_test_len = self::getMaxTestLen($methods, $limit);
+        $max_test_len = self::getMaxTestLen($methods, $limits);
 
         foreach($methods as $m) {
             $name = $m->name;
             if (substr($name, 0, 4) !== 'test')
                 continue;
 
-            /* If we're trying to limit to a specific test and can't match the
-             * substring, skip */
-            if ($limit && stristr($name, $limit) === false) {
+            /* If we're trying to limit the run and none of the requested
+             * substrings match, skip */
+            if ( ! self::testMatches($name, $limits)) {
                 continue;
             }
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -497,6 +497,8 @@ class TestSuite
             return true;
 
         self::$errors []= $this->assertionTrace("'%s' not found in '%s'", $needle, $haystack);
+
+        return false;
     }
 
     protected function assertPatternMatch(string $pattern, string $value): bool {
@@ -679,12 +681,13 @@ class TestSuite
                     $result = self::make_fail('FAILED');
                     $failed = true;
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 /* We may have simply skipped the test */
                 if ($e instanceof TestSkippedException) {
                     $result = self::make_warning('SKIPPED');
                 } else {
-                    $class_name::$errors[] = "Uncaught exception '".$e->getMessage()."' ($name)\n";
+                    $type = $e instanceof Exception ? 'exception' : get_class($e);
+                    $class_name::$errors[] = "Uncaught $type '".$e->getMessage()."' ($name)\n";
                     $result = self::make_fail('FAILED');
                     $failed = true;
                 }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -35,6 +35,7 @@ class TestSuite
 
     public static array $errors = [];
     public static array $warnings = [];
+    private static array $failed_tests = [];
 
     public function __construct(string $host, ?int $port, $auth, ?int $tls_port = 6378) {
         $this->host = $host;
@@ -612,6 +613,10 @@ class TestSuite
                           defined('STDOUT') && posix_isatty(STDOUT);
     }
 
+    public static function getFailedTests(): array {
+        return array_keys(self::$failed_tests);
+    }
+
     public static function run($class_name, $limit = NULL,
                                ?string $host = NULL, ?int $port = NULL,
                                $auth = NULL, ?int $tls_port = 6378)
@@ -639,6 +644,7 @@ class TestSuite
 
             $count = count($class_name::$errors);
             $rt = new $class_name($host, $port, $auth, $tls_port);
+            $failed = false;
 
             try {
                 $rt->setUp();
@@ -648,6 +654,7 @@ class TestSuite
                     $result = self::make_success('PASSED');
                 } else {
                     $result = self::make_fail('FAILED');
+                    $failed = true;
                 }
             } catch (Exception $e) {
                 /* We may have simply skipped the test */
@@ -656,8 +663,12 @@ class TestSuite
                 } else {
                     $class_name::$errors[] = "Uncaught exception '".$e->getMessage()."' ($name)\n";
                     $result = self::make_fail('FAILED');
+                    $failed = true;
                 }
             }
+
+            if ($failed)
+                self::$failed_tests[$name] = true;
 
             echo "[" . $result . "]\n";
         }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -519,42 +519,66 @@ class TestSuite
         throw new TestSkippedException($msg);
     }
 
-    private static function normalizeTestLimit($limit): ?array {
+    private static function normalizeTestFilters($limit): ?array {
         if ( ! $limit)
             return NULL;
 
         if ( ! is_array($limit))
             $limit = [$limit];
 
-        $result = [];
+        $result = [
+            'include' => [],
+            'exclude' => [],
+        ];
 
         foreach ($limit as $tests) {
             foreach (explode(',', $tests) as $test) {
                 $test = strtolower(trim($test));
 
+                if ($test === '')
+                    continue;
+
+                $type = $test[0] === '!' ? 'exclude' : 'include';
+                if ($type === 'exclude')
+                    $test = trim(substr($test, 1));
+
                 if ($test !== '')
-                    $result[$test] = true;
+                    $result[$type][$test] = true;
             }
         }
 
-        return $result ? array_keys($result) : NULL;
+        if ( ! $result['include'] && ! $result['exclude'])
+            return NULL;
+
+        return [
+            'include' => array_keys($result['include']),
+            'exclude' => array_keys($result['exclude']),
+        ];
     }
 
-    private static function testMatches(string $name, ?array $limits): bool {
-        if ($limits === NULL)
+    private static function testMatches(string $name, ?array $filters): bool {
+        if ($filters === NULL)
             return true;
 
         $name = strtolower($name);
 
-        foreach ($limits as $limit) {
-            if (strstr($name, $limit) !== false)
+        foreach ($filters['exclude'] as $filter) {
+            if (strstr($name, $filter) !== false)
+                return false;
+        }
+
+        if ( ! $filters['include'])
+            return true;
+
+        foreach ($filters['include'] as $filter) {
+            if (strstr($name, $filter) !== false)
                 return true;
         }
 
         return false;
     }
 
-    private static function getMaxTestLen(array $methods, ?array $limits): int {
+    private static function getMaxTestLen(array $methods, ?array $filters): int {
         $result = 0;
 
         foreach ($methods as $obj_method) {
@@ -562,7 +586,7 @@ class TestSuite
 
             if (substr($name, 0, 4) != 'test')
                 continue;
-            if ( ! self::testMatches($name, $limits))
+            if ( ! self::testMatches($name, $filters))
                 continue;
 
             if (strlen($name) > $result) {
@@ -621,21 +645,20 @@ class TestSuite
                                ?string $host = NULL, ?int $port = NULL,
                                $auth = NULL, ?int $tls_port = 6378)
     {
-        $limits = self::normalizeTestLimit($limit);
+        $filters = self::normalizeTestFilters($limit);
 
         $rc = new ReflectionClass($class_name);
         $methods = $rc->GetMethods(ReflectionMethod::IS_PUBLIC);
 
-        $max_test_len = self::getMaxTestLen($methods, $limits);
+        $max_test_len = self::getMaxTestLen($methods, $filters);
 
         foreach($methods as $m) {
             $name = $m->name;
             if (substr($name, 0, 4) !== 'test')
                 continue;
 
-            /* If we're trying to limit the run and none of the requested
-             * substrings match, skip */
-            if ( ! self::testMatches($name, $limits)) {
+            /* Skip tests that don't satisfy the requested filters */
+            if ( ! self::testMatches($name, $filters)) {
                 continue;
             }
 


### PR DESCRIPTION
Add some quality of life elements to the test suite

1. Allow users to run multiple specific tests with `--test` either with a CSV or by passsing multiple `--test` arguments.
2. Add the concept of "not" to the `--test` argument (e.g. `php tests/TestRedis.php --test '!lcs'`).
3. When we have test failures, output to the cli how to rerun only the failed tests.