### PR TITLE
Switch to a lower bound check for session lock retry test

### DIFF
--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -8797,7 +8797,7 @@ class Redis_Test extends TestSuite {
         }
         $et = microtime(true);
 
-        $this->assertBetween($et - $st, .15, .75);
+        $this->assertGTE(.15, $et - $st);
     }
 
     public function testSession_defaultLockRetryCount() {


### PR DESCRIPTION
Previously we were asserting that the amount of time a failed lock retry loop took was within a range when we primarily want to ensure at least some lower-bound time passed.