### PR TITLE
Implement `HIMPORT` command

### DIFF
--- a/cluster_library.c
+++ b/cluster_library.c
@@ -2000,6 +2000,19 @@ cluster_object_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
 }
 
 PHP_REDIS_API void
+cluster_himport_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+                     RedisCmdCtx ctx)
+{
+    ZEND_ASSERT(ctx.ptr == NULL || ctx.ptr == PHPREDIS_CTX_PTR);
+
+    if (ctx.ptr == PHPREDIS_CTX_PTR) {
+        cluster_long_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, redis_empty_ctx);
+    } else {
+        cluster_bool_resp(INTERNAL_FUNCTION_PARAM_PASSTHRU, c, redis_empty_ctx);
+    }
+}
+
+PHP_REDIS_API void
 cluster_set_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c, RedisCmdCtx ctx)
 {
     if (ctx.ptr == NULL) {

--- a/cluster_library.h
+++ b/cluster_library.h
@@ -448,6 +448,8 @@ PHP_REDIS_API void cluster_pop_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *
     RedisCmdCtx ctx);
 PHP_REDIS_API void cluster_object_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     RedisCmdCtx ctx);
+PHP_REDIS_API void cluster_himport_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
+    RedisCmdCtx ctx);
 PHP_REDIS_API void cluster_lpos_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,
     RedisCmdCtx ctx);
 PHP_REDIS_API void cluster_hrandfield_resp(INTERNAL_FUNCTION_PARAMETERS, redisCluster *c,

--- a/library.c
+++ b/library.c
@@ -1389,6 +1389,21 @@ redis_object_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
 }
 
 PHP_REDIS_API int
+redis_himport_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock,
+                       zval *z_tab, RedisCmdCtx ctx)
+{
+    ZEND_ASSERT(ctx.ptr == NULL || ctx.ptr == PHPREDIS_CTX_PTR);
+
+    if (ctx.ptr == PHPREDIS_CTX_PTR) {
+        return redis_long_response(INTERNAL_FUNCTION_PARAM_PASSTHRU, redis_sock,
+                                   z_tab, redis_empty_ctx);
+    } else {
+        return redis_boolean_response(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+                                      redis_sock, z_tab, redis_empty_ctx);
+    }
+}
+
+PHP_REDIS_API int
 redis_read_lpos_response(zval *zdst, RedisSock *redis_sock, char reply_type,
                          long long elements, RedisCmdCtx ctx)
 {

--- a/library.h
+++ b/library.h
@@ -168,6 +168,7 @@ redis_read_mpop_response(RedisSock *redis_sock, zval *zdst, int elements, RedisC
 
 /* Specialized ACL reply handlers */
 PHP_REDIS_API int redis_acl_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, RedisCmdCtx ctx);
+PHP_REDIS_API int redis_himport_response(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, RedisCmdCtx ctx);
 PHP_REDIS_API int redis_read_acl_getuser_reply(RedisSock *redis_sock, zval *zret, long len);
 PHP_REDIS_API int redis_acl_getuser_reply(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, zval *z_tab, RedisCmdCtx ctx);
 PHP_REDIS_API int redis_read_acl_log_reply(RedisSock *redis_sock, zval *zret, long count);

--- a/redis.c
+++ b/redis.c
@@ -1760,6 +1760,7 @@ REDIS_METHOD(hSet, redis_hset_cmd, redis_long_response);
 REDIS_METHOD(hSetNx, redis_hsetnx_cmd, redis_1_response);
 REDIS_METHOD(hStrLen, redis_hstrlen_cmd, redis_long_response);
 REDIS_METHOD(hgetdel, redis_hgetdel_cmd, redis_mbulk_reply_assoc);
+REDIS_METHOD(himport, redis_himport_cmd, redis_himport_response);
 REDIS_METHOD(hgetex, redis_hgetex_cmd, redis_mbulk_reply_assoc);
 REDIS_METHOD(hsetex, redis_hsetex_cmd, redis_long_response);
 REDIS_METHOD(incr, redis_incr_cmd, redis_long_response);

--- a/redis.stub.php
+++ b/redis.stub.php
@@ -2330,6 +2330,35 @@ class Redis {
     public function hgetdel(string $key, array $fields): Redis|array|false;
 
     /**
+     * Manage session local fieldsets and import hashes that use them.
+     *
+     * A fieldset is a named, session local list of field names that Redis can
+     * reuse for many hashes, allowing it to store them in a more memory
+     * efficient way.
+     *
+     * <code>
+     * <?php
+     * $redis->himport('PREPARE', null, 'user', ['first', 'last']);
+     * $redis->himport('SET', 'user:1', 'user', ['Jane', 'Doe']);
+     * $redis->himport('DISCARD', null, 'user');
+     * $redis->himport('DISCARDALL');
+     * ?>
+     * </code>
+     *
+     * @param string      $op        One of 'PREPARE', 'SET', 'DISCARD', or 'DISCARDALL'.
+     * @param string|null $hash      The hash to create, required for 'SET'.
+     * @param string|null $fieldset  The fieldset name, required for every operation but 'DISCARDALL'.
+     * @param array       $fields    Field names for 'PREPARE' or values for 'SET'.
+     *
+     * @return Redis|bool|int True for 'PREPARE' and 'SET', the number of
+     *                        fieldsets removed for 'DISCARD' and 'DISCARDALL',
+     *                        or false on failure.
+     *
+     * @see https://redis.io/docs/latest/commands/himport/
+     */
+    public function himport(string $op, ?string $hash = null, ?string $fieldset = null, array $fields = []): Redis|bool|int;
+
+    /**
      * Add or update one or more hash fields and values
      *
      * @param string $key        The hash to create/update

--- a/redis_arginfo.h
+++ b/redis_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d53b980175361aad909f18e3d13d5ffaf084b968 */
+ * Stub hash: 745c9be9bad265ecb49d4784a57101d019835758 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
@@ -460,6 +460,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hsetex, 0, 2, Re
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_himport, 0, 1, Redis, MAY_BE_BOOL|MAY_BE_LONG)
+	ZEND_ARG_TYPE_INFO(0, op, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hash, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fieldset, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fields, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Redis_hMset, 0, 2, Redis, MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
@@ -1457,6 +1464,7 @@ ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
 ZEND_METHOD(Redis, hsetex);
 ZEND_METHOD(Redis, hgetdel);
+ZEND_METHOD(Redis, himport);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1758,6 +1766,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hsetex, arginfo_class_Redis_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, himport, arginfo_class_Redis_himport, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/redis_cluster.c
+++ b/redis_cluster.c
@@ -1469,6 +1469,11 @@ PHP_METHOD(RedisCluster, hsetex) {
     CLUSTER_PROCESS_CMD(hsetex, cluster_long_resp, 0);
 }
 
+/* {{{ proto RedisCluster::himport(string op, string hash, ?string fieldset, array fields) */
+PHP_METHOD(RedisCluster, himport) {
+    CLUSTER_PROCESS_CMD(himport, cluster_himport_resp, 0);
+}
+
 PHP_METHOD(RedisCluster, hgetdel) {
     CLUSTER_PROCESS_CMD(hgetdel, cluster_mbulk_assoc_resp, 0);
 }

--- a/redis_cluster.stub.php
+++ b/redis_cluster.stub.php
@@ -580,6 +580,15 @@ class RedisCluster {
     public function hgetdel(string $key, array $fields): RedisCluster|array|false;
 
     /**
+     * Note that unlike `\Redis::himport()` the hash is required for every
+     * operation, as it is what directs the command to the correct node.  It is
+     * only sent to Redis for the 'SET' operation.
+     *
+     * @see \Redis::himport()
+     */
+    public function himport(string $op, string $hash, ?string $fieldset = null, array $fields = []): RedisCluster|bool|int;
+
+    /**
      * @see \Redis::hMset()
      */
     public function hmset(string $key, array $key_values): RedisCluster|bool;

--- a/redis_cluster_arginfo.h
+++ b/redis_cluster_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 65b0169d3db8c36a27189f63b956c10ba42dfdfb */
+ * Stub hash: a1e602cc43cf435986b15fbd59fac7b2d31b3cba */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 1)
@@ -460,6 +460,13 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hgetdel, 0, 2, RedisCluster, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_himport, 0, 2, RedisCluster, MAY_BE_BOOL|MAY_BE_LONG)
+	ZEND_ARG_TYPE_INFO(0, op, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, hash, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fieldset, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fields, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_RedisCluster_hmset, 0, 2, RedisCluster, MAY_BE_BOOL)
@@ -1338,6 +1345,7 @@ ZEND_METHOD(RedisCluster, hmget);
 ZEND_METHOD(RedisCluster, hgetex);
 ZEND_METHOD(RedisCluster, hsetex);
 ZEND_METHOD(RedisCluster, hgetdel);
+ZEND_METHOD(RedisCluster, himport);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
 ZEND_METHOD(RedisCluster, expiremember);
@@ -1606,6 +1614,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hsetex, arginfo_class_RedisCluster_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, himport, arginfo_class_RedisCluster_himport, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiremember, arginfo_class_RedisCluster_expiremember, ZEND_ACC_PUBLIC)

--- a/redis_cluster_legacy_arginfo.h
+++ b/redis_cluster_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 65b0169d3db8c36a27189f63b956c10ba42dfdfb */
+ * Stub hash: a1e602cc43cf435986b15fbd59fac7b2d31b3cba */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
@@ -401,6 +401,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_hgetdel, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
+	ZEND_ARG_INFO(0, fields)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RedisCluster_himport, 0, 0, 2)
+	ZEND_ARG_INFO(0, op)
+	ZEND_ARG_INFO(0, hash)
+	ZEND_ARG_INFO(0, fieldset)
 	ZEND_ARG_INFO(0, fields)
 ZEND_END_ARG_INFO()
 
@@ -1161,6 +1168,7 @@ ZEND_METHOD(RedisCluster, hmget);
 ZEND_METHOD(RedisCluster, hgetex);
 ZEND_METHOD(RedisCluster, hsetex);
 ZEND_METHOD(RedisCluster, hgetdel);
+ZEND_METHOD(RedisCluster, himport);
 ZEND_METHOD(RedisCluster, hmset);
 ZEND_METHOD(RedisCluster, hscan);
 ZEND_METHOD(RedisCluster, expiremember);
@@ -1429,6 +1437,7 @@ static const zend_function_entry class_RedisCluster_methods[] = {
 	ZEND_ME(RedisCluster, hgetex, arginfo_class_RedisCluster_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hsetex, arginfo_class_RedisCluster_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hgetdel, arginfo_class_RedisCluster_hgetdel, ZEND_ACC_PUBLIC)
+	ZEND_ME(RedisCluster, himport, arginfo_class_RedisCluster_himport, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hmset, arginfo_class_RedisCluster_hmset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, hscan, arginfo_class_RedisCluster_hscan, ZEND_ACC_PUBLIC)
 	ZEND_ME(RedisCluster, expiremember, arginfo_class_RedisCluster_expiremember, ZEND_ACC_PUBLIC)

--- a/redis_commands.c
+++ b/redis_commands.c
@@ -4974,6 +4974,179 @@ RedisCmd *redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock)
     return cmd;
 }
 
+typedef enum himportOp {
+    HIMPORT_OP_DISCARD,
+    HIMPORT_OP_DISCARDALL,
+    HIMPORT_OP_PREPARE,
+    HIMPORT_OP_SET,
+} himportOp;
+
+static zend_bool get_himport_op(himportOp *dst, zend_string *op) {
+    if (zend_string_equals_literal_ci(op, "DISCARD")) {
+        *dst = HIMPORT_OP_DISCARD;
+    } else if (zend_string_equals_literal_ci(op, "DISCARDALL")) {
+        *dst = HIMPORT_OP_DISCARDALL;
+    } else if (zend_string_equals_literal_ci(op, "PREPARE")) {
+        *dst = HIMPORT_OP_PREPARE;
+    } else if (zend_string_equals_literal_ci(op, "SET")) {
+        *dst = HIMPORT_OP_SET;
+    } else {
+        php_error_docref(NULL, E_WARNING, "Unknown HIMPORT operation '%s'",
+                         ZSTR_VAL(op));
+        return 0;
+    }
+
+    return 1;
+}
+
+static zend_bool
+validate_himport_args(himportOp hop, zend_string *op, zend_string *hash,
+                      zend_string *fieldset, HashTable *fields)
+{
+    switch (hop) {
+        case HIMPORT_OP_PREPARE:
+        case HIMPORT_OP_SET:
+            if (hop == HIMPORT_OP_SET && hash == NULL) {
+                php_error_docref(NULL, E_WARNING,
+                    "hash cannot be null for the SET operation");
+                return 0;
+            }
+            if (fieldset == NULL) {
+                php_error_docref(NULL, E_WARNING,
+                    "fieldset cannot be null for the %s operation", ZSTR_VAL(op));
+                return 0;
+            }
+            if (fields == NULL || zend_hash_num_elements(fields) == 0) {
+                php_error_docref(NULL, E_WARNING,
+                    "Must pass at least one field for the %s operation", ZSTR_VAL(op));
+                return 0;
+            }
+            break;
+        case HIMPORT_OP_DISCARD:
+            if (fieldset == NULL) {
+                php_error_docref(NULL, E_WARNING,
+                    "fieldset cannot be null for the DISCARD operation");
+                return 0;
+            }
+            if (fields != NULL && zend_hash_num_elements(fields) != 0) {
+                php_error_docref(NULL, E_WARNING,
+                    "fields must be empty for the DISCARD operation");
+                return 0;
+            }
+            break;
+        case HIMPORT_OP_DISCARDALL:
+            if (fieldset != NULL) {
+                php_error_docref(NULL, E_WARNING,
+                    "fieldset must be null for the DISCARDALL operation");
+                return 0;
+            }
+            if (fields != NULL && zend_hash_num_elements(fields) != 0) {
+                php_error_docref(NULL, E_WARNING,
+                    "fields must be empty for the DISCARDALL operation");
+                return 0;
+            }
+            break;
+    }
+
+    return 1;
+}
+
+static void redis_cmd_cat_himport_op(RedisCmd *cmd, himportOp hop) {
+    switch (hop) {
+        case HIMPORT_OP_DISCARD:
+            redis_cmd_cat_literal(cmd, "DISCARD");
+            break;
+        case HIMPORT_OP_DISCARDALL:
+            redis_cmd_cat_literal(cmd, "DISCARDALL");
+            break;
+        case HIMPORT_OP_PREPARE:
+            redis_cmd_cat_literal(cmd, "PREPARE");
+            break;
+        case HIMPORT_OP_SET:
+            redis_cmd_cat_literal(cmd, "SET");
+            break;
+    }
+}
+
+/* Every HIMPORT operation but SET is session local and doesn't take a key, so
+ * in cluster we use the hash simply to direct the command to a node. */
+static void redis_cmd_set_slot_zstr(RedisCmd *cmd, zend_string *key) {
+    zend_string *prefixed;
+
+    if (cmd->redis_sock == NULL || cmd->redis_sock->type != REDIS_SOCK_CLUSTER)
+        return;
+
+    prefixed = redis_key_prefix_zstr(cmd->redis_sock, key);
+    cmd->slot = cluster_hash_key(ZSTR_VAL(prefixed), ZSTR_LEN(prefixed));
+    zend_string_release(prefixed);
+}
+
+RedisCmd *redis_himport_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock) {
+    zend_string *op, *hash = NULL, *fieldset = NULL;
+    HashTable *fields = NULL;
+    zend_bool cluster;
+    himportOp hop;
+    RedisCmd *cmd;
+    zval *zv;
+
+    cluster = redis_sock != NULL && redis_sock->type == REDIS_SOCK_CLUSTER;
+
+    /* RedisCluster always requires the hash, as it is what directs the command */
+    if (cluster) {
+        ZEND_PARSE_PARAMETERS_START(2, 4)
+            Z_PARAM_STR(op)
+            Z_PARAM_STR(hash)
+            Z_PARAM_OPTIONAL
+            Z_PARAM_STR_OR_NULL(fieldset)
+            Z_PARAM_ARRAY_HT(fields)
+        ZEND_PARSE_PARAMETERS_END_EX(return NULL);
+    } else {
+        ZEND_PARSE_PARAMETERS_START(1, 4)
+            Z_PARAM_STR(op)
+            Z_PARAM_OPTIONAL
+            Z_PARAM_STR_OR_NULL(hash)
+            Z_PARAM_STR_OR_NULL(fieldset)
+            Z_PARAM_ARRAY_HT(fields)
+        ZEND_PARSE_PARAMETERS_END_EX(return NULL);
+    }
+
+    if (!get_himport_op(&hop, op))
+        return NULL;
+
+    if (!validate_himport_args(hop, op, hash, fieldset, fields))
+        return NULL;
+
+    cmd = redis_cmd_create_literal(redis_sock, "HIMPORT");
+    redis_cmd_cat_himport_op(cmd, hop);
+
+    if (hop == HIMPORT_OP_SET) {
+        redis_cmd_cat_key_zstr(cmd, hash);
+    } else if (hash != NULL) {
+        redis_cmd_set_slot_zstr(cmd, hash);
+    }
+
+    if (hop != HIMPORT_OP_DISCARDALL)
+        redis_cmd_cat_zstr(cmd, fieldset);
+
+    if (hop == HIMPORT_OP_PREPARE || hop == HIMPORT_OP_SET) {
+        ZEND_HASH_FOREACH_VAL(fields, zv) {
+            /* Field names are sent as-is, whereas values are serialized */
+            if (hop == HIMPORT_OP_SET) {
+                redis_cmd_cat_zval(cmd, zv);
+            } else {
+                redis_cmd_cat_zval_zstr(cmd, zv);
+            }
+        } ZEND_HASH_FOREACH_END();
+    }
+
+    /* DISCARD and DISCARDALL reply with the number of fieldsets removed, the
+     * other operations simply reply with +OK */
+    if (hop == HIMPORT_OP_DISCARD || hop == HIMPORT_OP_DISCARDALL)
+        redis_cmd_set_ctx(cmd, PHPREDIS_CTX_PTR);
+
+    return cmd;
+}
+
 RedisCmd *
 redis_hexpire_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock, const char *kw, size_t kw_len)
 

--- a/redis_commands.h
+++ b/redis_commands.h
@@ -104,6 +104,7 @@ RedisCmd *redis_hmget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_hgetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_hsetex_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_hgetdel_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
+RedisCmd *redis_himport_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_mget_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_hmset_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);
 RedisCmd *redis_hstrlen_cmd(INTERNAL_FUNCTION_PARAMETERS, RedisSock *redis_sock);

--- a/redis_legacy_arginfo.h
+++ b/redis_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d53b980175361aad909f18e3d13d5ffaf084b968 */
+ * Stub hash: 745c9be9bad265ecb49d4784a57101d019835758 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
@@ -411,6 +411,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Redis_hsetex arginfo_class_Redis_hgetex
 
 #define arginfo_class_Redis_hgetdel arginfo_class_Redis_hMget
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_himport, 0, 0, 1)
+	ZEND_ARG_INFO(0, op)
+	ZEND_ARG_INFO(0, hash)
+	ZEND_ARG_INFO(0, fieldset)
+	ZEND_ARG_INFO(0, fields)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Redis_hMset, 0, 0, 2)
 	ZEND_ARG_INFO(0, key)
@@ -1283,6 +1290,7 @@ ZEND_METHOD(Redis, hMget);
 ZEND_METHOD(Redis, hgetex);
 ZEND_METHOD(Redis, hsetex);
 ZEND_METHOD(Redis, hgetdel);
+ZEND_METHOD(Redis, himport);
 ZEND_METHOD(Redis, hMset);
 ZEND_METHOD(Redis, hRandField);
 ZEND_METHOD(Redis, hSet);
@@ -1584,6 +1592,7 @@ static const zend_function_entry class_Redis_methods[] = {
 	ZEND_ME(Redis, hgetex, arginfo_class_Redis_hgetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hsetex, arginfo_class_Redis_hsetex, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hgetdel, arginfo_class_Redis_hgetdel, ZEND_ACC_PUBLIC)
+	ZEND_ME(Redis, himport, arginfo_class_Redis_himport, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hMset, arginfo_class_Redis_hMset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hRandField, arginfo_class_Redis_hRandField, ZEND_ACC_PUBLIC)
 	ZEND_ME(Redis, hSet, arginfo_class_Redis_hSet, ZEND_ACC_PUBLIC)

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -6920,6 +6920,112 @@ class Redis_Test extends TestSuite {
         $this->assertEquals(['ship' => 'Defiant'], $this->redis->hgetall('hash'));
     }
 
+    public function testHImport() {
+        if ( ! $this->haveCommand('HIMPORT'))
+            $this->markTestSkipped();
+
+        $this->assertIsInt($this->redis->del('hash'));
+
+        /* Note that we always pass the hash, as RedisCluster requires it to
+         * direct the command even when it isn't sent to Redis. */
+        $this->assertIsInt($this->redis->himport('DISCARDALL', 'hash'));
+
+        $fields = ['ship', 'captain'];
+        $values = ['Defiant', 'Sisko'];
+
+        $this->assertTrue($this->redis->himport('PREPARE', 'hash', 'crew', $fields));
+        $this->assertTrue($this->redis->himport('SET', 'hash', 'crew', $values));
+
+        /* HIMPORT doesn't preserve the order fields were prepared in */
+        $expected = array_combine($fields, $values);
+        ksort($expected);
+
+        $actual = $this->redis->hgetall('hash');
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+
+        /* The whole point of the command is a more efficient encoding */
+        $this->assertEquals('template-listpack',
+                            $this->redis->object('encoding', 'hash'));
+
+        /* We can reuse the fieldset for as many hashes as we want */
+        $this->assertIsInt($this->redis->del('hash'));
+        $this->assertTrue($this->redis->himport('SET', 'hash', 'crew', ['Rio Grande', 'Kira']));
+
+        $actual = $this->redis->hgetall('hash');
+        ksort($actual);
+
+        $this->assertEquals(['captain' => 'Kira', 'ship' => 'Rio Grande'], $actual);
+
+        /* Discarding a fieldset that exists returns 1, and 0 once it's gone */
+        $this->assertEquals(1, $this->redis->himport('DISCARD', 'hash', 'crew'));
+        $this->assertEquals(0, $this->redis->himport('DISCARD', 'hash', 'crew'));
+
+        /* DISCARDALL returns how many fieldsets it removed */
+        $this->assertTrue($this->redis->himport('PREPARE', 'hash', 'fs1', ['a']));
+        $this->assertTrue($this->redis->himport('PREPARE', 'hash', 'fs2', ['b']));
+        $this->assertEquals(2, $this->redis->himport('DISCARDALL', 'hash'));
+    }
+
+    public function testHImportSerialization() {
+        if ( ! $this->haveCommand('HIMPORT'))
+            $this->markTestSkipped();
+
+        $fields = ['numbers', 'name'];
+        $values = [[1, 2, 3], 'Sisko'];
+
+        foreach ($this->getSerializers() as $serializer) {
+            $this->redis->setOption(Redis::OPT_SERIALIZER, $serializer);
+
+            $this->assertIsInt($this->redis->del('hash'));
+            $this->assertIsInt($this->redis->himport('DISCARDALL', 'hash'));
+            $this->assertTrue($this->redis->himport('PREPARE', 'hash', 'crew', $fields));
+
+            /* Values are serialized but field names never are */
+            if ($serializer == Redis::SERIALIZER_NONE) {
+                $expected = array_combine($fields, ['Array', 'Sisko']);
+                $res = @$this->redis->himport('SET', 'hash', 'crew', $values);
+            } else {
+                $expected = array_combine($fields, $values);
+                $res = $this->redis->himport('SET', 'hash', 'crew', $values);
+            }
+
+            ksort($expected);
+
+            $actual = $this->redis->hgetall('hash');
+            ksort($actual);
+
+            $this->assertTrue($res);
+            $this->assertEquals($expected, $actual);
+            $this->assertEquals(1, $this->redis->himport('DISCARD', 'hash', 'crew'));
+        }
+
+        $this->redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+    }
+
+    public function testHImportBadArguments() {
+        if ( ! $this->haveCommand('HIMPORT'))
+            $this->markTestSkipped();
+
+        /* Unknown operation */
+        $this->assertFalse(@$this->redis->himport('KAZOO', 'hash', 'crew', ['a']));
+
+        /* PREPARE and SET need a fieldset and at least one field */
+        foreach (['PREPARE', 'SET'] as $op) {
+            $this->assertFalse(@$this->redis->himport($op, 'hash', NULL, ['a']));
+            $this->assertFalse(@$this->redis->himport($op, 'hash', 'crew', []));
+        }
+
+        /* DISCARD needs a fieldset and no fields */
+        $this->assertFalse(@$this->redis->himport('DISCARD', 'hash', NULL));
+        $this->assertFalse(@$this->redis->himport('DISCARD', 'hash', 'crew', ['a']));
+
+        /* DISCARDALL takes neither a fieldset nor fields */
+        $this->assertFalse(@$this->redis->himport('DISCARDALL', 'hash', 'crew'));
+        $this->assertFalse(@$this->redis->himport('DISCARDALL', 'hash', NULL, ['a']));
+    }
+
     public function testHScan() {
         if (version_compare($this->version, '2.8.0') < 0)
             $this->markTestSkipped();


### PR DESCRIPTION
This is a new Redis command where hash fields are stored once globally and then referenced in the actual keys themselves.