### PR TITLE
tests: Output server info when running tests

### DIFF
--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -165,14 +165,8 @@ class Redis_Cluster_Test extends Redis_Test {
         self::$seeds = $this->loadSeeds($host, $port);
     }
 
-    /* Override setUp to get info from a specific node */
-    public function setUp() {
-        $this->redis    = $this->newInstance();
-        $info           = $this->redis->info(uniqid());
-        $this->version  = $info['redis_version'] ?? '0.0.0';
-        $this->is_keydb = $this->detectKeyDB($info);
-        $this->is_valkey = $this->detectValkey($info);
-        $this->valkey_version = $info['valkey_version'] ?? '0.0.0';
+    protected function queryServerInfo($redis) {
+        return $redis->info(uniqid());
     }
 
     private function findCliExe() {

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -70,13 +70,30 @@ class Redis_Test extends TestSuite {
     }
 
     protected function detectValkey($info) {
-        return is_array($info) && ($info['executable'] ?? '') === 'valkey';
+        return is_array($info) &&
+               (($info['server_name'] ?? NULL) === 'valkey' ||
+                isset($info['valkey_version']));
+    }
+
+    /* RedisCluster overrides this because INFO must be directed at a node. */
+    protected function queryServerInfo($redis) {
+        return $redis->info();
+    }
+
+    public function getServerInfo() {
+        $redis = $this->newInstance();
+
+        try {
+            return $this->queryServerInfo($redis);
+        } finally {
+            $redis->close();
+        }
     }
 
     public function setUp() {
         $this->redis = $this->newInstance();
 
-        $info = $this->redis->info();
+        $info = $this->queryServerInfo($this->redis);
 
         $this->version = $info['redis_version'] ?? '0.0.0';
         $this->valkey_version = $info['valkey_version'] ?? '0.0.0';

--- a/tests/TestRedis.php
+++ b/tests/TestRedis.php
@@ -185,6 +185,15 @@ foreach ($classes as $class) {
         }
     } else {
         echo TestSuite::make_bold($class) . "\n";
+
+        try {
+            $test = new $class($host, $port, $auth, $tls_port);
+            if (($server = $test->getServerVersion()) !== NULL)
+                echo "Using $server\n";
+        } catch (Throwable $e) {
+            /* Version reporting is best-effort; let the test run report errors. */
+        }
+
         if (TestSuite::run("$class", $filter, $host, $port, $auth, $tls_port)) {
             printFailedTestCommand($argv);
             exit(1);

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -49,6 +49,34 @@ class TestSuite
     public function getTlsPort() { return $this->tls_port; }
     public function getAuth() { return $this->auth; }
 
+    /* Test classes that can query INFO may override this. */
+    public function getServerInfo() {
+        return NULL;
+    }
+
+    /* Return a human-readable server/version string when INFO identifies it. */
+    public function getServerVersion() {
+        $info = $this->getServerInfo();
+
+        if ( ! is_array($info))
+            return NULL;
+
+        if (isset($info['dragonfly_version']))
+            return 'Dragonfly version ' . $info['dragonfly_version'];
+
+        if (($info['server_name'] ?? NULL) === 'valkey' ||
+            isset($info['valkey_version']))
+        {
+            $version = $info['valkey_version'] ?? $info['redis_version'] ?? NULL;
+            return $version === NULL ? 'Valkey' : 'Valkey version ' . $version;
+        }
+
+        if (isset($info['redis_version']))
+            return 'Redis version ' . $info['redis_version'];
+
+        return NULL;
+    }
+
     public static function errorMessage(string $fmt, ...$args) {
         $msg = vsprintf($fmt . "\n", $args);
 


### PR DESCRIPTION
Adds logic to output the server and version we've connected to when running tests. This is useful since we can see if we're running against a fork of Redis and also what eversion the fork is.