### PR TITLE
fix: Prevent UNWATCH in multi mode for RedisCluster

### DIFF
--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -2252,6 +2252,13 @@ PHP_METHOD(RedisCluster, unwatch) {
     redisCluster *c = GET_CONTEXT();
     short slot;
 
+    // Disallow in MULTI mode
+    if (c->flags->mode == MULTI) {
+        php_error_docref(NULL, E_WARNING,
+            "UNWATCH command not allowed in MULTI mode");
+        RETURN_FALSE;
+    }
+
     // Send UNWATCH to nodes that need it
     for(slot = 0; slot < REDIS_CLUSTER_SLOTS; slot++) {
         if (c->master[slot] && cluster_slot_master_sock(c,slot)->watching) {

--- a/tests/RedisClusterTest.php
+++ b/tests/RedisClusterTest.php
@@ -588,6 +588,15 @@ class Redis_Cluster_Test extends Redis_Test {
         $this->assertEquals(['44'], $ret);
     }
 
+    /* UNWATCH cannot be issued after entering MULTI mode */
+    public function testUnwatchInMulti() {
+        $key = __METHOD__;
+
+        $this->redis->multi()->set($key, 'value');
+        $this->assertFalse(@$this->redis->unwatch());
+        $this->assertEquals([true], $this->redis->exec());
+    }
+
     public function testDiscard() {
         $this->redis->multi();
         $this->redis->set('pipecount', 'over9000');


### PR DESCRIPTION
Previously this would crash. Now it cleanly raises a warning and returtns false.